### PR TITLE
Improvements to ISO-3166.csv

### DIFF
--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -3380,7 +3380,6 @@ Philippines;PH;PHL;180;"Zamboanga del Norte";"Zamboanga del Norte";province;ZAN;
 Philippines;PH;PHL;180;"Zamboanga del Sur";"Zamboanga del Sur";province;ZAS;17238
 Philippines;PH;PHL;180;"Zamboanga Peninsula (Region IX)";"Zamboanga Peninsula (Region IX)";region;09;48243
 Philippines;PH;PHL;180;"Zamboanga Sibuguey (Zamboanga Sibugay)";"Zamboanga Sibuguey (Zamboanga Sibugay)";province;ZSI;17672
-Philippines;PH;PHL;180;;;;48079
 Poland;PL;POL;183;Dolnoslaskie;Dolnoslaskie;voivodeship;DS;17731
 Poland;PL;POL;183;Kujawsko-pomorskie;Kujawsko-pomorskie;voivodeship;KP;17732
 Poland;PL;POL;183;Lubelskie;Lubelskie;voivodeship;LU;17733

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -3189,7 +3189,7 @@ Palau;PW;PLW;172;Ngiwal;Ngiwal;state;228;15896
 Palau;PW;PLW;172;Peleliu;Peleliu;state;350;15897
 Palau;PW;PLW;172;Sonsorol;Sonsorol;state;370;15884
 "Occupied Palestinian Territory";PS;PSE;173;"Bethlehem Bayt Laḩm";"Bethlehem Bayt Lahm";governorate;BTH;48863
-"Occupied Palestinian Territory";PS;PSE;173;"Deir El Balah Dayr al Balaḩ";"Deir El Balah Dayr al Balah”;governorate;DEB;48864
+"Occupied Palestinian Territory";PS;PSE;173;"Deir El Balah Dayr al Balaḩ";"Deir El Balah Dayr al Balah";governorate;DEB;48864
 "Occupied Palestinian Territory";PS;PSE;173;"Gaza Ghazzah";"Gaza Ghazzah";governorate;GZA;48865
 "Occupied Palestinian Territory";PS;PSE;173;"Hebron Al Khalīl";"Hebron Al Khalil";governorate;HBN;48866
 "Occupied Palestinian Territory";PS;PSE;173;"Jenin Janīn";"Jenin Janin";governorate;JEN;48867
@@ -3199,7 +3199,7 @@ Palau;PW;PLW;172;Sonsorol;Sonsorol;state;370;15884
 "Occupied Palestinian Territory";PS;PSE;173;"Nablus Nāblus";"Nablus Nablus";governorate;NBS;48871
 "Occupied Palestinian Territory";PS;PSE;173;"North Gaza Shamāl Ghazzah";"North Gaza Shamal Ghazzah";governorate;NGZ;48872
 "Occupied Palestinian Territory";PS;PSE;173;"Qalqilya Qalqīlyah";"Qalqilya Qalqilyah";governorate;QQA;48873
-"Occupied Palestinian Territory";PS;PSE;173;"Rafah Rafaḩ";"Rafah Rafah”;governorate;RFH;48874
+"Occupied Palestinian Territory";PS;PSE;173;"Rafah Rafaḩ";"Rafah Rafah";governorate;RFH;48874
 "Occupied Palestinian Territory";PS;PSE;173;"Ramallah Rām Allāh wa al Bīrah";"Ramallah Ram Allah wa al Birah";governorate;RBH;48875
 "Occupied Palestinian Territory";PS;PSE;173;"Salfit Salfīt";"Salfit Salfit";governorate;SLT;48876
 "Occupied Palestinian Territory";PS;PSE;173;"Tubas Ţūbās";"Tubas Tubas";governorate;TBS;48877

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -4036,7 +4036,6 @@ Spain;ES;ESP;212;Zamora;Zamora;province;ZA;18114
 Spain;ES;ESP;212;Zaragoza;Zaragoza;province;Z;18110
 Spain;ES;ESP;212;Álava;Alava;province;VI;18121
 Spain;ES;ESP;212;Ávila;Avila;province;AV;18139
-Spain;ES;ESP;212;;;;19573
 Spain;ES;ESP;212;;"autonomous community";"autonomous community";42629
 "Sri Lanka";LK;LKA;213;Ampāra;Ampara;district;52;18178
 "Sri Lanka";LK;LKA;213;Anurādhapura;Anuradhapura;district;71;18175
@@ -4216,7 +4215,6 @@ Switzerland;CH;CHE;219;"Zürich (de)";"Zurich (de)";canton;ZH;18256
 Tajikistan;TJ;TJK;222;Gorno-Badakhshan;Gorno-Badakhshan;"autonomous region";GB;18331
 Tajikistan;TJ;TJK;222;Khatlon;Khatlon;region;KT;18327
 Tajikistan;TJ;TJK;222;Sughd;Sughd;region;SU;18330
-Tajikistan;TJ;TJK;222;;city;city;18329
 "United Republic of Tanzania";TZ;TZA;223;Arusha;Arusha;region;01;18349
 "United Republic of Tanzania";TZ;TZA;223;"Dar es Salaam";"Dar es Salaam";region;02;18350
 "United Republic of Tanzania";TZ;TZA;223;Dodoma;Dodoma;region;03;18351
@@ -4469,8 +4467,6 @@ Turkmenistan;TM;TKM;233;Balkan;Balkan;region;B;18568
 Turkmenistan;TM;TKM;233;Dasoguz;Dasoguz;region;D;18571
 Turkmenistan;TM;TKM;233;Lebap;Lebap;region;L;18572
 Turkmenistan;TM;TKM;233;Mary;Mary;region;M;18566
-Turkmenistan;TM;TKM;233;;City;city;18567
-Turkmenistan;TM;TKM;233;;City;city;48134
 Tuvalu;TV;TUV;235;Funafuti;Funafuti;"island council";FUN;18586
 Tuvalu;TV;TUV;235;Nanumanga;Nanumanga;"island council";NMG;18580
 Tuvalu;TV;TUV;235;Nanumea;Nanumea;"island council";NMA;18581
@@ -4909,9 +4905,6 @@ Uruguay;UY;URY;242;"San José";"San Jose";department;SJ;18692
 Uruguay;UY;URY;242;Soriano;Soriano;department;SO;18706
 Uruguay;UY;URY;242;Tacuarembó;Tacuarembo;department;TA;18691
 Uruguay;UY;URY;242;"Treinta y Tres";"Treinta y Tres";department;TT;18707
-Uruguay;UY;URY;242;;Department;department;18697
-Uruguay;UY;URY;242;;Department;department;18708
-Uruguay;UY;URY;242;;Department;department;18698
 Uzbekistan;UZ;UZB;243;Andijon;Andijon;region;AN;18715
 Uzbekistan;UZ;UZB;243;Buxoro;Buxoro;region;BU;18717
 Uzbekistan;UZ;UZB;243;Farg‘ona;Farg'ona;region;FA;18714

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -4036,7 +4036,6 @@ Spain;ES;ESP;212;Zamora;Zamora;province;ZA;18114
 Spain;ES;ESP;212;Zaragoza;Zaragoza;province;Z;18110
 Spain;ES;ESP;212;Álava;Alava;province;VI;18121
 Spain;ES;ESP;212;Ávila;Avila;province;AV;18139
-Spain;ES;ESP;212;;"autonomous community";"autonomous community";42629
 "Sri Lanka";LK;LKA;213;Ampāra;Ampara;district;52;18178
 "Sri Lanka";LK;LKA;213;Anurādhapura;Anuradhapura;district;71;18175
 "Sri Lanka";LK;LKA;213;Badulla;Badulla;district;81;18179

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -1841,7 +1841,6 @@ Ireland;IE;IRL;109;Cavan;Cavan;county;CN;14795
 Ireland;IE;IRL;109;Clare;Clare;county;CE;14799
 Ireland;IE;IRL;109;Connaught;Connaught;province;C;48469
 Ireland;IE;IRL;109;Cork;Cork;county;CO;48897
-Ireland;IE;IRL;109;Cork;Cork;county;C;14800
 Ireland;IE;IRL;109;Donegal;Donegal;county;DL;14796
 Ireland;IE;IRL;109;Dublin;Dublin;county;D;14801
 Ireland;IE;IRL;109;Galway;Galway;county;G;14797

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -3913,7 +3913,6 @@ Slovenia;SI;SVN;207;Škofljica;Skofljica;;123;20044
 Slovenia;SI;SVN;207;"Šmarje pri Jelšah";"Smarje pri Jelsah";;124;20045
 Slovenia;SI;SVN;207;"Šmarješke Toplice";"Smarjeske Toplice";commune;206;48211
 Slovenia;SI;SVN;207;"Šmartno ob Paki";"Smartno ob Paki";;125;20046
-Slovenia;SI;SVN;207;"Šmartno pri Litiji";"Smartno pri Litiji";;194;20047
 Slovenia;SI;SVN;207;"Šmartno pri Litiji";"Smartno pri Litiji";commune;194;48196
 Slovenia;SI;SVN;207;Šoštanj;Sostanj;;126;20048
 Slovenia;SI;SVN;207;Štore;Store;;127;20049

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -3565,10 +3565,8 @@ Rwanda;RW;RWA;191;Ouest;Ouest;province;04;19065
 Rwanda;RW;RWA;191;Sud;Sud;province;05;17912
 Rwanda;RW;RWA;191;"Ville de Kigali";"Ville de Kigali";province;01;17923
 "Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;Ascension;Ascension;dependency;AC;17926
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;Ascension;Ascension;"geographical entity";AC;48879
 "Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Saint Helena";"Saint Helena";"geographical entity";HL;48880
 "Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Saint Helena";"Saint Helena";"administrative area";SH;17930
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Tristan da Cunha";"Tristan da Cunha";"geographical entity";TA;48881
 "Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Tristan da Cunha";"Tristan da Cunha";dependency;TA;17925
 "Saint Kitts And Nevis";KN;KNA;193;"Christ Church Nichola Town";"Christ Church Nichola Town";parish;01;17933
 "Saint Kitts And Nevis";KN;KNA;193;Nevis;Nevis;state;N;48461

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -1,5078 +1,5078 @@
-COUNTRY NAME; COUNTRY SHORT CODE; COUNTRY LONG CODE; COUNTRY NUMBER CODE; REGION NAME; REGION TYPE; REGIONAL CODE; REGIONAL NUMBER CODE
-"Afghanistan";AF;AFG;2;"Badakhshān";Province;"BDS";12267
-"Afghanistan";AF;AFG;2;"Baghlān";Province;"BGL";12268
-"Afghanistan";AF;AFG;2;"Balkh";Province;"BAL";12273
-"Afghanistan";AF;AFG;2;"Bādghīs";Province;"BDG";12272
-"Afghanistan";AF;AFG;2;"Bāmyān";Province;"BAM";12269
-"Afghanistan";AF;AFG;2;"Dāykundī";Province;"DAY";20221
-"Afghanistan";AF;AFG;2;"Farāh";Province;"FRA";12274
-"Afghanistan";AF;AFG;2;"Fāryāb";Province;"FYB";12270
-"Afghanistan";AF;AFG;2;"Ghaznī";Province;"GHA";12271
-"Afghanistan";AF;AFG;2;"Ghōr";Province;"GHO";12275
-"Afghanistan";AF;AFG;2;"Helmand";Province;"HEL";12277
-"Afghanistan";AF;AFG;2;"Herāt";Province;"HER";12262
-"Afghanistan";AF;AFG;2;"Jowzjān";Province;"JOW";12283
-"Afghanistan";AF;AFG;2;"Kandahār";Province;"KAN";12263
-"Afghanistan";AF;AFG;2;"Khōst";Province;"KHO";12276
-"Afghanistan";AF;AFG;2;"Kunar";Province;"KNR";12284
-"Afghanistan";AF;AFG;2;"Kunduz";Province;"KDZ";12256
-"Afghanistan";AF;AFG;2;"Kābul";Province;"KAB";12278
-"Afghanistan";AF;AFG;2;"Kāpīsā";Province;"KAP";12261
-"Afghanistan";AF;AFG;2;"Laghmān";Province;"LAG";12279
-"Afghanistan";AF;AFG;2;"Lōgar";Province;"LOW";12260
-"Afghanistan";AF;AFG;2;"Nangarhār";Province;"NAN";12280
-"Afghanistan";AF;AFG;2;"Nīmrōz";Province;"NIM";12285
-"Afghanistan";AF;AFG;2;"Nūristān";Province;"NUR";12281
-"Afghanistan";AF;AFG;2;"Paktia";Province;"PIA";12282
-"Afghanistan";AF;AFG;2;"Paktika";Province;"PKA";12259
-"Afghanistan";AF;AFG;2;"Panjshayr";Province;"PAN";20222
-"Afghanistan";AF;AFG;2;"Parwān";Province;"PAR";12257
-"Afghanistan";AF;AFG;2;"Samangan";Province;"SAM";12264
-"Afghanistan";AF;AFG;2;"Sar-e Pul";Province;"SAR";12258
-"Afghanistan";AF;AFG;2;"Takhar";Province;"TAK";12265
-"Afghanistan";AF;AFG;2;"Uruzgān";Province;"URU";12255
-"Afghanistan";AF;AFG;2;"Uruzgān";Province;"ORU";48898
-"Afghanistan";AF;AFG;2;"Wardak";Province;"WAR";12266
-"Afghanistan";AF;AFG;2;"Zābul";Province;"ZAB";12254
-"Albania";AL;ALB;4;"Berat";District;"BR";12316
-"Albania";AL;ALB;4;"Berat";county;"01";48288
-"Albania";AL;ALB;4;"Bulqizë";District;"BU";12309
-"Albania";AL;ALB;4;"Delvinë";District;"DL";12310
-"Albania";AL;ALB;4;"Devoll";District;"DV";12317
-"Albania";AL;ALB;4;"Dibër";District;"DI";12311
-"Albania";AL;ALB;4;"Dibër";county;"09";48289
-"Albania";AL;ALB;4;"Durrës";county;"02";48290
-"Albania";AL;ALB;4;"Durrës";District;"DR";12312
-"Albania";AL;ALB;4;"Elbasan";District;"EL";12315
-"Albania";AL;ALB;4;"Elbasan";county;"03";48291
-"Albania";AL;ALB;4;"Fier";county;"04";48292
-"Albania";AL;ALB;4;"Fier";District;"FR";12313
-"Albania";AL;ALB;4;"Gjirokastër";District;"GJ";12314
-"Albania";AL;ALB;4;"Gjirokastër";county;"05";48293
-"Albania";AL;ALB;4;"Gramsh";District;"GR";12318
-"Albania";AL;ALB;4;"Has";District;"HA";12300
-"Albania";AL;ALB;4;"Kavajë";District;"KA";12301
-"Albania";AL;ALB;4;"Kolonjë";District;"ER";12290
-"Albania";AL;ALB;4;"Korçë";District;"KO";12302
-"Albania";AL;ALB;4;"Korçë";county;"06";48294
-"Albania";AL;ALB;4;"Krujë";District;"KR";12303
-"Albania";AL;ALB;4;"Kukës";District;"KU";12304
-"Albania";AL;ALB;4;"Kukës";county;"07";48295
-"Albania";AL;ALB;4;"Kurbin";District;"KB";12305
-"Albania";AL;ALB;4;"Kuçovë";District;"KC";12319
-"Albania";AL;ALB;4;"Lezhë";District;"LE";12320
-"Albania";AL;ALB;4;"Lezhë";county;"08";48296
-"Albania";AL;ALB;4;"Librazhd";District;"LB";12306
-"Albania";AL;ALB;4;"Lushnjë";District;"LU";12307
-"Albania";AL;ALB;4;"Mallakastër";District;"MK";12321
-"Albania";AL;ALB;4;"Malësi e Madhe";District;"MM";12308
-"Albania";AL;ALB;4;"Mat";District;"MT";12291
-"Albania";AL;ALB;4;"Mirditë";District;"MR";12289
-"Albania";AL;ALB;4;"Peqin";District;"PQ";12292
-"Albania";AL;ALB;4;"Pogradec";District;"PG";12288
-"Albania";AL;ALB;4;"Pukë";District;"PU";12294
-"Albania";AL;ALB;4;"Përmet";District;"PR";12293
-"Albania";AL;ALB;4;"Sarandë";District;"SR";12295
-"Albania";AL;ALB;4;"Shkodër";District;"SH";12287
-"Albania";AL;ALB;4;"Shkodër";county;"10";48297
-"Albania";AL;ALB;4;"Skrapar";District;"SK";12296
-"Albania";AL;ALB;4;"Tepelenë";District;"TE";12297
-"Albania";AL;ALB;4;"Tiranë";District;"TR";12286
-"Albania";AL;ALB;4;"Tiranë";county;"11";48298
-"Albania";AL;ALB;4;"Tropojë";District;"TP";12298
-"Albania";AL;ALB;4;"Vlorë";county;"12";48299
-"Albania";AL;ALB;4;"Vlorë";District;"VL";12299
-"Algeria";DZ;DZA;5;"Adrar";Province;"01";12363
-"Algeria";DZ;DZA;5;"Alger";Province;"16";12344
-"Algeria";DZ;DZA;5;"Annaba";Province;"23";12332
-"Algeria";DZ;DZA;5;"Aïn Defla";Province;"44";12351
-"Algeria";DZ;DZA;5;"Aïn Témouchent";Province;"46";12333
-"Algeria";DZ;DZA;5;"Batna";Province;"05";12334
-"Algeria";DZ;DZA;5;"Biskra";Province;"07";12354
-"Algeria";DZ;DZA;5;"Blida";Province;"09";12336
-"Algeria";DZ;DZA;5;"Bordj Bou Arréridj";Province;"34";12342
-"Algeria";DZ;DZA;5;"Bouira";Province;"10";12341
-"Algeria";DZ;DZA;5;"Boumerdès";Province;"35";12337
-"Algeria";DZ;DZA;5;"Béchar";Province;"08";12352
-"Algeria";DZ;DZA;5;"Béjaïa";Province;"06";12335
-"Algeria";DZ;DZA;5;"Chlef";Province;"02";12367
-"Algeria";DZ;DZA;5;"Constantine";Province;"25";12348
-"Algeria";DZ;DZA;5;"Djelfa";Province;"17";12345
-"Algeria";DZ;DZA;5;"El Bayadh";Province;"32";12353
-"Algeria";DZ;DZA;5;"El Oued";Province;"39";12323
-"Algeria";DZ;DZA;5;"El Tarf";Province;"36";12357
-"Algeria";DZ;DZA;5;"Ghardaïa";Province;"47";12343
-"Algeria";DZ;DZA;5;"Guelma";Province;"24";12366
-"Algeria";DZ;DZA;5;"Illizi";Province;"33";12340
-"Algeria";DZ;DZA;5;"Jijel";Province;"18";12330
-"Algeria";DZ;DZA;5;"Khenchela";Province;"40";12339
-"Algeria";DZ;DZA;5;"Laghouat";Province;"03";12350
-"Algeria";DZ;DZA;5;"Mascara";Province;"29";12365
-"Algeria";DZ;DZA;5;"Mila";Province;"43";12329
-"Algeria";DZ;DZA;5;"Mostaganem";Province;"27";12347
-"Algeria";DZ;DZA;5;"Msila";Province;"28";12364
-"Algeria";DZ;DZA;5;"Médéa";Province;"26";12346
-"Algeria";DZ;DZA;5;"Naama";Province;"45";12328
-"Algeria";DZ;DZA;5;"Oran";Province;"31";12362
-"Algeria";DZ;DZA;5;"Ouargla";Province;"30";12322
-"Algeria";DZ;DZA;5;"Oum el Bouaghi";Province;"04";12361
-"Algeria";DZ;DZA;5;"Relizane";Province;"48";12338
-"Algeria";DZ;DZA;5;"Saïda";Province;"20";12327
-"Algeria";DZ;DZA;5;"Sidi Bel Abbès";Province;"22";12326
-"Algeria";DZ;DZA;5;"Skikda";Province;"21";12349
-"Algeria";DZ;DZA;5;"Souk Ahras";Province;"41";12356
-"Algeria";DZ;DZA;5;"Sétif";Province;"19";12355
-"Algeria";DZ;DZA;5;"Tamanghasset";Province;"11";12368
-"Algeria";DZ;DZA;5;"Tiaret";Province;"14";12360
-"Algeria";DZ;DZA;5;"Tindouf";Province;"37";12359
-"Algeria";DZ;DZA;5;"Tipaza";Province;"42";12369
-"Algeria";DZ;DZA;5;"Tissemsilt";Province;"38";12325
-"Algeria";DZ;DZA;5;"Tizi Ouzou";Province;"15";12324
-"Algeria";DZ;DZA;5;"Tlemcen";Province;"13";12370
-"Algeria";DZ;DZA;5;"Tébessa";Province;"12";12358
-"Andorra";AD;AND;7;"Andorra la Vella";Parish;"07";12382
-"Andorra";AD;AND;7;"Canillo";Parish;"02";12381
-"Andorra";AD;AND;7;"Encamp";Parish;"03";12383
-"Andorra";AD;AND;7;"Escaldes-Engordany";Parish;"08";12380
-"Andorra";AD;AND;7;"La Massana";Parish;"04";12384
-"Andorra";AD;AND;7;"Ordino";Parish;"05";12379
-"Andorra";AD;AND;7;"Sant Julià de Lòria";Parish;"06";12378
-"Angola";AO;AGO;8;"Bengo";Province;"BGO";12390
-"Angola";AO;AGO;8;"Benguela";Province;"BGU";12391
-"Angola";AO;AGO;8;"Bié";Province;"BIE";12395
-"Angola";AO;AGO;8;"Cabinda";Province;"CAB";12392
-"Angola";AO;AGO;8;"Cuando-Cubango";Province;"CCU";12394
-"Angola";AO;AGO;8;"Cuanza Norte";Province;"CNO";12388
-"Angola";AO;AGO;8;"Cuanza Sul";Province;"CUS";12397
-"Angola";AO;AGO;8;"Cunene";Province;"CNN";12389
-"Angola";AO;AGO;8;"Huambo";Province;"HUA";12393
-"Angola";AO;AGO;8;"Huíla";Province;"HUI";12396
-"Angola";AO;AGO;8;"Luanda";Province;"LUA";12387
-"Angola";AO;AGO;8;"Lunda Norte";Province;"LNO";12398
-"Angola";AO;AGO;8;"Lunda Sul";Province;"LSU";12386
-"Angola";AO;AGO;8;"Malange";Province;"MAL";12399
-"Angola";AO;AGO;8;"Moxico";Province;"MOX";12401
-"Angola";AO;AGO;8;"Namibe";Province;"NAM";12402
-"Angola";AO;AGO;8;"Uíge";Province;"UIG";12400
-"Angola";AO;AGO;8;"Zaire";Province;"ZAI";12385
-"Antigua and Barbuda";AG;ATG;11;"Barbuda";Dependency;"10";12426
-"Antigua and Barbuda";AG;ATG;11;"Redonda";Dependency;"11";12425
-"Antigua and Barbuda";AG;ATG;11;"Redonda";Dependency;"X2~";48127
-"Antigua and Barbuda";AG;ATG;11;"Saint George";Parish;"03";12427
-"Antigua and Barbuda";AG;ATG;11;"Saint John’s";Parish;"04";12431
-"Antigua and Barbuda";AG;ATG;11;"Saint Mary";Parish;"05";12428
-"Antigua and Barbuda";AG;ATG;11;"Saint Paul";Parish;"06";12429
-"Antigua and Barbuda";AG;ATG;11;"Saint Peter";Parish;"07";12432
-"Antigua and Barbuda";AG;ATG;11;"Saint Philip";Parish;"08";12430
-"Argentina";AR;ARG;12;"Buenos Aires";province;"B";12439
-"Argentina";AR;ARG;12;"Catamarca";province;"K";12438
-"Argentina";AR;ARG;12;"Chaco";province;"H";12440
-"Argentina";AR;ARG;12;"Chubut";province;"U";12454
-"Argentina";AR;ARG;12;"Ciudad Autónoma de Buenos Aires";federal district;"C";12437
-"Argentina";AR;ARG;12;"Corrientes";province;"W";12442
-"Argentina";AR;ARG;12;"Córdoba";province;"X";12441
-"Argentina";AR;ARG;12;"Entre Ríos";province;"E";12443
-"Argentina";AR;ARG;12;"Formosa";province;"P";12455
-"Argentina";AR;ARG;12;"Jujuy";province;"Y";12444
-"Argentina";AR;ARG;12;"La Pampa";province;"L";12445
-"Argentina";AR;ARG;12;"La Rioja";province;"F";12436
-"Argentina";AR;ARG;12;"Mendoza";province;"M";12446
-"Argentina";AR;ARG;12;"Misiones";province;"N";12456
-"Argentina";AR;ARG;12;"Neuquén";province;"Q";12447
-"Argentina";AR;ARG;12;"Río Negro";province;"R";12448
-"Argentina";AR;ARG;12;"Salta";province;"A";12435
-"Argentina";AR;ARG;12;"San Juan";province;"J";12449
-"Argentina";AR;ARG;12;"San Luis";province;"D";12450
-"Argentina";AR;ARG;12;"Santa Cruz";province;"Z";12434
-"Argentina";AR;ARG;12;"Santa Fe";province;"S";12451
-"Argentina";AR;ARG;12;"Santiago del Estero";province;"G";12433
-"Argentina";AR;ARG;12;"Tierra del Fuego";province;"V";12452
-"Argentina";AR;ARG;12;"Tucumán";province;"T";12453
-"Armenia";AM;ARM;13;"Aragac?otn";Province;"AG";12466
-"Armenia";AM;ARM;13;"Ararat";Province;"AR";12461
-"Armenia";AM;ARM;13;"Armavir";Province;"AV";12467
-"Armenia";AM;ARM;13;"Erevan";city;"ER";12464
-"Armenia";AM;ARM;13;"Gegark'unik'";Province;"GR";12460
-"Armenia";AM;ARM;13;"Kotayk'";Province;"KT";12462
-"Armenia";AM;ARM;13;"Lo?y";Province;"LO";12465
-"Armenia";AM;ARM;13;"Syunik'";Province;"SU";12463
-"Armenia";AM;ARM;13;"Tavuš";Province;"TV";12457
-"Armenia";AM;ARM;13;"Vayoc Jor";Province;"VD";12458
-"Armenia";AM;ARM;13;"Širak";Province;"SH";12459
-"Australia";AU;AUS;15;"Australian Capital Territory";territory;"ACT";12471
-"Australia";AU;AUS;15;"New South Wales";state;"NSW";12477
-"Australia";AU;AUS;15;"Northern Territory";territory;"NT";12475
-"Australia";AU;AUS;15;"Queensland";state;"QLD";12476
-"Australia";AU;AUS;15;"South Australia";state;"SA";12472
-"Australia";AU;AUS;15;"Tasmania";state;"TAS";12474
-"Australia";AU;AUS;15;"Victoria";state;"VIC";12473
-"Australia";AU;AUS;15;"Western Australia";state;"WA";12470
-"Austria";AT;AUT;16;"Burgenland";State;"1";12480
-"Austria";AT;AUT;16;"Kärnten";State;"2";12481
-"Austria";AT;AUT;16;"Niederösterreich";State;"3";12485
-"Austria";AT;AUT;16;"Oberösterreich";State;"4";12482
-"Austria";AT;AUT;16;"Salzburg";State;"5";12479
-"Austria";AT;AUT;16;"Steiermark";State;"6";12483
-"Austria";AT;AUT;16;"Tirol";State;"7";12486
-"Austria";AT;AUT;16;"Vorarlberg";State;"8";12484
-"Austria";AT;AUT;16;"Wien";State;"9";12478
-"Azerbaijan";AZ;AZE;17;"Abseron";District;"ABS";12521
-"Azerbaijan";AZ;AZE;17;"Agcabädi";District;"AGC";12522
-"Azerbaijan";AZ;AZE;17;"Agdam";District;"AGM";12550
-"Azerbaijan";AZ;AZE;17;"Agdas";District;"AGS";12523
-"Azerbaijan";AZ;AZE;17;"Agstafa";District;"AGA";12493
-"Azerbaijan";AZ;AZE;17;"Agsu";District;"AGU";12524
-"Azerbaijan";AZ;AZE;17;"Astara";District;"AST";12525
-"Azerbaijan";AZ;AZE;17;"Babäk";District;"BAB";12494
-"Azerbaijan";AZ;AZE;17;"Baki";municipality;"BA";12526
-"Azerbaijan";AZ;AZE;17;"Balakän";District;"BAL";12527
-"Azerbaijan";AZ;AZE;17;"Beyläqan";District;"BEY";12528
-"Azerbaijan";AZ;AZE;17;"Biläsuvar";District;"BIL";12529
-"Azerbaijan";AZ;AZE;17;"Bärdä";District;"BAR";12495
-"Azerbaijan";AZ;AZE;17;"Culfa";District;"CUL";12531
-"Azerbaijan";AZ;AZE;17;"Cäbrayil";District;"CAB";12496
-"Azerbaijan";AZ;AZE;17;"Cälilabab";District;"CAL";12530
-"Azerbaijan";AZ;AZE;17;"Daskäsän";District;"DAS";12497
-"Azerbaijan";AZ;AZE;17;"Däväçi";District;"DAV";12532
-"Azerbaijan";AZ;AZE;17;"Füzuli";District;"FUZ";12533
-"Azerbaijan";AZ;AZE;17;"Goranboy";District;"GOR";12512
-"Azerbaijan";AZ;AZE;17;"Gädäbäy";District;"GAD";12534
-"Azerbaijan";AZ;AZE;17;"Göygöl";District;"GYG";48902
-"Azerbaijan";AZ;AZE;17;"Göyçay";District;"GOY";12513
-"Azerbaijan";AZ;AZE;17;"Gəncə";municipality;"GA";12499
-"Azerbaijan";AZ;AZE;17;"Haciqabul";District;"HAC";12500
-"Azerbaijan";AZ;AZE;17;"Imisli";District;"IMI";12514
-"Azerbaijan";AZ;AZE;17;"Ismayilli";District;"ISM";12501
-"Azerbaijan";AZ;AZE;17;"Kälbäcär";District;"KAL";12515
-"Azerbaijan";AZ;AZE;17;"Kürdämir";District;"KUR";12516
-"Azerbaijan";AZ;AZE;17;"Kǝngǝrli";District;"KAN";48903
-"Azerbaijan";AZ;AZE;17;"Laçin";District;"LAC";12551
-"Azerbaijan";AZ;AZE;17;"Lerik";District;"LER";12518
-"Azerbaijan";AZ;AZE;17;"Länkäran";District;"LAN";12517
-"Azerbaijan";AZ;AZE;17;"Lənkəran";municipality;"LA";20104
-"Azerbaijan";AZ;AZE;17;"Masalli";District;"MAS";12552
-"Azerbaijan";AZ;AZE;17;"Mingəçevir";municipality;"MI";12519
-"Azerbaijan";AZ;AZE;17;"Naftalan";municipality;"NA";12520
-"Azerbaijan";AZ;AZE;17;"Naxçivan";autonomous republic;"NX";12553
-"Azerbaijan";AZ;AZE;17;"Naxçıvan";municipality;"NV";48899
-"Azerbaijan";AZ;AZE;17;"Neftçala";District;"NEF";12535
-"Azerbaijan";AZ;AZE;17;"Oguz";District;"OGU";12554
-"Azerbaijan";AZ;AZE;17;"Ordubad";District;"ORD";12536
-"Azerbaijan";AZ;AZE;17;"Qax";District;"QAX";12537
-"Azerbaijan";AZ;AZE;17;"Qazax";District;"QAZ";12555
-"Azerbaijan";AZ;AZE;17;"Qobustan";District;"QOB";12539
-"Azerbaijan";AZ;AZE;17;"Quba";District;"QBA";12556
-"Azerbaijan";AZ;AZE;17;"Qubadli";District;"QBI";12540
-"Azerbaijan";AZ;AZE;17;"Qusar";District;"QUS";12541
-"Azerbaijan";AZ;AZE;17;"Qäbälä";District;"QAB";12538
-"Azerbaijan";AZ;AZE;17;"Saatli";District;"SAT";12557
-"Azerbaijan";AZ;AZE;17;"Sabirabad";District;"SAB";12542
-"Azerbaijan";AZ;AZE;17;"Sahbuz";District;"SAH";12502
-"Azerbaijan";AZ;AZE;17;"Salyan";District;"SAL";12558
-"Azerbaijan";AZ;AZE;17;"Samaxi";District;"SMI";12503
-"Azerbaijan";AZ;AZE;17;"Samux";District;"SMX";12492
-"Azerbaijan";AZ;AZE;17;"Siyäzän";District;"SIY";12507
-"Azerbaijan";AZ;AZE;17;"Sumqayıt";municipality;"SM";12491
-"Azerbaijan";AZ;AZE;17;"Susa";District;"SUS";12508
-"Azerbaijan";AZ;AZE;17;"Susa City";municipality;"SS";20106
-"Azerbaijan";AZ;AZE;17;"Sädäräk";District;"SAD";12504
-"Azerbaijan";AZ;AZE;17;"Säki";District;"SAK";12505
-"Azerbaijan";AZ;AZE;17;"Sämkir";District;"SKR";12559
-"Azerbaijan";AZ;AZE;17;"Särur";District;"SAR";12506
-"Azerbaijan";AZ;AZE;17;"Tovuz";District;"TOV";12560
-"Azerbaijan";AZ;AZE;17;"Tärtär";District;"TAR";12509
-"Azerbaijan";AZ;AZE;17;"Ucar";District;"UCA";12510
-"Azerbaijan";AZ;AZE;17;"Xankəndi";municipality;"XA";12490
-"Azerbaijan";AZ;AZE;17;"Xanlar";District;"XAN";12544
-"Azerbaijan";AZ;AZE;17;"Xaçmaz";District;"XAC";12543
-"Azerbaijan";AZ;AZE;17;"Xizi";District;"XIZ";12545
-"Azerbaijan";AZ;AZE;17;"Xocali";District;"XCI";12489
-"Azerbaijan";AZ;AZE;17;"Xocavänd";District;"XVD";12546
-"Azerbaijan";AZ;AZE;17;"Yardimli";District;"YAR";12488
-"Azerbaijan";AZ;AZE;17;"Yevlax";District;"YEV";12547
-"Azerbaijan";AZ;AZE;17;"Yevlax City";municipality;"YE";20107
-"Azerbaijan";AZ;AZE;17;"Zaqatala";District;"ZAQ";12548
-"Azerbaijan";AZ;AZE;17;"Zängilan";District;"ZAN";12487
-"Azerbaijan";AZ;AZE;17;"Zärdab";District;"ZAR";12549
-"Azerbaijan";AZ;AZE;17;"Äli Bayramli";municipality;"AB";12498
-"Azerbaijan";AZ;AZE;17;"Şabran";District;"SBN";48901
-"Azerbaijan";AZ;AZE;17;"Şirvan";municipality;"SR";48900
-"Azerbaijan";AZ;AZE;17;"Şəki";municipality;"SA";20105
-"Bahamas";BS;BHS;18;"Acklins  Islands";District;"AK";12567
-"Bahamas";BS;BHS;18;"Acklins and Crooked Islands";District;"AC";48139
-"Bahamas";BS;BHS;18;"Berry Islands";district;"BY";48140
-"Bahamas";BS;BHS;18;"Bimini and Cat Cay";District;"BI";12574
-"Bahamas";BS;BHS;18;"Black Point";district;"BP";48141
-"Bahamas";BS;BHS;18;"Cat Island";District;"CI";12575
-"Bahamas";BS;BHS;18;"Central Abaco";district;"CO";48142
-"Bahamas";BS;BHS;18;"Central Andros";district;"CS";48143
-"Bahamas";BS;BHS;18;"Central Eleuthera";district;"CE";48144
-"Bahamas";BS;BHS;18;"City of Freeport";district;"FP";12566
-"Bahamas";BS;BHS;18;"Crooked Island and Long Cay";district;"CK";48146
-"Bahamas";BS;BHS;18;"East Grand Bahama";district;"EG";48147
-"Bahamas";BS;BHS;18;"Exuma";District;"EX";12578
-"Bahamas";BS;BHS;18;"Governor's Harbour";District;"GH";12577
-"Bahamas";BS;BHS;18;"Grand Cay";District;"GC";12572
-"Bahamas";BS;BHS;18;"Green Turtle Cay";District;"GT";12571
-"Bahamas";BS;BHS;18;"Harbour Island";District;"HI";12579
-"Bahamas";BS;BHS;18;"High Rock";District;"HR";20112
-"Bahamas";BS;BHS;18;"Hope Town";district;"HT";48148
-"Bahamas";BS;BHS;18;"Inagua";District;"IN";12565
-"Bahamas";BS;BHS;18;"Kemps Bay";District;"KB";20113
-"Bahamas";BS;BHS;18;"Long Island";District;"LI";12580
-"Bahamas";BS;BHS;18;"Mangrove Cay";district;"MC";48149
-"Bahamas";BS;BHS;18;"Marsh Harbour";District;"MH";20114
-"Bahamas";BS;BHS;18;"Mayaguana";District;"MG";12564
-"Bahamas";BS;BHS;18;"Moore’s Island";district;"MI";48150
-"Bahamas";BS;BHS;18;"New Providence";District;"NP";12563
-"Bahamas";BS;BHS;18;"Nicholls Town and Berry Islands";District;"NB";12573
-"Bahamas";BS;BHS;18;"North Abaco";district;"NO";48151
-"Bahamas";BS;BHS;18;"North Andros";district;"NS";48152
-"Bahamas";BS;BHS;18;"North Eleuthera";district;"NE";48153
-"Bahamas";BS;BHS;18;"Ragged Island";District;"RI";12568
-"Bahamas";BS;BHS;18;"Rock Sound";District;"RS";20115
-"Bahamas";BS;BHS;18;"Rum Cay";district;"RC";48154
-"Bahamas";BS;BHS;18;"San Salvador";district;"SS";48155
-"Bahamas";BS;BHS;18;"San Salvador and Rum Cay";District;"SR";12569
-"Bahamas";BS;BHS;18;"Sandy Point";District;"SP";20116
-"Bahamas";BS;BHS;18;"South Abaco";district;"SO";48156
-"Bahamas";BS;BHS;18;"South Andros";district;"SA";48157
-"Bahamas";BS;BHS;18;"South Eleuthera";district;"SE";48158
-"Bahamas";BS;BHS;18;"Spanish Wells";district;"SW";48159
-"Bahamas";BS;BHS;18;"West Grand Bahama";district;"WG";48160
-"Bahrain";BH;BHR;21;"Al Janubiyah";Governorate;"14";12592
-"Bahrain";BH;BHR;21;"Al Manamah (Al ‘Asimah)";Governorate;"13";12589
-"Bahrain";BH;BHR;21;"Al Muharraq";Governorate;"15";12583
-"Bahrain";BH;BHR;21;"Al Wustá";Governorate;"16";12581
-"Bahrain";BH;BHR;21;"Ash Shamaliyah";Governorate;"17";12582
-"Bangladesh";BD;BGD;22;"Bagerhat";District;"05";12600
-"Bangladesh";BD;BGD;22;"Bandarban";District;"01";12601
-"Bangladesh";BD;BGD;22;"Barguna";District;"02";12602
-"Bangladesh";BD;BGD;22;"Barisal";division;"A";48675
-"Bangladesh";BD;BGD;22;"Barisal";District;"06";12612
-"Bangladesh";BD;BGD;22;"Barisal";division;"1";48257
-"Bangladesh";BD;BGD;22;"Bhola";District;"07";12613
-"Bangladesh";BD;BGD;22;"Bogra";District;"03";12614
-"Bangladesh";BD;BGD;22;"Brahmanbaria";District;"04";12630
-"Bangladesh";BD;BGD;22;"Chandpur";District;"09";12615
-"Bangladesh";BD;BGD;22;"Chittagong";division;"2";48258
-"Bangladesh";BD;BGD;22;"Chittagong";division;"B";48676
-"Bangladesh";BD;BGD;22;"Chittagong";District;"10";12631
-"Bangladesh";BD;BGD;22;"Chuadanga";District;"12";12632
-"Bangladesh";BD;BGD;22;"Comilla";District;"08";12606
-"Bangladesh";BD;BGD;22;"Cox's Bazar";District;"11";12641
-"Bangladesh";BD;BGD;22;"Dhaka";District;"13";12616
-"Bangladesh";BD;BGD;22;"Dhaka";division;"C";48677
-"Bangladesh";BD;BGD;22;"Dhaka";division;"3";48259
-"Bangladesh";BD;BGD;22;"Dinajpur";District;"14";12633
-"Bangladesh";BD;BGD;22;"Faridpur";District;"15";12617
-"Bangladesh";BD;BGD;22;"Feni";District;"16";12618
-"Bangladesh";BD;BGD;22;"Gaibandha";District;"19";12634
-"Bangladesh";BD;BGD;22;"Gazipur";District;"18";12635
-"Bangladesh";BD;BGD;22;"Gopalganj";District;"17";12619
-"Bangladesh";BD;BGD;22;"Habiganj";District;"20";12636
-"Bangladesh";BD;BGD;22;"Jaipurhat";District;"24";12620
-"Bangladesh";BD;BGD;22;"Jamalpur";District;"21";12637
-"Bangladesh";BD;BGD;22;"Jessore";District;"22";12603
-"Bangladesh";BD;BGD;22;"Jhalakati";District;"25";12638
-"Bangladesh";BD;BGD;22;"Jhenaidah";District;"23";12604
-"Bangladesh";BD;BGD;22;"Khagrachari";District;"29";12639
-"Bangladesh";BD;BGD;22;"Khulna";division;"4";48260
-"Bangladesh";BD;BGD;22;"Khulna";division;"D";48678
-"Bangladesh";BD;BGD;22;"Khulna";District;"27";12640
-"Bangladesh";BD;BGD;22;"Kishoreganj";District;"26";12605
-"Bangladesh";BD;BGD;22;"Kurigram";District;"28";12642
-"Bangladesh";BD;BGD;22;"Kushtia";District;"30";12607
-"Bangladesh";BD;BGD;22;"Lakshmipur";District;"31";12643
-"Bangladesh";BD;BGD;22;"Lalmonirhat";District;"32";12608
-"Bangladesh";BD;BGD;22;"Madaripur";District;"36";12644
-"Bangladesh";BD;BGD;22;"Magura";District;"37";12609
-"Bangladesh";BD;BGD;22;"Manikganj";District;"33";12610
-"Bangladesh";BD;BGD;22;"Meherpur";District;"39";12611
-"Bangladesh";BD;BGD;22;"Moulvibazar";District;"38";12622
-"Bangladesh";BD;BGD;22;"Munshiganj";District;"35";12623
-"Bangladesh";BD;BGD;22;"Mymensingh";District;"34";12621
-"Bangladesh";BD;BGD;22;"Naogaon";District;"48";12626
-"Bangladesh";BD;BGD;22;"Narail";District;"43";12624
-"Bangladesh";BD;BGD;22;"Narayanganj";District;"40";12599
-"Bangladesh";BD;BGD;22;"Narsingdi";District;"42";12625
-"Bangladesh";BD;BGD;22;"Natore";District;"44";12653
-"Bangladesh";BD;BGD;22;"Nawabganj";District;"45";12598
-"Bangladesh";BD;BGD;22;"Netrakona";District;"41";12627
-"Bangladesh";BD;BGD;22;"Nilphamari";District;"46";12654
-"Bangladesh";BD;BGD;22;"Noakhali";District;"47";12628
-"Bangladesh";BD;BGD;22;"Pabna";District;"49";12629
-"Bangladesh";BD;BGD;22;"Panchagarh";District;"52";12597
-"Bangladesh";BD;BGD;22;"Patuakhali";District;"51";12645
-"Bangladesh";BD;BGD;22;"Pirojpur";District;"50";12655
-"Bangladesh";BD;BGD;22;"Rajbari";District;"53";12646
-"Bangladesh";BD;BGD;22;"Rajshahi";District;"54";12596
-"Bangladesh";BD;BGD;22;"Rajshahi";division;"5";48261
-"Bangladesh";BD;BGD;22;"Rajshahi";division;"E";48679
-"Bangladesh";BD;BGD;22;"Rangamati   Parbattya Chattagram";District;"56";12647
-"Bangladesh";BD;BGD;22;"Rangpur";District;"55";12648
-"Bangladesh";BD;BGD;22;"Rangpur";division;"F";48681
-"Bangladesh";BD;BGD;22;"Satkhira";District;"58";12656
-"Bangladesh";BD;BGD;22;"Shariatpur";District;"62";12649
-"Bangladesh";BD;BGD;22;"Sherpur";District;"57";12595
-"Bangladesh";BD;BGD;22;"Sirajganj";District;"59";12594
-"Bangladesh";BD;BGD;22;"Sunamganj";District;"61";12651
-"Bangladesh";BD;BGD;22;"Sylhet";division;"6";48262
-"Bangladesh";BD;BGD;22;"Sylhet";District;"60";12650
-"Bangladesh";BD;BGD;22;"Sylhet";division;"G";48680
-"Bangladesh";BD;BGD;22;"Tangail";District;"63";12593
-"Bangladesh";BD;BGD;22;"Thakurgaon";District;"64";12652
-"Barbados";BB;BRB;23;"Christ Church";Parish;"01";12661
-"Barbados";BB;BRB;23;"Saint Andrew";Parish;"02";12663
-"Barbados";BB;BRB;23;"Saint George";Parish;"03";12662
-"Barbados";BB;BRB;23;"Saint James";Parish;"04";12660
-"Barbados";BB;BRB;23;"Saint John";Parish;"05";12664
-"Barbados";BB;BRB;23;"Saint Joseph";Parish;"06";12659
-"Barbados";BB;BRB;23;"Saint Lucy";Parish;"07";12665
-"Barbados";BB;BRB;23;"Saint Michael";Parish;"08";12658
-"Barbados";BB;BRB;23;"Saint Peter";Parish;"09";12666
-"Barbados";BB;BRB;23;"Saint Philip";Parish;"10";12667
-"Barbados";BB;BRB;23;"Saint Thomas";Parish;"11";12657
-"Belarus";BY;BLR;24;"Brestskaya voblasts";Region;"BR";12669
-"Belarus";BY;BLR;24;"Homyel'skaya voblasts";Region;"HO";12670
-"Belarus";BY;BLR;24;"Horad Minsk";city;"HM";12674
-"Belarus";BY;BLR;24;"Horad Minsk";Municipality;"X1~";48130
-"Belarus";BY;BLR;24;"Hrodzenskaya voblasts";Region;"HR";12672
-"Belarus";BY;BLR;24;"Mahilyowskaya voblasts";Region;"MA";12671
-"Belarus";BY;BLR;24;"Minskaya voblasts";Region;"MI";12673
-"Belarus";BY;BLR;24;"Vitsyebskaya voblasts";Region;"VI";12668
-"Belgium";BE;BEL;25;"Antwerpen";Province;"VAN";12683
-"Belgium";BE;BEL;25;"Brabant Wallon";Province;"WBR";12679
-"Belgium";BE;BEL;25;"Brussels";Capital Region;"BRU";12682
-"Belgium";BE;BEL;25;"Flemish Region";region;"VLG";48264
-"Belgium";BE;BEL;25;"Hainaut";Province;"WHT";12678
-"Belgium";BE;BEL;25;"Limburg";Province;"VLI";12680
-"Belgium";BE;BEL;25;"Liège";Province;"WLG";12684
-"Belgium";BE;BEL;25;"Luxembourg";Province;"WLX";12676
-"Belgium";BE;BEL;25;"Namur";Province;"WNA";12685
-"Belgium";BE;BEL;25;"Oost-Vlaanderen";Province;"VOV";12677
-"Belgium";BE;BEL;25;"Vlaams Brabant";Province;"VBR";12675
-"Belgium";BE;BEL;25;"Wallonia";region;"WAL";48265
-"Belgium";BE;BEL;25;"West-Vlaanderen";Province;"VWV";12681
-"Belize";BZ;BLZ;26;"Belize";District;"BZ";12687
-"Belize";BZ;BLZ;26;"Cayo";District;"CY";12691
-"Belize";BZ;BLZ;26;"Corozal";District;"CZL";12688
-"Belize";BZ;BLZ;26;"Orange Walk";District;"OW";12689
-"Belize";BZ;BLZ;26;"Stann Creek";District;"SC";12686
-"Belize";BZ;BLZ;26;"Toledo";District;"TOL";12690
-"Benin";BJ;BEN;27;"Alibori";Department;"AL";12696
-"Benin";BJ;BEN;27;"Atakora";Department;"AK";12702
-"Benin";BJ;BEN;27;"Atlantique";Department;"AQ";12697
-"Benin";BJ;BEN;27;"Borgou";Department;"BO";12698
-"Benin";BJ;BEN;27;"Collines";Department;"CO";12704
-"Benin";BJ;BEN;27;"Donga";Department;"DO";12705
-"Benin";BJ;BEN;27;"Kouffo";Department;"KO";12699
-"Benin";BJ;BEN;27;"Littoral";Department;"LI";12694
-"Benin";BJ;BEN;27;"Mono";Department;"MO";12700
-"Benin";BJ;BEN;27;"Ouémé";Department;"OU";12701
-"Benin";BJ;BEN;27;"Plateau";Department;"PL";12693
-"Benin";BJ;BEN;27;"Zou";Department;"ZO";12692
-"Bermuda";BM;BMU;28;"Devonshire";Parish;"DEV";12708
-"Bermuda";BM;BMU;28;"Hamilton";Parish;"HAM";12707
-"Bermuda";BM;BMU;28;"Hamilton municipality";Municipality;"HA";12709
-"Bermuda";BM;BMU;28;"Paget";Parish;"PAG";12710
-"Bermuda";BM;BMU;28;"Pembroke";Parish;"PEM";12711
-"Bermuda";BM;BMU;28;"Saint George";Parish;"SGE";12712
-"Bermuda";BM;BMU;28;"Saint George municipality";Municipality;"SG";12716
-"Bermuda";BM;BMU;28;"Sandys";Parish;"SAN";12713
-"Bermuda";BM;BMU;28;"Smiths";Parish;"SMI";12706
-"Bermuda";BM;BMU;28;"Southampton";Parish;"SOU";12714
-"Bermuda";BM;BMU;28;"Warwick";Parish;"WAR";12715
-"Bhutan";BT;BTN;29;"Bumthang";District;"33";12724
-"Bhutan";BT;BTN;29;"Chhukha";District;"12";12735
-"Bhutan";BT;BTN;29;"Dagana";District;"22";12723
-"Bhutan";BT;BTN;29;"Gasa";District;"GA";12733
-"Bhutan";BT;BTN;29;"Ha";District;"13";12736
-"Bhutan";BT;BTN;29;"Lhuentse";District;"44";12727
-"Bhutan";BT;BTN;29;"Monggar";District;"42";12722
-"Bhutan";BT;BTN;29;"Paro";District;"11";12729
-"Bhutan";BT;BTN;29;"Pemagatshel";District;"43";12728
-"Bhutan";BT;BTN;29;"Punakha";District;"23";12719
-"Bhutan";BT;BTN;29;"Samdrup Jongkha";District;"45";12730
-"Bhutan";BT;BTN;29;"Samtse";District;"14";12718
-"Bhutan";BT;BTN;29;"Sarpang";District;"31";12726
-"Bhutan";BT;BTN;29;"Thimphu";District;"15";12731
-"Bhutan";BT;BTN;29;"Trashi Yangtse";District;"TY";12734
-"Bhutan";BT;BTN;29;"Trashigang";District;"41";12721
-"Bhutan";BT;BTN;29;"Trongsa";District;"32";12717
-"Bhutan";BT;BTN;29;"Tsirang";District;"21";12725
-"Bhutan";BT;BTN;29;"Wangdue Phodrang";District;"24";12732
-"Bhutan";BT;BTN;29;"Zhemgang";District;"34";12720
-"Plurinational State Of Bolivia";BO;BOL;30;"Chuquisaca";Department;"H";12739
-"Plurinational State Of Bolivia";BO;BOL;30;"Cochabamba";Department;"C";12741
-"Plurinational State Of Bolivia";BO;BOL;30;"El Beni";Department;"B";12740
-"Plurinational State Of Bolivia";BO;BOL;30;"La Paz";Department;"L";12742
-"Plurinational State Of Bolivia";BO;BOL;30;"Oruro";Department;"O";12738
-"Plurinational State Of Bolivia";BO;BOL;30;"Pando";Department;"N";12743
-"Plurinational State Of Bolivia";BO;BOL;30;"Potosí";Department;"P";12737
-"Plurinational State Of Bolivia";BO;BOL;30;"Santa Cruz";Department;"S";12744
-"Plurinational State Of Bolivia";BO;BOL;30;"Tarija";Department;"T";12745
-"Sint Eustatius and Saba Bonaire";BQ;BES;700;"Bonaire";municipality;"BO";48682
-"Sint Eustatius and Saba Bonaire";BQ;BES;700;"Saba";municipality;"SA";48683
-"Sint Eustatius and Saba Bonaire";BQ;BES;700;"Sint Eustatius";municipality;"SE";48684
-"Bosnia and Herzegovina";BA;BIH;31;"Bosansko-podrinjski kanton";canton;"05";48161
-"Bosnia and Herzegovina";BA;BIH;31;"Brčko distrikt";District;"BRC";42644
-"Bosnia and Herzegovina";BA;BIH;31;"Federacija Bosna i Hercegovina";Entity;"BIH";12746
-"Bosnia and Herzegovina";BA;BIH;31;"Hercegova?ko-neretvanski kanton";canton;"07";48162
-"Bosnia and Herzegovina";BA;BIH;31;"Kanton br. 10 (Livanjski kanton)";canton;"10";48163
-"Bosnia and Herzegovina";BA;BIH;31;"Kanton Sarajevo";canton;"09";48164
-"Bosnia and Herzegovina";BA;BIH;31;"Posavski kanton";canton;"02";48165
-"Bosnia and Herzegovina";BA;BIH;31;"Republika Srpska";Entity;"SRP";12747
-"Bosnia and Herzegovina";BA;BIH;31;"Srednjobosanski kanton";canton;"06";48166
-"Bosnia and Herzegovina";BA;BIH;31;"Tuzlanski kanton";canton;"03";48167
-"Bosnia and Herzegovina";BA;BIH;31;"Unsko-sanski kanton";canton;"01";48168
-"Bosnia and Herzegovina";BA;BIH;31;"Zapadnohercegova?ki kanton";canton;"08";48169
-"Bosnia and Herzegovina";BA;BIH;31;"Zeni?ko-dobojski kanton";canton;"04";48170
-"Botswana";BW;BWA;32;"Central";District;"CE";19401
-"Botswana";BW;BWA;32;"Ghanzi";District;"GH";12759
-"Botswana";BW;BWA;32;"Kgalagadi";District;"KG";19402
-"Botswana";BW;BWA;32;"Kgatleng";District;"KL";12770
-"Botswana";BW;BWA;32;"Kweneng";District;"KW";12762
-"Botswana";BW;BWA;32;"North-East";District;"NE";12749
-"Botswana";BW;BWA;32;"North-West";District;"NW";19403
-"Botswana";BW;BWA;32;"South-East";District;"SE";12751
-"Botswana";BW;BWA;32;"Southern";District;"SO";19404
-"Brazil";BR;BRA;34;"Acre";state;"AC";12793
-"Brazil";BR;BRA;34;"Alagoas";state;"AL";12784
-"Brazil";BR;BRA;34;"Amapá";state;"AP";12775
-"Brazil";BR;BRA;34;"Amazonas";state;"AM";12794
-"Brazil";BR;BRA;34;"Bahia";state;"BA";12776
-"Brazil";BR;BRA;34;"Ceará";state;"CE";12795
-"Brazil";BR;BRA;34;"Distrito Federal";federal district;"DF";12777
-"Brazil";BR;BRA;34;"Espírito Santo";state;"ES";12778
-"Brazil";BR;BRA;34;"Goiás";state;"GO";12796
-"Brazil";BR;BRA;34;"Maranhão";state;"MA";12779
-"Brazil";BR;BRA;34;"Mato Grosso";state;"MT";12780
-"Brazil";BR;BRA;34;"Mato Grosso do Sul";state;"MS";12774
-"Brazil";BR;BRA;34;"Minas Gerais";state;"MG";12781
-"Brazil";BR;BRA;34;"Paraná";state;"PR";12783
-"Brazil";BR;BRA;34;"Paraíba";state;"PB";12782
-"Brazil";BR;BRA;34;"Pará";state;"PA";12797
-"Brazil";BR;BRA;34;"Pernambuco";state;"PE";12773
-"Brazil";BR;BRA;34;"Piauí";state;"PI";12785
-"Brazil";BR;BRA;34;"Rio de Janeiro";state;"RJ";12786
-"Brazil";BR;BRA;34;"Rio Grande do Norte";state;"RN";12798
-"Brazil";BR;BRA;34;"Rio Grande do Sul";state;"RS";12787
-"Brazil";BR;BRA;34;"Rondônia";state;"RO";12772
-"Brazil";BR;BRA;34;"Roraima";state;"RR";12788
-"Brazil";BR;BRA;34;"Santa Catarina";state;"SC";12789
-"Brazil";BR;BRA;34;"Sergipe";state;"SE";12790
-"Brazil";BR;BRA;34;"São Paulo";state;"SP";12771
-"Brazil";BR;BRA;34;"Tocantins";state;"TO";12791
-"Brunei Darussalam";BN;BRN;36;"Belait";District;"BE";12805
-"Brunei Darussalam";BN;BRN;36;"Brunei-Muara";District;"BM";12807
-"Brunei Darussalam";BN;BRN;36;"Temburong";District;"TE";12806
-"Brunei Darussalam";BN;BRN;36;"Tutong";District;"TU";12804
-"Bulgaria";BG;BGR;37;"Blagoevgrad";Region;"01";12829
-"Bulgaria";BG;BGR;37;"Burgas";Region;"02";12813
-"Bulgaria";BG;BGR;37;"Dobrich";Region;"08";12830
-"Bulgaria";BG;BGR;37;"Gabrovo";Region;"07";12823
-"Bulgaria";BG;BGR;37;"Haskovo";Region;"26";12824
-"Bulgaria";BG;BGR;37;"Kardzhali";Region;"09";12825
-"Bulgaria";BG;BGR;37;"Kjustendil";Region;"10";12831
-"Bulgaria";BG;BGR;37;"Lovech";Region;"11";12826
-"Bulgaria";BG;BGR;37;"Montana";Region;"12";12811
-"Bulgaria";BG;BGR;37;"Pazardzhik";Region;"13";12827
-"Bulgaria";BG;BGR;37;"Pernik";Region;"14";12832
-"Bulgaria";BG;BGR;37;"Pleven";Region;"15";12828
-"Bulgaria";BG;BGR;37;"Plovdiv";Region;"16";12814
-"Bulgaria";BG;BGR;37;"Razgrad";Region;"17";12810
-"Bulgaria";BG;BGR;37;"Ruse";Region;"18";12815
-"Bulgaria";BG;BGR;37;"Silistra";Region;"19";12833
-"Bulgaria";BG;BGR;37;"Sliven";Region;"20";12816
-"Bulgaria";BG;BGR;37;"Smolyan";Region;"21";12809
-"Bulgaria";BG;BGR;37;"Sofia";Region;"23";12834
-"Bulgaria";BG;BGR;37;"Sofia-Grad";Region;"22";12817
-"Bulgaria";BG;BGR;37;"Stara Zagora";Region;"24";12818
-"Bulgaria";BG;BGR;37;"Targovishte";Region;"25";12835
-"Bulgaria";BG;BGR;37;"Varna";Region;"03";12820
-"Bulgaria";BG;BGR;37;"Veliko Tarnovo";Region;"04";12808
-"Bulgaria";BG;BGR;37;"Vidin";Region;"05";12821
-"Bulgaria";BG;BGR;37;"Vratsa";Region;"06";12822
-"Bulgaria";BG;BGR;37;"Yambol";Region;"28";12812
-"Bulgaria";BG;BGR;37;"Šumen";Region;"27";12819
-"Burkina Faso";BF;BFA;38;"Balé";Province;"BAL";12846
-"Burkina Faso";BF;BFA;38;"Bam";Province;"BAM";12855
-"Burkina Faso";BF;BFA;38;"Banwa";Province;"BAN";12847
-"Burkina Faso";BF;BFA;38;"Bazèga";Province;"BAZ";12856
-"Burkina Faso";BF;BFA;38;"Boucle du Mouhoun";region;"01";48171
-"Burkina Faso";BF;BFA;38;"Bougouriba";Province;"BGR";12857
-"Burkina Faso";BF;BFA;38;"Boulgou";Province;"BLG";12848
-"Burkina Faso";BF;BFA;38;"Boulkiemdé";Province;"BLK";12858
-"Burkina Faso";BF;BFA;38;"Cascades";region;"02";48172
-"Burkina Faso";BF;BFA;38;"Centre";region;"03";48173
-"Burkina Faso";BF;BFA;38;"Centre-Est";region;"04";48174
-"Burkina Faso";BF;BFA;38;"Centre-Nord";region;"05";48175
-"Burkina Faso";BF;BFA;38;"Centre-Ouest";region;"06";48176
-"Burkina Faso";BF;BFA;38;"Centre-Sud";region;"07";48177
-"Burkina Faso";BF;BFA;38;"Comoé";Province;"COM";12849
-"Burkina Faso";BF;BFA;38;"Est";region;"08";48178
-"Burkina Faso";BF;BFA;38;"Ganzourgou";Province;"GAN";12859
-"Burkina Faso";BF;BFA;38;"Gnagna";Province;"GNA";12860
-"Burkina Faso";BF;BFA;38;"Gourma";Province;"GOU";12850
-"Burkina Faso";BF;BFA;38;"Hauts-Bassins";region;"09";48179
-"Burkina Faso";BF;BFA;38;"Houet";Province;"HOU";12861
-"Burkina Faso";BF;BFA;38;"Ioba";Province;"IOB";12851
-"Burkina Faso";BF;BFA;38;"Kadiogo";Province;"KAD";12862
-"Burkina Faso";BF;BFA;38;"Komondjari";Province;"KMD";12863
-"Burkina Faso";BF;BFA;38;"Kompienga";Province;"KMP";12864
-"Burkina Faso";BF;BFA;38;"Kossi";Province;"KOS";12853
-"Burkina Faso";BF;BFA;38;"Koulpélogo";Province;"KOP";12865
-"Burkina Faso";BF;BFA;38;"Kouritenga";Province;"KOT";12854
-"Burkina Faso";BF;BFA;38;"Kourwéogo";Province;"KOW";12866
-"Burkina Faso";BF;BFA;38;"Kénédougou";Province;"KEN";12852
-"Burkina Faso";BF;BFA;38;"Loroum";Province;"LOR";12837
-"Burkina Faso";BF;BFA;38;"Léraba";Province;"LER";12867
-"Burkina Faso";BF;BFA;38;"Mouhoun";Province;"MOU";12868
-"Burkina Faso";BF;BFA;38;"Nahouri";Province;"NAO";12838
-"Burkina Faso";BF;BFA;38;"Namentenga";Province;"NAM";12869
-"Burkina Faso";BF;BFA;38;"Nayala";Province;"NAY";12870
-"Burkina Faso";BF;BFA;38;"Nord";region;"10";48180
-"Burkina Faso";BF;BFA;38;"Noumbiel";Province;"NOU";12839
-"Burkina Faso";BF;BFA;38;"Oubritenga";Province;"OUB";12871
-"Burkina Faso";BF;BFA;38;"Oudalan";Province;"OUD";12840
-"Burkina Faso";BF;BFA;38;"Passoré";Province;"PAS";12872
-"Burkina Faso";BF;BFA;38;"Plateau-Central";region;"11";48181
-"Burkina Faso";BF;BFA;38;"Poni";Province;"PON";12873
-"Burkina Faso";BF;BFA;38;"Sahel";region;"12";48182
-"Burkina Faso";BF;BFA;38;"Sanguié";Province;"SNG";12841
-"Burkina Faso";BF;BFA;38;"Sanmatenga";Province;"SMT";12874
-"Burkina Faso";BF;BFA;38;"Sissili";Province;"SIS";12843
-"Burkina Faso";BF;BFA;38;"Soum";Province;"SOM";12844
-"Burkina Faso";BF;BFA;38;"Sourou";Province;"SOR";12845
-"Burkina Faso";BF;BFA;38;"Sud-Ouest";region;"13";48183
-"Burkina Faso";BF;BFA;38;"Séno";Province;"SEN";12842
-"Burkina Faso";BF;BFA;38;"Tapoa";Province;"TAP";12879
-"Burkina Faso";BF;BFA;38;"Tui";Province;"TUI";12880
-"Burkina Faso";BF;BFA;38;"Yagha";Province;"YAG";12878
-"Burkina Faso";BF;BFA;38;"Yatenga";Province;"YAT";12877
-"Burkina Faso";BF;BFA;38;"Ziro";Province;"ZIR";12876
-"Burkina Faso";BF;BFA;38;"Zondoma";Province;"ZON";12881
-"Burkina Faso";BF;BFA;38;"Zoundwéogo";Province;"ZOU";12882
-"Burundi";BI;BDI;39;"Bubanza";Province;"BB";12893
-"Burundi";BI;BDI;39;"Bujumbura";Province;"BJ";12884
-"Burundi";BI;BDI;39;"Bujumbura Mairie";Province;"BM";48128
-"Burundi";BI;BDI;39;"Bujumbura Rural";Province;"BL";48129
-"Burundi";BI;BDI;39;"Bururi";Province;"BR";12895
-"Burundi";BI;BDI;39;"Cankuzo";Province;"CA";12885
-"Burundi";BI;BDI;39;"Cibitoke";Province;"CI";12896
-"Burundi";BI;BDI;39;"Gitega";Province;"GI";12886
-"Burundi";BI;BDI;39;"Karuzi";Province;"KR";12887
-"Burundi";BI;BDI;39;"Kayanza";Province;"KY";12894
-"Burundi";BI;BDI;39;"Kirundo";Province;"KI";12888
-"Burundi";BI;BDI;39;"Makamba";Province;"MA";12889
-"Burundi";BI;BDI;39;"Muramvya";Province;"MU";12897
-"Burundi";BI;BDI;39;"Muyinga";Province;"MY";12890
-"Burundi";BI;BDI;39;"Mwaro";Province;"MW";12898
-"Burundi";BI;BDI;39;"Ngozi";Province;"NG";12891
-"Burundi";BI;BDI;39;"Rutana";Province;"RT";12892
-"Burundi";BI;BDI;39;"Ruyigi";Province;"RY";12883
-"Cambodia";KH;KHM;40;"Baat Dambang [Batdâmbâng]";province;"2";12918
-"Cambodia";KH;KHM;40;"Banteay Mean Chey [Bântéay Méanchey]";province;"1";12911
-"Cambodia";KH;KHM;40;"Kampong Chaam [Kâmpóng Cham]";province;"3";12912
-"Cambodia";KH;KHM;40;"Kampong Chhnang [Kâmpóng Chhnang]";province;"4";12919
-"Cambodia";KH;KHM;40;"Kampong Spueu [Kâmpóng Spœ]";province;"5";12920
-"Cambodia";KH;KHM;40;"Kampong Thum [Kâmpóng Thum]";province;"6";12902
-"Cambodia";KH;KHM;40;"Kampot [Kâmpôt]";province;"7";12903
-"Cambodia";KH;KHM;40;"Kandaal [Kândal]";province;"8";12904
-"Cambodia";KH;KHM;40;"Kaoh Kong [Kaôh Kong]";province;"9";12905
-"Cambodia";KH;KHM;40;"Kracheh [Krâchéh]";province;"10";12906
-"Cambodia";KH;KHM;40;"Krong Kaeb [Krong Kêb]";autonomous municipality;"23";12907
-"Cambodia";KH;KHM;40;"Krong Pailin [Krong Pailin]";autonomous municipality;"24";12908
-"Cambodia";KH;KHM;40;"Krong Preah Sihanouk [Krong Preah Sihanouk]";autonomous municipality;"18";12909
-"Cambodia";KH;KHM;40;"Mondol Kiri [Môndól Kiri]";province;"11";12910
-"Cambodia";KH;KHM;40;"Otdar Mean Chey [Otdâr Méanchey]";province;"22";12901
-"Cambodia";KH;KHM;40;"Phnom Penh [Phnum Pénh]";autonomous municipality;"12";12921
-"Cambodia";KH;KHM;40;"Pousaat [Pouthisat]";province;"15";12900
-"Cambodia";KH;KHM;40;"Preah Vihear [Preah Vihéar]";province;"13";12913
-"Cambodia";KH;KHM;40;"Prey Veaeng [Prey Vêng]";province;"14";12914
-"Cambodia";KH;KHM;40;"Rotanak Kiri [Rôtânôkiri]";province;"16";12922
-"Cambodia";KH;KHM;40;"Siem Reab [Siemréab]";province;"17";12915
-"Cambodia";KH;KHM;40;"Stueng Traeng [Stœ?ng Trêng]";province;"19";12925
-"Cambodia";KH;KHM;40;"Svaay Rieng [Svay Rieng]";province;"20";12916
-"Cambodia";KH;KHM;40;"Taakaev [Takêv]";province;"21";12924
-"Cameroon";CM;CMR;41;"Adamaoua";Region;"AD";12932
-"Cameroon";CM;CMR;41;"Centre";Region;"CE";12928
-"Cameroon";CM;CMR;41;"East";Region;"ES";12933
-"Cameroon";CM;CMR;41;"Far North";Region;"EN";12934
-"Cameroon";CM;CMR;41;"Littoral";Region;"LT";12929
-"Cameroon";CM;CMR;41;"North";Region;"NO";12931
-"Cameroon";CM;CMR;41;"North-West";Region;"NW";12927
-"Cameroon";CM;CMR;41;"South";Region;"SU";12935
-"Cameroon";CM;CMR;41;"South-West";Region;"SW";12926
-"Cameroon";CM;CMR;41;"West";Region;"OU";12930
-"Canada";CA;CAN;42;"Alberta";province;"AB";12940
-"Canada";CA;CAN;42;"British Columbia";province;"BC";12938
-"Canada";CA;CAN;42;"Manitoba";province;"MB";12941
-"Canada";CA;CAN;42;"New Brunswick";province;"NB";12937
-"Canada";CA;CAN;42;"Newfoundland and Labrador";province;"NL";12942
-"Canada";CA;CAN;42;"Northwest Territories";territory;"NT";12939
-"Canada";CA;CAN;42;"Nova Scotia";province;"NS";12943
-"Canada";CA;CAN;42;"Nunavut";territory;"NU";12944
-"Canada";CA;CAN;42;"Ontario";province;"ON";12948
-"Canada";CA;CAN;42;"Prince Edward Island";province;"PE";12945
-"Canada";CA;CAN;42;"Quebec";province;"QC";12946
-"Canada";CA;CAN;42;"Saskatchewan";province;"SK";12936
-"Canada";CA;CAN;42;"Yukon Territory";territory;"YT";12947
-"Cape Verde";CV;CPV;43;"Boa Vista";municipality;"BV";12953
-"Cape Verde";CV;CPV;43;"Brava";municipality;"BR";12957
-"Cape Verde";CV;CPV;43;"Calheta de São Miguel";;"CS";19405
-"Cape Verde";CV;CPV;43;"Ilhas de Barlavento";geographical region;"B";48184
-"Cape Verde";CV;CPV;43;"Ilhas de Sotavento";geographical region;"S";48185
-"Cape Verde";CV;CPV;43;"Maio";municipality;"MA";12954
-"Cape Verde";CV;CPV;43;"Mosteiros";municipality;"MO";19406
-"Cape Verde";CV;CPV;43;"Paul";municipality;"PA";19407
-"Cape Verde";CV;CPV;43;"Porto Novo";municipality;"PN";19408
-"Cape Verde";CV;CPV;43;"Praia";municipality;"PR";19409
-"Cape Verde";CV;CPV;43;"Ribeira Brava";municipality;"RB";48244
-"Cape Verde";CV;CPV;43;"Ribeira Grande";municipality;"RG";12955
-"Cape Verde";CV;CPV;43;"Ribeira Grande de Santiago";municipality;"RS";48245
-"Cape Verde";CV;CPV;43;"Sal";municipality;"SL";12956
-"Cape Verde";CV;CPV;43;"Santa Catarina";municipality;"CA";19411
-"Cape Verde";CV;CPV;43;"Santa Catarina do Fogo";municipality;"CF";48246
-"Cape Verde";CV;CPV;43;"Santa Cruz";municipality;"CR";19412
-"Cape Verde";CV;CPV;43;"São Domingos";municipality;"SD";19413
-"Cape Verde";CV;CPV;43;"São Filipe";municipality;"SF";19414
-"Cape Verde";CV;CPV;43;"São Lourenço dos Órgãos";municipality;"SO";48904
-"Cape Verde";CV;CPV;43;"São Miguel";municipality;"SM";48247
-"Cape Verde";CV;CPV;43;"São Nicolau";;"SN";12949
-"Cape Verde";CV;CPV;43;"São Salvador do Mundo";municipality;"SS";48248
-"Cape Verde";CV;CPV;43;"São Vicente";municipality;"SV";12950
-"Cape Verde";CV;CPV;43;"Tarrafal";municipality;"TA";19415
-"Cape Verde";CV;CPV;43;"Tarrafal de São Nicolau";municipality;"TS";48249
-"Cayman Islands";KY;CYM;44;"Bodden Town";District;"01~";48080
-"Cayman Islands";KY;CYM;44;"Cayman Brac";District;"02~";12962
-"Cayman Islands";KY;CYM;44;"East End";District;"03~";20891
-"Cayman Islands";KY;CYM;44;"George Town";District;"04~";48081
-"Cayman Islands";KY;CYM;44;"Little Cayman";District;"05~";12958
-"Cayman Islands";KY;CYM;44;"North Side";District;"06~";48082
-"Cayman Islands";KY;CYM;44;"West Bay";District;"07~";48083
-"Central African Republic";CF;CAF;45;"Bamingui-Bangoran";prefecture;"BB";12972
-"Central African Republic";CF;CAF;45;"Bangui";commune;"BGF";12969
-"Central African Republic";CF;CAF;45;"Basse-Kotto";prefecture;"BK";12973
-"Central African Republic";CF;CAF;45;"Gribingui";economic prefecture;"KB";12965
-"Central African Republic";CF;CAF;45;"Haut-Mbomou";prefecture;"HM";12974
-"Central African Republic";CF;CAF;45;"Haute-Kotto";prefecture;"HK";12968
-"Central African Republic";CF;CAF;45;"Haute-Sangha / Mambéré-Kadéï";prefecture;"HS";12966
-"Central African Republic";CF;CAF;45;"Kémo-Gribingui";prefecture;"KG";12967
-"Central African Republic";CF;CAF;45;"Lobaye";prefecture;"LB";12975
-"Central African Republic";CF;CAF;45;"Mbomou";prefecture;"MB";12976
-"Central African Republic";CF;CAF;45;"Nana-Mambéré";prefecture;"NM";12977
-"Central African Republic";CF;CAF;45;"Ombella-Mpoko";prefecture;"MP";12964
-"Central African Republic";CF;CAF;45;"Ouaka";prefecture;"UK";12979
-"Central African Republic";CF;CAF;45;"Ouham";prefecture;"AC";12978
-"Central African Republic";CF;CAF;45;"Ouham-Pendé";prefecture;"OP";12970
-"Central African Republic";CF;CAF;45;"Sangha";economic prefecture;"SE";12963
-"Central African Republic";CF;CAF;45;"Vakaga";prefecture;"VK";12971
-"Chad";TD;TCD;46;"Al Baṭḩah";Region;"BA";12981
-"Chad";TD;TCD;46;"Al Buḩayrah";Region;"LC";12985
-"Chad";TD;TCD;46;"Baḩr al Ghazāl";region;"BG";48189
-"Chad";TD;TCD;46;"Borkou-Ennedi-Tibesti";Region;"BET";12982
-"Chad";TD;TCD;46;"Būrkū";region;"BO";48190
-"Chad";TD;TCD;46;"Innīdī";region;"EN";48191
-"Chad";TD;TCD;46;"Kānim";Region;"KA";12984
-"Chad";TD;TCD;46;"Lūqūn al Gharbī";Region;"LO";12986
-"Chad";TD;TCD;46;"Lūqūn ash Sharqī";Region;"LR";12987
-"Chad";TD;TCD;46;"Madīnat Injamīnā";Region;"ND";19420
-"Chad";TD;TCD;46;"Māndūl";Region;"MA";19417
-"Chad";TD;TCD;46;"Māyū Kībbī al Gharbī";Region;"MO";19419
-"Chad";TD;TCD;46;"Māyū Kībbī ash Sharqī";Region;"ME";19418
-"Chad";TD;TCD;46;"Qīrā";Region;"GR";12983
-"Chad";TD;TCD;46;"Salāmāt";Region;"SA";12992
-"Chad";TD;TCD;46;"Shārī al Awsaṭ";Region;"MC";12991
-"Chad";TD;TCD;46;"Shārī Bāqirmī";Region;"CB";12990
-"Chad";TD;TCD;46;"Sīlā";region;"SI";48192
-"Chad";TD;TCD;46;"Tibastī";region;"TI";48193
-"Chad";TD;TCD;46;"Tānjilī";Region;"TA";12980
-"Chad";TD;TCD;46;"Waddāy";Region;"OD";12988
-"Chad";TD;TCD;46;"Wādī Fīrā";Region;"WF";19421
-"Chad";TD;TCD;46;"Ḥajjar Lamīs";Region;"HL";19416
-"Chile";CL;CHL;47;"Aisén del General Carlos Ibáñez del Campo";Region;"AI";13004
-"Chile";CL;CHL;47;"Antofagasta";Region;"AN";12998
-"Chile";CL;CHL;47;"Araucanía";Region;"AR";12997
-"Chile";CL;CHL;47;"Arica y Parinacota";Region;"AP";21383
-"Chile";CL;CHL;47;"Atacama";Region;"AT";12999
-"Chile";CL;CHL;47;"Bío-Bío";Region;"BI";13005
-"Chile";CL;CHL;47;"Coquimbo";Region;"CO";12996
-"Chile";CL;CHL;47;"Libertador General Bernardo O'Higgins";Region;"LI";13000
-"Chile";CL;CHL;47;"Los Lagos";Region;"LL";13006
-"Chile";CL;CHL;47;"Los Ríos";Region;"LR";21384
-"Chile";CL;CHL;47;"Magallanes";Region;"MA";13001
-"Chile";CL;CHL;47;"Maule";Region;"ML";12995
-"Chile";CL;CHL;47;"Región Metropolitana de Santiago";Region;"RM";13002
-"Chile";CL;CHL;47;"Tarapacá";Region;"TA";12994
-"Chile";CL;CHL;47;"Valparaíso";Region;"VS";13003
-"China";CN;CHN;48;"Anhui";province;"34";13012
-"China";CN;CHN;48;"Aomen (zh) ***";special administrative region;"92";13034
-"China";CN;CHN;48;"Beijing";municipality;"11";13013
-"China";CN;CHN;48;"Chongqing";municipality;"50";13014
-"China";CN;CHN;48;"Fujian";province;"35";13035
-"China";CN;CHN;48;"Gansu";province;"62";13015
-"China";CN;CHN;48;"Guangdong";province;"44";13016
-"China";CN;CHN;48;"Guangxi";autonomous region;"45";13036
-"China";CN;CHN;48;"Guizhou";province;"52";13017
-"China";CN;CHN;48;"Hainan";province;"46";13018
-"China";CN;CHN;48;"Hebei";province;"13";13019
-"China";CN;CHN;48;"Heilongjiang";province;"23";13028
-"China";CN;CHN;48;"Henan";province;"41";13029
-"China";CN;CHN;48;"Hubei";province;"42";13020
-"China";CN;CHN;48;"Hunan";province;"43";13030
-"China";CN;CHN;48;"Jiangsu";province;"32";13031
-"China";CN;CHN;48;"Jiangxi";province;"36";13021
-"China";CN;CHN;48;"Jilin";province;"22";13022
-"China";CN;CHN;48;"Liaoning";province;"21";13023
-"China";CN;CHN;48;"Nei Mongol (mn)";autonomous region;"15";13024
-"China";CN;CHN;48;"Ningxia";autonomous region;"64";13025
-"China";CN;CHN;48;"Qinghai";province;"63";13026
-"China";CN;CHN;48;"Shaanxi";province;"61";13027
-"China";CN;CHN;48;"Shandong";province;"37";13011
-"China";CN;CHN;48;"Shanghai";municipality;"31";13037
-"China";CN;CHN;48;"Shanxi";province;"14";13010
-"China";CN;CHN;48;"Sichuan";province;"51";13038
-"China";CN;CHN;48;"Taiwan *";province;"71";18995
-"China";CN;CHN;48;"Tianjin";municipality;"12";13009
-"China";CN;CHN;48;"Xianggang (zh) **";special administrative region;"91";13039
-"China";CN;CHN;48;"Xinjiang";autonomous region;"65";13008
-"China";CN;CHN;48;"Xizang";autonomous region;"54";13032
-"China";CN;CHN;48;"Yunnan";province;"53";13033
-"China";CN;CHN;48;"Zhejiang";province;"33";13007
-"Colombia";CO;COL;51;"Amazonas";department;"AMA";13045
-"Colombia";CO;COL;51;"Antioquia";department;"ANT";13055
-"Colombia";CO;COL;51;"Arauca";department;"ARA";13046
-"Colombia";CO;COL;51;"Atlántico";department;"ATL";13047
-"Colombia";CO;COL;51;"Bolívar";department;"BOL";13048
-"Colombia";CO;COL;51;"Boyacá";department;"BOY";13057
-"Colombia";CO;COL;51;"Caldas";department;"CAL";13049
-"Colombia";CO;COL;51;"Caquetá";department;"CAQ";13050
-"Colombia";CO;COL;51;"Casanare";department;"CAS";13058
-"Colombia";CO;COL;51;"Cauca";department;"CAU";13051
-"Colombia";CO;COL;51;"Cesar";department;"CES";13059
-"Colombia";CO;COL;51;"Chocó";department;"CHO";13052
-"Colombia";CO;COL;51;"Cundinamarca";department;"CUN";13060
-"Colombia";CO;COL;51;"Córdoba";department;"COR";13053
-"Colombia";CO;COL;51;"Distrito Capital de Bogotá";capital district;"DC";13056
-"Colombia";CO;COL;51;"Guainía";department;"GUA";13054
-"Colombia";CO;COL;51;"Guaviare";department;"GUV";13061
-"Colombia";CO;COL;51;"Huila";department;"HUI";13063
-"Colombia";CO;COL;51;"La Guajira";department;"LAG";13064
-"Colombia";CO;COL;51;"Magdalena";department;"MAG";13062
-"Colombia";CO;COL;51;"Meta";department;"MET";13065
-"Colombia";CO;COL;51;"Nariño";department;"NAR";13044
-"Colombia";CO;COL;51;"Norte de Santander";department;"NSA";13066
-"Colombia";CO;COL;51;"Putumayo";department;"PUT";13067
-"Colombia";CO;COL;51;"Quindío";department;"QUI";13042
-"Colombia";CO;COL;51;"Risaralda";department;"RIS";13068
-"Colombia";CO;COL;51;"Providencia y Santa Catalina San Andrés";department;"SAP";13043
-"Colombia";CO;COL;51;"Santander";department;"SAN";13069
-"Colombia";CO;COL;51;"Sucre";department;"SUC";13041
-"Colombia";CO;COL;51;"Tolima";department;"TOL";13070
-"Colombia";CO;COL;51;"Valle del Cauca";department;"VAC";13071
-"Colombia";CO;COL;51;"Vaupés";department;"VAU";13040
-"Colombia";CO;COL;51;"Vichada";department;"VID";13072
-"Comoros";KM;COM;52;"Andjazîdja";island;"G";13074
-"Comoros";KM;COM;52;"Andjouân (Anjwān)";island;"A";13073
-"Comoros";KM;COM;52;"Moûhîlî (Mūhīlī)";island;"M";13075
-"Congo";CG;COG;53;"Bouenza";Department;"11";13078
-"Congo";CG;COG;53;"Brazzaville";Commune;"BZV";13080
-"Congo";CG;COG;53;"Cuvette";Department;"8";13077
-"Congo";CG;COG;53;"Cuvette-Ouest";Department;"15";13076
-"Congo";CG;COG;53;"Kouilou";Department;"5";13081
-"Congo";CG;COG;53;"Likouala";Department;"7";13079
-"Congo";CG;COG;53;"Lékoumou";Department;"2";13082
-"Congo";CG;COG;53;"Niari";Department;"9";13083
-"Congo";CG;COG;53;"Plateaux";Department;"14";13086
-"Congo";CG;COG;53;"Pool";Department;"12";13084
-"Congo";CG;COG;53;"Sangha";Department;"13";13085
-"The Democratic Republic Of The Congo";CD;COD;54;"Bandundu";province;"BN";13094
-"The Democratic Republic Of The Congo";CD;COD;54;"Bas-Congo";province;"BC";13088
-"The Democratic Republic Of The Congo";CD;COD;54;"Kasai-Occidental";province;"KW";13092
-"The Democratic Republic Of The Congo";CD;COD;54;"Kasai-Oriental";province;"KE";13090
-"The Democratic Republic Of The Congo";CD;COD;54;"Katanga";province;"KA";13097
-"The Democratic Republic Of The Congo";CD;COD;54;"Kinshasa";city;"KN";13091
-"The Democratic Republic Of The Congo";CD;COD;54;"Maniema";province;"MA";13095
-"The Democratic Republic Of The Congo";CD;COD;54;"Nord-Kivu";province;"NK";13087
-"The Democratic Republic Of The Congo";CD;COD;54;"Orientale";province;"OR";13089
-"The Democratic Republic Of The Congo";CD;COD;54;"Sud-Kivu";province;"SK";13096
-"The Democratic Republic Of The Congo";CD;COD;54;"Équateur";province;"EQ";13093
-"Costa Rica";CR;CRI;56;"Alajuela";Province;"A";13119
-"Costa Rica";CR;CRI;56;"Cartago";Province;"C";13115
-"Costa Rica";CR;CRI;56;"Guanacaste";Province;"G";13116
-"Costa Rica";CR;CRI;56;"Heredia";Province;"H";13118
-"Costa Rica";CR;CRI;56;"Limón";Province;"L";13114
-"Costa Rica";CR;CRI;56;"Puntarenas";Province;"P";13113
-"Costa Rica";CR;CRI;56;"San José";Province;"SJ";13117
-"Croatia";HR;HRV;58;"Bjelovarsko-bilogorska županija";county;"07";13135
-"Croatia";HR;HRV;58;"Brodsko-posavska županija";county;"12";13130
-"Croatia";HR;HRV;58;"Dubrovacko-neretvanska županija";county;"19";13122
-"Croatia";HR;HRV;58;"Grad Zagreb";city;"21";13123
-"Croatia";HR;HRV;58;"Istarska županija";county;"18";13121
-"Croatia";HR;HRV;58;"Karlovacka županija";county;"04";13124
-"Croatia";HR;HRV;58;"Koprivnicko-križevacka županija";county;"06";13136
-"Croatia";HR;HRV;58;"Krapinsko-zagorska županija";county;"02";13125
-"Croatia";HR;HRV;58;"Licko-senjska županija";county;"09";13126
-"Croatia";HR;HRV;58;"Medimurska županija";county;"20";13140
-"Croatia";HR;HRV;58;"Osjecko-baranjska županija";county;"14";13127
-"Croatia";HR;HRV;58;"Požeško-slavonska županija";county;"11";13139
-"Croatia";HR;HRV;58;"Primorsko-goranska županija";county;"08";13128
-"Croatia";HR;HRV;58;"Sisacko-moslavacka županija";county;"03";13138
-"Croatia";HR;HRV;58;"Splitsko-dalmatinska županija";county;"17";13137
-"Croatia";HR;HRV;58;"Varaždinska županija";county;"05";13131
-"Croatia";HR;HRV;58;"Viroviticko-podravska županija";county;"10";13132
-"Croatia";HR;HRV;58;"Vukovarsko-srijemska županija";county;"16";13120
-"Croatia";HR;HRV;58;"Zadarska županija";county;"13";13133
-"Croatia";HR;HRV;58;"Zagrebacka županija";county;"01";13134
-"Croatia";HR;HRV;58;"Šibensko-kninska županija";county;"15";13129
-"Cuba";CU;CUB;59;"Camagüey";province;"09";13152
-"Cuba";CU;CUB;59;"Ciego de Ávila";province;"08";13153
-"Cuba";CU;CUB;59;"Cienfuegos";province;"06";13154
-"Cuba";CU;CUB;59;"Ciudad de La Habana";province;"03";13142
-"Cuba";CU;CUB;59;"Granma";province;"12";13155
-"Cuba";CU;CUB;59;"Guantánamo";province;"14";13157
-"Cuba";CU;CUB;59;"Holguín";province;"11";13156
-"Cuba";CU;CUB;59;"Isla de la Juventud";special municipality;"99";13143
-"Cuba";CU;CUB;59;"La Habana";province;"02";13159
-"Cuba";CU;CUB;59;"Las Tunas";province;"10";13144
-"Cuba";CU;CUB;59;"Matanzas";province;"04";13145
-"Cuba";CU;CUB;59;"Pinar del Río";province;"01";13160
-"Cuba";CU;CUB;59;"Sancti Spíritus";province;"07";13146
-"Cuba";CU;CUB;59;"Santiago de Cuba";province;"13";13158
-"Cuba";CU;CUB;59;"Villa Clara";province;"05";13147
-"Cyprus";CY;CYP;60;"Ammochostos";District;"04";20225
-"Cyprus";CY;CYP;60;"Keryneia";District;"06";19428
-"Cyprus";CY;CYP;60;"Larnaka";District;"03";19429
-"Cyprus";CY;CYP;60;"Lefkosia";District;"01";19430
-"Cyprus";CY;CYP;60;"Lemesos";District;"02";19431
-"Cyprus";CY;CYP;60;"Pafos";District;"05";19433
-"Czech Republic";CZ;CZE;61;"Benešov";district;"201 ";13247
-"Czech Republic";CZ;CZE;61;"Beroun";district;"202 ";13201
-"Czech Republic";CZ;CZE;61;"Blansko";district;"621 ";13231
-"Czech Republic";CZ;CZE;61;"Brno-město";district;"622 ";13192
-"Czech Republic";CZ;CZE;61;"Brno-venkov";district;"623 ";13233
-"Czech Republic";CZ;CZE;61;"Bruntál";district;"801 ";13180
-"Czech Republic";CZ;CZE;61;"Břeclav";district;"624 ";13232
-"Czech Republic";CZ;CZE;61;"Cheb";district;"411 ";13175
-"Czech Republic";CZ;CZE;61;"Chomutov";district;"422 ";13173
-"Czech Republic";CZ;CZE;61;"Chrudim";district;"531 ";13240
-"Czech Republic";CZ;CZE;61;"Domažlice";district;"321 ";13242
-"Czech Republic";CZ;CZE;61;"Děčín";district;"421 ";13164
-"Czech Republic";CZ;CZE;61;"Frýdek Místek";district;"802 ";13213
-"Czech Republic";CZ;CZE;61;"Havlíčkův Brod";district;"611 ";13204
-"Czech Republic";CZ;CZE;61;"Hodonín";district;"625 ";13174
-"Czech Republic";CZ;CZE;61;"Hradec Králové";district;"521 ";13237
-"Czech Republic";CZ;CZE;61;"Jablonec nad Nisou";district;"512 ";13179
-"Czech Republic";CZ;CZE;61;"Jeseník";district;"711 ";13216
-"Czech Republic";CZ;CZE;61;"Jihlava";district;"612 ";13205
-"Czech Republic";CZ;CZE;61;"Jihoceský kraj";Region;"JC";13219
-"Czech Republic";CZ;CZE;61;"Jihomoravský kraj";Region;"JM";13220
-"Czech Republic";CZ;CZE;61;"Jindřichův Hradec";district;"313 ";13228
-"Czech Republic";CZ;CZE;61;"Jičín";district;"522 ";13177
-"Czech Republic";CZ;CZE;61;"Karlovarský kraj";Region;"KA";13183
-"Czech Republic";CZ;CZE;61;"Karlovy Vary";district;"412 ";13236
-"Czech Republic";CZ;CZE;61;"Karviná";district;"803 ";13181
-"Czech Republic";CZ;CZE;61;"Kladno";district;"203 ";13200
-"Czech Republic";CZ;CZE;61;"Klatovy";district;"322 ";13243
-"Czech Republic";CZ;CZE;61;"Kolín";district;"204 ";13202
-"Czech Republic";CZ;CZE;61;"Kromĕříž";district;"721 ";13207
-"Czech Republic";CZ;CZE;61;"Královéhradecký kraj";Region;"KR";13221
-"Czech Republic";CZ;CZE;61;"Kutná Hora";district;"205 ";13165
-"Czech Republic";CZ;CZE;61;"Liberec";district;"513 ";13211
-"Czech Republic";CZ;CZE;61;"Liberecký kraj";Region;"LI";13184
-"Czech Republic";CZ;CZE;61;"Litoměřice";district;"423 ";13248
-"Czech Republic";CZ;CZE;61;"Louny";district;"424 ";13252
-"Czech Republic";CZ;CZE;61;"Mladá Boleslav";district;"207 ";13167
-"Czech Republic";CZ;CZE;61;"Moravskoslezský kraj";Region;"MO";13222
-"Czech Republic";CZ;CZE;61;"Most";district;"425 ";13251
-"Czech Republic";CZ;CZE;61;"Mělník";district;"206 ";13166
-"Czech Republic";CZ;CZE;61;"Nový Jičín";district;"804 ";13214
-"Czech Republic";CZ;CZE;61;"Nymburk";district;"208 ";13168
-"Czech Republic";CZ;CZE;61;"Náchod";district;"523 ";13238
-"Czech Republic";CZ;CZE;61;"Olomouc";district;"712 ";13193
-"Czech Republic";CZ;CZE;61;"Olomoucký kraj";Region;"OL";13185
-"Czech Republic";CZ;CZE;61;"Opava";district;"805 ";13182
-"Czech Republic";CZ;CZE;61;"Ostrava město";district;"806 ";13215
-"Czech Republic";CZ;CZE;61;"Pardubice";district;"532 ";13195
-"Czech Republic";CZ;CZE;61;"Pardubický kraj";Region;"PA";13223
-"Czech Republic";CZ;CZE;61;"Pelhřimov";district;"613 ";13253
-"Czech Republic";CZ;CZE;61;"Plzenský kraj";Region;"PL";13186
-"Czech Republic";CZ;CZE;61;"Plzeň jih";district;"324 ";13197
-"Czech Republic";CZ;CZE;61;"Plzeň město";district;"323 ";13244
-"Czech Republic";CZ;CZE;61;"Plzeň sever";district;"325 ";13198
-"Czech Republic";CZ;CZE;61;"Prachatice";district;"315 ";13190
-"Czech Republic";CZ;CZE;61;"Praha 1";district;"101";48300
-"Czech Republic";CZ;CZE;61;"Praha 10";district;"10A";48309
-"Czech Republic";CZ;CZE;61;"Praha 11";district;"10B";48310
-"Czech Republic";CZ;CZE;61;"Praha 12";district;"10C";48311
-"Czech Republic";CZ;CZE;61;"Praha 13";district;"10D";48312
-"Czech Republic";CZ;CZE;61;"Praha 14";district;"10E";48313
-"Czech Republic";CZ;CZE;61;"Praha 15";district;"10F";48314
-"Czech Republic";CZ;CZE;61;"Praha 2";district;"102";48301
-"Czech Republic";CZ;CZE;61;"Praha 3";district;"103";48302
-"Czech Republic";CZ;CZE;61;"Praha 4";district;"104";48303
-"Czech Republic";CZ;CZE;61;"Praha 5";district;"105";48304
-"Czech Republic";CZ;CZE;61;"Praha 6";district;"106";48305
-"Czech Republic";CZ;CZE;61;"Praha 7";district;"107";48306
-"Czech Republic";CZ;CZE;61;"Praha 8";district;"108";48307
-"Czech Republic";CZ;CZE;61;"Praha 9";district;"109";48308
-"Czech Republic";CZ;CZE;61;"Praha východ";district;"209 ";13170
-"Czech Republic";CZ;CZE;61;"Praha západ";district;"20A ";13171
-"Czech Republic";CZ;CZE;61;"hlavní mesto Praha";Region;"PR";13224
-"Czech Republic";CZ;CZE;61;"Prostĕjov";district;"713 ";13194
-"Czech Republic";CZ;CZE;61;"Písek";district;"314 ";13229
-"Czech Republic";CZ;CZE;61;"Přerov";district;"714 ";13217
-"Czech Republic";CZ;CZE;61;"Příbram";district;"20B ";13169
-"Czech Republic";CZ;CZE;61;"Rakovník";district;"20C ";13172
-"Czech Republic";CZ;CZE;61;"Rokycany";district;"326 ";13245
-"Czech Republic";CZ;CZE;61;"Rychnov nad Kněžnou";district;"524 ";13239
-"Czech Republic";CZ;CZE;61;"Semily";district;"514 ";13212
-"Czech Republic";CZ;CZE;61;"Sokolov";district;"413 ";13176
-"Czech Republic";CZ;CZE;61;"Strakonice";district;"316 ";13230
-"Czech Republic";CZ;CZE;61;"Stredoceský kraj";Region;"ST";13187
-"Czech Republic";CZ;CZE;61;"Svitavy";district;"533 ";13241
-"Czech Republic";CZ;CZE;61;"Tachov";district;"327 ";13246
-"Czech Republic";CZ;CZE;61;"Teplice";district;"426 ";13203
-"Czech Republic";CZ;CZE;61;"Trutnov";district;"525 ";13178
-"Czech Republic";CZ;CZE;61;"Tábor";district;"317 ";13191
-"Czech Republic";CZ;CZE;61;"Třebíč";district;"614 ";13206
-"Czech Republic";CZ;CZE;61;"Uherské Hradištĕ";district;"722 ";13208
-"Czech Republic";CZ;CZE;61;"Vsetín";district;"723 ";13163
-"Czech Republic";CZ;CZE;61;"Vysocina";Region;"VY";13188
-"Czech Republic";CZ;CZE;61;"Vyškov";district;"626 ";13234
-"Czech Republic";CZ;CZE;61;"Zlín";district;"724 ";13209
-"Czech Republic";CZ;CZE;61;"Zlínský kraj";Region;"ZL";13226
-"Czech Republic";CZ;CZE;61;"Znojmo";district;"627 ";13235
-"Czech Republic";CZ;CZE;61;"Ústecký kraj";Region;"US";13225
-"Czech Republic";CZ;CZE;61;"Ústí nad Labem";district;"427 ";13250
-"Czech Republic";CZ;CZE;61;"Ústí nad Orlicí";district;"534 ";13196
-"Czech Republic";CZ;CZE;61;"Česká Lípa";district;"511 ";13210
-"Czech Republic";CZ;CZE;61;"České Budějovice";district;"311 ";13227
-"Czech Republic";CZ;CZE;61;"Český Krumlov";district;"312 ";13189
-"Czech Republic";CZ;CZE;61;"Šumperk";district;"715 ";13218
-"Czech Republic";CZ;CZE;61;"Žd’ár nad Sázavou";district;"615 ";13249
-"Côte D'Ivoire";CI;CIV;57;"18 Montagnes (Région des)";Region;"06";18974
-"Côte D'Ivoire";CI;CIV;57;"Agnébi (Région de l')";Region;"16";18975
-"Côte D'Ivoire";CI;CIV;57;"Bafing (Région du)";Region;"17";18976
-"Côte D'Ivoire";CI;CIV;57;"Bas-Sassandra (Région du)";Region;"09";18977
-"Côte D'Ivoire";CI;CIV;57;"Denguélé (Région du)";Region;"10";18978
-"Côte D'Ivoire";CI;CIV;57;"Fromager (Région du)";Region;"18";18979
-"Côte D'Ivoire";CI;CIV;57;"Haut-Sassandra (Région du)";Region;"02";18980
-"Côte D'Ivoire";CI;CIV;57;"Lacs (Région des)";Region;"07";18981
-"Côte D'Ivoire";CI;CIV;57;"Lagunes (Région des)";Region;"01";18982
-"Côte D'Ivoire";CI;CIV;57;"Marahoué (Région de la)";Region;"12";18983
-"Côte D'Ivoire";CI;CIV;57;"Moyen-Cavally (Région du)";Region;"19";18984
-"Côte D'Ivoire";CI;CIV;57;"Moyen-Comoé (Région du)";Region;"05";18985
-"Côte D'Ivoire";CI;CIV;57;"Nzi-Comoé (Région)";Region;"11";18986
-"Côte D'Ivoire";CI;CIV;57;"Savanes (Région des)";Region;"03";18987
-"Côte D'Ivoire";CI;CIV;57;"Sud-Bandama (Région du)";Region;"15";18988
-"Côte D'Ivoire";CI;CIV;57;"Sud-Comoé (Région du)";Region;"13";18989
-"Côte D'Ivoire";CI;CIV;57;"Vallée du Bandama (Région de la)";Region;"04";18990
-"Côte D'Ivoire";CI;CIV;57;"Worodougou (Région du)";Region;"14";18991
-"Côte D'Ivoire";CI;CIV;57;"Zanzan (Région du)";Region;"08";18992
-"Denmark";DK;DNK;62;"Bornholm";county;"040";13256
-"Denmark";DK;DNK;62;"Capital";Region;"84";19434
-"Denmark";DK;DNK;62;"Central Jutland";Region;"82";19435
-"Denmark";DK;DNK;62;"Frederiksberg City";city;"147";13275
-"Denmark";DK;DNK;62;"Frederiksborg";county;"020";13257
-"Denmark";DK;DNK;62;"Fyn";county;"042";13265
-"Denmark";DK;DNK;62;"København";county;"015";13266
-"Denmark";DK;DNK;62;"København City";city;"101";13258
-"Denmark";DK;DNK;62;"Nordjylland";county;"080";13267
-"Denmark";DK;DNK;62;"North Jutland";Region;"81";19436
-"Denmark";DK;DNK;62;"Ribe";county;"055";13268
-"Denmark";DK;DNK;62;"Ringkøbing";county;"065";13259
-"Denmark";DK;DNK;62;"Roskilde";county;"025";13269
-"Denmark";DK;DNK;62;"South Denmark";Region;"83";19438
-"Denmark";DK;DNK;62;"Storstrøm";county;"035";13261
-"Denmark";DK;DNK;62;"Sønderjylland";county;"050";13260
-"Denmark";DK;DNK;62;"Vejle";county;"060";13262
-"Denmark";DK;DNK;62;"Vestsjælland";county;"030";13263
-"Denmark";DK;DNK;62;"Viborg";county;"076";13264
-"Denmark";DK;DNK;62;"Zeeland";Region;"85";19437
-"Denmark";DK;DNK;62;"Århus";county;"070";13274
-"Djibouti";DJ;DJI;63;"Ali Sabieh";Region;"AS";13283
-"Djibouti";DJ;DJI;63;"Arta";Region;"AR";19439
-"Djibouti";DJ;DJI;63;"Dikhil";Region;"DI";13282
-"Djibouti";DJ;DJI;63;"Djibouti";City;"DJ";13280
-"Djibouti";DJ;DJI;63;"Obock";Region;"OB";13281
-"Djibouti";DJ;DJI;63;"Tadjourah";Region;"TA";13284
-"Dominica";DM;DMA;64;"Saint Andrew";Parish;"02";13286
-"Dominica";DM;DMA;64;"Saint David";Parish;"03";13289
-"Dominica";DM;DMA;64;"Saint George";Parish;"04";13293
-"Dominica";DM;DMA;64;"Saint John";Parish;"05";13292
-"Dominica";DM;DMA;64;"Saint Joseph";Parish;"06";13291
-"Dominica";DM;DMA;64;"Saint Luke";Parish;"07";13294
-"Dominica";DM;DMA;64;"Saint Mark";Parish;"08";13290
-"Dominica";DM;DMA;64;"Saint Patrick";Parish;"09";13285
-"Dominica";DM;DMA;64;"Saint Paul";Parish;"10";13287
-"Dominica";DM;DMA;64;"Saint Peter";Parish;"11";13288
-"Dominican Republic";DO;DOM;65;"Azua";province;"02";13506
-"Dominican Republic";DO;DOM;65;"Bahoruco";province;"03";13489
-"Dominican Republic";DO;DOM;65;"Barahona";province;"04";13477
-"Dominican Republic";DO;DOM;65;"Dajabón";province;"05";13490
-"Dominican Republic";DO;DOM;65;"Distrito Nacional (Santo Domingo)";province;"01";13520
-"Dominican Republic";DO;DOM;65;"Duarte";province;"06";13491
-"Dominican Republic";DO;DOM;65;"El Seybo [El Seibo]";province;"08";13492
-"Dominican Republic";DO;DOM;65;"Espaillat";province;"09";13493
-"Dominican Republic";DO;DOM;65;"Hato Mayor";province;"30";13510
-"Dominican Republic";DO;DOM;65;"Independencia";province;"10";13494
-"Dominican Republic";DO;DOM;65;"La Altagracia";province;"11";13511
-"Dominican Republic";DO;DOM;65;"La Estrelleta [Elías Piña]";province;"07";13509
-"Dominican Republic";DO;DOM;65;"La Romana";province;"12";13487
-"Dominican Republic";DO;DOM;65;"La Vega";province;"13";13512
-"Dominican Republic";DO;DOM;65;"María Trinidad Sánchez";province;"14";13496
-"Dominican Republic";DO;DOM;65;"Monseñor Nouel";province;"28";13513
-"Dominican Republic";DO;DOM;65;"Monte Cristi";province;"15";13497
-"Dominican Republic";DO;DOM;65;"Monte Plata";province;"29";13514
-"Dominican Republic";DO;DOM;65;"Pedernales";province;"16";13498
-"Dominican Republic";DO;DOM;65;"Peravia";province;"17";13499
-"Dominican Republic";DO;DOM;65;"Puerto Plata";province;"18";13515
-"Dominican Republic";DO;DOM;65;"Salcedo";province;"19";13500
-"Dominican Republic";DO;DOM;65;"Samaná";province;"20";13516
-"Dominican Republic";DO;DOM;65;"San Cristóbal";province;"21";13517
-"Dominican Republic";DO;DOM;65;"San Jose de Ocoa";province;"31";13502
-"Dominican Republic";DO;DOM;65;"San Juan";province;"22";13518
-"Dominican Republic";DO;DOM;65;"San Pedro de Macorís";province;"23";13503
-"Dominican Republic";DO;DOM;65;"Santiago";province;"25";13519
-"Dominican Republic";DO;DOM;65;"Santiago Rodríguez";province;"26";13504
-"Dominican Republic";DO;DOM;65;"Santo Domingo";;"32";13508
-"Dominican Republic";DO;DOM;65;"Sánchez Ramírez";province;"24";13501
-"Dominican Republic";DO;DOM;65;"Valverde";province;"27";13505
-"Ecuador";EC;ECU;66;"Azuay";Province;"A";13570
-"Ecuador";EC;ECU;66;"Bolívar";Province;"B";13571
-"Ecuador";EC;ECU;66;"Carchi";Province;"C";13572
-"Ecuador";EC;ECU;66;"Cañar";Province;"F";13578
-"Ecuador";EC;ECU;66;"Chimborazo";Province;"H";13579
-"Ecuador";EC;ECU;66;"Cotopaxi";Province;"X";13573
-"Ecuador";EC;ECU;66;"El Oro";Province;"O";13574
-"Ecuador";EC;ECU;66;"Esmeraldas";Province;"E";13580
-"Ecuador";EC;ECU;66;"Galápagos";Province;"W";13575
-"Ecuador";EC;ECU;66;"Guayas";Province;"G";13576
-"Ecuador";EC;ECU;66;"Imbabura";Province;"I";13581
-"Ecuador";EC;ECU;66;"Loja";Province;"L";13577
-"Ecuador";EC;ECU;66;"Los Ríos";Province;"R";13582
-"Ecuador";EC;ECU;66;"Manabí";Province;"M";13583
-"Ecuador";EC;ECU;66;"Morona-Santiago";Province;"S";13584
-"Ecuador";EC;ECU;66;"Napo";Province;"N";13569
-"Ecuador";EC;ECU;66;"Orellana";Province;"D";13585
-"Ecuador";EC;ECU;66;"Pastaza";Province;"Y";13568
-"Ecuador";EC;ECU;66;"Pichincha";Province;"P";13586
-"Ecuador";EC;ECU;66;"Santa Elena";Province;"X1~";48131
-"Ecuador";EC;ECU;66;"Santa Elena";Province;"SE";21342
-"Ecuador";EC;ECU;66;"Santo Domingo de los Tsachilas";Province;"SD";21343
-"Ecuador";EC;ECU;66;"Santo Domingo de los Tsachilas";Province;"X2~";48132
-"Ecuador";EC;ECU;66;"Sucumbíos";Province;"U";13567
-"Ecuador";EC;ECU;66;"Tungurahua";Province;"T";13587
-"Ecuador";EC;ECU;66;"Zamora-Chinchipe";Province;"Z";13566
-"Egypt";EG;EGY;67;"Ad Daqahliyah";Governorate;"DK";13607
-"Egypt";EG;EGY;67;"Al Bahr al Ahmar";Governorate;"BA";13605
-"Egypt";EG;EGY;67;"Al Buhayrah";Governorate;"BH";13606
-"Egypt";EG;EGY;67;"Al Fayyum";Governorate;"FYM";13608
-"Egypt";EG;EGY;67;"Al Gharbiyah";Governorate;"GH";13609
-"Egypt";EG;EGY;67;"Al Iskandariyah";Governorate;"ALX";13595
-"Egypt";EG;EGY;67;"Al Ismā`īlīyah";Governorate;"IS";13610
-"Egypt";EG;EGY;67;"Al Jizah";Governorate;"GZ";13596
-"Egypt";EG;EGY;67;"Al Minufiyah";Governorate;"MNF";13612
-"Egypt";EG;EGY;67;"Al Minya";Governorate;"MN";13591
-"Egypt";EG;EGY;67;"Al Qahirah";Governorate;"C";13598
-"Egypt";EG;EGY;67;"Al Qalyubiyah";Governorate;"KB";13613
-"Egypt";EG;EGY;67;"Al Wadi al Jadid";Governorate;"WAD";13588
-"Egypt";EG;EGY;67;"al-Uqsur";Governorate;"LX";13589
-"Egypt";EG;EGY;67;"As Suways";Governorate;"SUZ";13601
-"Egypt";EG;EGY;67;"As Sādis min Uktūbar";governorate;"SU";48194
-"Egypt";EG;EGY;67;"Ash Sharqiyah";Governorate;"SHR";13600
-"Egypt";EG;EGY;67;"Aswan";Governorate;"ASN";13602
-"Egypt";EG;EGY;67;"Asyut";Governorate;"AST";13604
-"Egypt";EG;EGY;67;"Bani Suwayf";Governorate;"BNS";13603
-"Egypt";EG;EGY;67;"Būr Sa`īd";Governorate;"PTS";13593
-"Egypt";EG;EGY;67;"Dumyat";Governorate;"DT";13594
-"Egypt";EG;EGY;67;"Ḩulwān";governorate;"HU";48195
-"Egypt";EG;EGY;67;"Janub Sina'";Governorate;"JS";13611
-"Egypt";EG;EGY;67;"Kafr ash Shaykh";Governorate;"KFS";13592
-"Egypt";EG;EGY;67;"Matrūh";Governorate;"MT";13597
-"Egypt";EG;EGY;67;"Qina";Governorate;"KN";13599
-"Egypt";EG;EGY;67;"Shamal Sina'";Governorate;"SIN";13590
-"Egypt";EG;EGY;67;"Suhaj";Governorate;"SHG";13614
-"El Salvador";SV;SLV;68;"Ahuachapán";Department;"AH";13619
-"El Salvador";SV;SLV;68;"Cabañas";Department;"CA";13620
-"El Salvador";SV;SLV;68;"Chalatenango";Department;"CH";13618
-"El Salvador";SV;SLV;68;"Cuscatlán";Department;"CU";13621
-"El Salvador";SV;SLV;68;"La Libertad";Department;"LI";13627
-"El Salvador";SV;SLV;68;"La Paz";Department;"PA";13622
-"El Salvador";SV;SLV;68;"La Unión";Department;"UN";13623
-"El Salvador";SV;SLV;68;"Morazán";Department;"MO";13617
-"El Salvador";SV;SLV;68;"San Miguel";Department;"SM";13624
-"El Salvador";SV;SLV;68;"San Salvador";Department;"SS";13628
-"El Salvador";SV;SLV;68;"San Vicente";Department;"SV";13616
-"El Salvador";SV;SLV;68;"Santa Ana";Department;"SA";13625
-"El Salvador";SV;SLV;68;"Sonsonate";Department;"SO";13626
-"El Salvador";SV;SLV;68;"Usulután";Department;"US";13615
-"Equatorial Guinea";GQ;GNQ;69;"Annobón";province;"AN";13635
-"Equatorial Guinea";GQ;GNQ;69;"Bioko Norte";province;"BN";13632
-"Equatorial Guinea";GQ;GNQ;69;"Bioko Sur";province;"BS";13634
-"Equatorial Guinea";GQ;GNQ;69;"Centro Sur";province;"CS";13633
-"Equatorial Guinea";GQ;GNQ;69;"Kie-Ntem";province;"KN";13630
-"Equatorial Guinea";GQ;GNQ;69;"Litoral";province;"LI";13631
-"Equatorial Guinea";GQ;GNQ;69;"Región Continental";region;"C";19440
-"Equatorial Guinea";GQ;GNQ;69;"Región Insular";region;"I";19441
-"Equatorial Guinea";GQ;GNQ;69;"Wele-Nzás";province;"WN";13629
-"Eritrea";ER;ERI;70;"Anseba";Region;"AN";13638
-"Eritrea";ER;ERI;70;"Debub";Region;"DU";13641
-"Eritrea";ER;ERI;70;"Debubawi K’eyyĭḥ Baḥri";Region;"DK";13639
-"Eritrea";ER;ERI;70;"Gash-Barka";Region;"GB";13637
-"Eritrea";ER;ERI;70;"Ma’ĭkel";Region;"MA";13640
-"Eritrea";ER;ERI;70;"Semienawi K’eyyĭḥ Baḥri";Region;"SK";13636
-"Estonia";EE;EST;71;"Harjumaa";County;"37";13653
-"Estonia";EE;EST;71;"Hiiumaa";County;"39";13654
-"Estonia";EE;EST;71;"Ida-Virumaa";County;"44";13646
-"Estonia";EE;EST;71;"Järvamaa";County;"51";13652
-"Estonia";EE;EST;71;"Jõgevamaa";County;"49";13647
-"Estonia";EE;EST;71;"Lääne-Virumaa";County;"59";13655
-"Estonia";EE;EST;71;"Läänemaa";County;"57";13648
-"Estonia";EE;EST;71;"Pärnumaa";County;"67";13649
-"Estonia";EE;EST;71;"Põlvamaa";County;"65";13650
-"Estonia";EE;EST;71;"Raplamaa";County;"70";13643
-"Estonia";EE;EST;71;"Saaremaa";County;"74";13645
-"Estonia";EE;EST;71;"Tartumaa";County;"78";13656
-"Estonia";EE;EST;71;"Valgamaa";County;"82";13651
-"Estonia";EE;EST;71;"Viljandimaa";County;"84";13644
-"Estonia";EE;EST;71;"Võrumaa";County;"86";13642
-"Ethiopia";ET;ETH;73;"Adis Abeba";administration;"AA";13661
-"Ethiopia";ET;ETH;73;"Afar";state;"AF";13662
-"Ethiopia";ET;ETH;73;"Amara";state;"AM";13658
-"Ethiopia";ET;ETH;73;"Binshangul Gumuz";state;"BE";13663
-"Ethiopia";ET;ETH;73;"Dire Dawa";administration;"DD";13667
-"Ethiopia";ET;ETH;73;"Gambela Hizboch";state;"GA";13666
-"Ethiopia";ET;ETH;73;"Hareri Hizb";state;"HA";13665
-"Ethiopia";ET;ETH;73;"Oromiya";state;"OR";13668
-"Ethiopia";ET;ETH;73;"Sumale";state;"SO";13664
-"Ethiopia";ET;ETH;73;"Tigray";state;"TI";13659
-"Ethiopia";ET;ETH;73;"YeDebub Biheroch Bihereseboch na Hizboch";state;"SN";13657
-"Fiji";FJ;FJI;76;"Central";division;"C";13683
-"Fiji";FJ;FJI;76;"Eastern";division;"E";13682
-"Fiji";FJ;FJI;76;"Northern";division;"N";13684
-"Fiji";FJ;FJI;76;"Rotuma";dependency;"R";18998
-"Fiji";FJ;FJI;76;"Western";division;"W";13681
-"Finland";FI;FIN;77;"Ahvenanmaan lääni";;"AL";13703
-"Finland";FI;FIN;77;"Ahvenanmaan maakunta";region;"01";48686
-"Finland";FI;FIN;77;"Etelä-Karjala";region;"02";48687
-"Finland";FI;FIN;77;"Etelä-Pohjanmaa";region;"03";48688
-"Finland";FI;FIN;77;"Etelä-Savo";region;"04";48689
-"Finland";FI;FIN;77;"Etelä-Suomen lääni";;"ES";20230
-"Finland";FI;FIN;77;"Itä-Suomen lääni";;"IS";13706
-"Finland";FI;FIN;77;"Kainuu";region;"05";48690
-"Finland";FI;FIN;77;"Kanta-Häme";region;"06";48691
-"Finland";FI;FIN;77;"Keski-Pohjanmaa";region;"07";48692
-"Finland";FI;FIN;77;"Keski-Suomi";region;"08";48693
-"Finland";FI;FIN;77;"Kymenlaakso";region;"09";48694
-"Finland";FI;FIN;77;"Lapin lääni";;"LL";13690
-"Finland";FI;FIN;77;"Lappi";region;"10";48695
-"Finland";FI;FIN;77;"Länsi-Suomen lääni";;"LS";20233
-"Finland";FI;FIN;77;"Oulun lääni";;"OL";20234
-"Finland";FI;FIN;77;"Pirkanmaa";region;"11";48696
-"Finland";FI;FIN;77;"Pohjanmaa";region;"12";48697
-"Finland";FI;FIN;77;"Pohjois-Karjala";region;"13";48698
-"Finland";FI;FIN;77;"Pohjois-Pohjanmaa";region;"14";48699
-"Finland";FI;FIN;77;"Pohjois-Savo";region;"15";48700
-"Finland";FI;FIN;77;"Päijät-Häme";region;"16";48701
-"Finland";FI;FIN;77;"Satakunta";region;"17";48702
-"Finland";FI;FIN;77;"Uusimaa";region;"18";48703
-"Finland";FI;FIN;77;"Varsinais-Suomi";region;"19";48704
-"France";FR;FRA;78;"Ain";metropolitan department;"01";13736
-"France";FR;FRA;78;"Aisne";metropolitan department;"02";13737
-"France";FR;FRA;78;"Allier";metropolitan department;"03";13717
-"France";FR;FRA;78;"Alpes-de-Haute-Provence";metropolitan department;"04";13738
-"France";FR;FRA;78;"Alpes-Maritimes";metropolitan department;"06";13718
-"France";FR;FRA;78;"Alsace";Metropolitan regions;"A ";48315
-"France";FR;FRA;78;"Aquitaine";Metropolitan regions;"B ";48316
-"France";FR;FRA;78;"Ardennes";metropolitan department;"08";13719
-"France";FR;FRA;78;"Ardèche";metropolitan department;"07";13739
-"France";FR;FRA;78;"Ariège";metropolitan department;"09";13740
-"France";FR;FRA;78;"Aube";metropolitan department;"10";13741
-"France";FR;FRA;78;"Aude";metropolitan department;"11";13720
-"France";FR;FRA;78;"Auvergne";Metropolitan regions;"C ";48317
-"France";FR;FRA;78;"Aveyron";metropolitan department;"12";13742
-"France";FR;FRA;78;"Bas-Rhin";metropolitan department;"67";13721
-"France";FR;FRA;78;"Basse-Normandie";Metropolitan regions;"P ";48318
-"France";FR;FRA;78;"Bouches-du-Rhône";metropolitan department;"13";13743
-"France";FR;FRA;78;"Bourgogne";Metropolitan regions;"D ";48319
-"France";FR;FRA;78;"Bretagne";Metropolitan regions;"E ";48320
-"France";FR;FRA;78;"Calvados";metropolitan department;"14";13722
-"France";FR;FRA;78;"Cantal";metropolitan department;"15";13744
-"France";FR;FRA;78;"Centre";Metropolitan regions;"F ";48321
-"France";FR;FRA;78;"Champagne-Ardenne";Metropolitan regions;"G ";48322
-"France";FR;FRA;78;"Charente";metropolitan department;"16";13723
-"France";FR;FRA;78;"Charente-Maritime";metropolitan department;"17";13745
-"France";FR;FRA;78;"Cher";metropolitan department;"18";13746
-"France";FR;FRA;78;"Clipperton";Dependency;"CP";21344
-"France";FR;FRA;78;"Corrèze";metropolitan department;"19";13791
-"France";FR;FRA;78;"Corse";Metropolitan regions;"H ";48323
-"France";FR;FRA;78;"Corse-du-Sud";metropolitan department;"2A";13747
-"France";FR;FRA;78;"Creuse";metropolitan department;"23";13794
-"France";FR;FRA;78;"Côte-d'Or";metropolitan department;"21";13792
-"France";FR;FRA;78;"Côtes-d'Armor";metropolitan department;"22";13793
-"France";FR;FRA;78;"Deux-Sèvres";metropolitan department;"79";13795
-"France";FR;FRA;78;"Dordogne";metropolitan department;"24";13796
-"France";FR;FRA;78;"Doubs";metropolitan department;"25";13797
-"France";FR;FRA;78;"Drôme";metropolitan department;"26";13816
-"France";FR;FRA;78;"Essonne";metropolitan department;"91";13817
-"France";FR;FRA;78;"Eure";metropolitan department;"27";13818
-"France";FR;FRA;78;"Eure-et-Loir";metropolitan department;"28";13819
-"France";FR;FRA;78;"Finistère";metropolitan department;"29";13820
-"France";FR;FRA;78;"Franche-Comté";Metropolitan regions;"I ";48324
-"France";FR;FRA;78;"Gard";metropolitan department;"30";13821
-"France";FR;FRA;78;"Gers";metropolitan department;"32";13822
-"France";FR;FRA;78;"Gironde";metropolitan department;"33";13823
-"France";FR;FRA;78;"Guadeloupe (see also separate entry under GP)";overseas regions;"GP ";48337
-"France";FR;FRA;78;"Guyane (française) (see also separate entry under GF)";overseas regions;"GF ";48338
-"France";FR;FRA;78;"Haut-Rhin";metropolitan department;"68";13753
-"France";FR;FRA;78;"Haute-Corse";metropolitan department;"2B";13748
-"France";FR;FRA;78;"Haute-Garonne";metropolitan department;"31";13824
-"France";FR;FRA;78;"Haute-Loire";metropolitan department;"43";13749
-"France";FR;FRA;78;"Haute-Marne";metropolitan department;"52";13807
-"France";FR;FRA;78;"Haute-Normandie";Metropolitan regions;"Q ";48325
-"France";FR;FRA;78;"Haute-Savoie";metropolitan department;"74";13751
-"France";FR;FRA;78;"Haute-Saône";metropolitan department;"70";13808
-"France";FR;FRA;78;"Haute-Vienne";metropolitan department;"87";13809
-"France";FR;FRA;78;"Hautes-Alpes";metropolitan department;"05";13750
-"France";FR;FRA;78;"Hautes-Pyrénées";metropolitan department;"65";13752
-"France";FR;FRA;78;"Hauts-de-Seine";metropolitan department;"92";13810
-"France";FR;FRA;78;"Hérault";metropolitan department;"34";13754
-"France";FR;FRA;78;"Ille-et-Vilaine";metropolitan department;"35";13811
-"France";FR;FRA;78;"Indre";metropolitan department;"36";13755
-"France";FR;FRA;78;"Indre-et-Loire";metropolitan department;"37";13756
-"France";FR;FRA;78;"Isère";metropolitan department;"38";13812
-"France";FR;FRA;78;"Jura";metropolitan department;"39";13757
-"France";FR;FRA;78;"La Réunion (see also separate entry under RE)";overseas regions;"RE ";48340
-"France";FR;FRA;78;"Landes";metropolitan department;"40";13813
-"France";FR;FRA;78;"Languedoc-Roussillon";Metropolitan regions;"K ";48327
-"France";FR;FRA;78;"Limousin";Metropolitan regions;"L ";48328
-"France";FR;FRA;78;"Loir-et-Cher";metropolitan department;"41";13760
-"France";FR;FRA;78;"Loire";metropolitan department;"42";13758
-"France";FR;FRA;78;"Loire-Atlantique";metropolitan department;"44";13814
-"France";FR;FRA;78;"Loiret";metropolitan department;"45";13759
-"France";FR;FRA;78;"Lorraine";Metropolitan regions;"M ";48329
-"France";FR;FRA;78;"Lot";metropolitan department;"46";13815
-"France";FR;FRA;78;"Lot-et-Garonne";metropolitan department;"47";13761
-"France";FR;FRA;78;"Lozère";metropolitan department;"48";13798
-"France";FR;FRA;78;"Maine-et-Loire";metropolitan department;"49";13762
-"France";FR;FRA;78;"Manche";metropolitan department;"50";13799
-"France";FR;FRA;78;"Marne";metropolitan department;"51";13763
-"France";FR;FRA;78;"Martinique (see also separate entry under MQ)";overseas regions;"MQ ";48339
-"France";FR;FRA;78;"Mayenne";metropolitan department;"53";13764
-"France";FR;FRA;78;"Mayotte (see also separate entry under YT)";territorial collectivity;"YT";18999
-"France";FR;FRA;78;"Meurthe-et-Moselle";metropolitan department;"54";13800
-"France";FR;FRA;78;"Meuse";metropolitan department;"55";13765
-"France";FR;FRA;78;"Midi-Pyrénées";Metropolitan regions;"N ";48330
-"France";FR;FRA;78;"Morbihan";metropolitan department;"56";13801
-"France";FR;FRA;78;"Moselle";metropolitan department;"57";13766
-"France";FR;FRA;78;"Nièvre";metropolitan department;"58";13802
-"France";FR;FRA;78;"Nord";metropolitan department;"59";13767
-"France";FR;FRA;78;"Nord-Pas-de-Calais";Metropolitan regions;"O ";48331
-"France";FR;FRA;78;"Nouvelle-Calédonie (see also separate entry under NC)";overseas territory;"NC";19000
-"France";FR;FRA;78;"Oise";metropolitan department;"60";13768
-"France";FR;FRA;78;"Orne";metropolitan department;"61";13803
-"France";FR;FRA;78;"Paris";metropolitan department;"75";13769
-"France";FR;FRA;78;"Pas-de-Calais";metropolitan department;"62";13804
-"France";FR;FRA;78;"Pays-de-la-Loire";Metropolitan regions;"R ";48332
-"France";FR;FRA;78;"Picardie";Metropolitan regions;"S ";48333
-"France";FR;FRA;78;"Poitou-Charentes";Metropolitan regions;"T ";48334
-"France";FR;FRA;78;"Polynésie française (see also separate entry under PF)";overseas territory;"PF";19001
-"France";FR;FRA;78;"Provence-Alpes-Côte-d'Azur";Metropolitan regions;"U ";48335
-"France";FR;FRA;78;"Puy-de-Dôme";metropolitan department;"63";13770
-"France";FR;FRA;78;"Pyrénées-Atlantiques";metropolitan department;"64";13805
-"France";FR;FRA;78;"Pyrénées-Orientales";metropolitan department;"66";13771
-"France";FR;FRA;78;"Rhône";metropolitan department;"69";13772
-"France";FR;FRA;78;"Rhône-Alpes";Metropolitan regions;"V ";48336
-"France";FR;FRA;78;"Saint-Barthélemy (see also separate entry under BL)";Overseas territorial collectivity;"BL";21345
-"France";FR;FRA;78;"Saint-Martin (see also separate entry under MF)";Overseas territorial collectivity;"MF";21346
-"France";FR;FRA;78;"Saint-Pierre-et-Miquelon (see also separate entry under PM)";territorial collectivity;"PM";19002
-"France";FR;FRA;78;"Sarthe";metropolitan department;"72";13773
-"France";FR;FRA;78;"Savoie";metropolitan department;"73";13714
-"France";FR;FRA;78;"Saône-et-Loire";metropolitan department;"71";13806
-"France";FR;FRA;78;"Seine-et-Marne";metropolitan department;"77";13774
-"France";FR;FRA;78;"Seine-Maritime";metropolitan department;"76";13710
-"France";FR;FRA;78;"Seine-Saint-Denis";metropolitan department;"93";13775
-"France";FR;FRA;78;"Somme";metropolitan department;"80";13711
-"France";FR;FRA;78;"Tarn";metropolitan department;"81";13776
-"France";FR;FRA;78;"Tarn-et-Garonne";metropolitan department;"82";13712
-"France";FR;FRA;78;"Terres Australes Françaises (see also separate entry under TF)";overseas territory;"TF";19003
-"France";FR;FRA;78;"Territoire de Belfort";metropolitan department;"90";13777
-"France";FR;FRA;78;"Val-d'Oise";metropolitan department;"95";13709
-"France";FR;FRA;78;"Val-de-Marne";metropolitan department;"94";13778
-"France";FR;FRA;78;"Var";metropolitan department;"83";13779
-"France";FR;FRA;78;"Vaucluse";metropolitan department;"84";13713
-"France";FR;FRA;78;"Vendée";metropolitan department;"85";13780
-"France";FR;FRA;78;"Vienne";metropolitan department;"86";13781
-"France";FR;FRA;78;"Vosges";metropolitan department;"88";13708
-"France";FR;FRA;78;"Wallis et Futuna (see also separate entry under WF)";overseas territory;"WF";19004
-"France";FR;FRA;78;"Yonne";metropolitan department;"89";13782
-"France";FR;FRA;78;"Yvelines";metropolitan department;"78";13707
-"France";FR;FRA;78;"Île-de-France";Metropolitan regions;"J ";48326
-"French Southern Territories";TF;ATF;82;"Crozet Islands";district;"X2~";13836
-"French Southern Territories";TF;ATF;82;"Ile Saint-Paul et Ile Amsterdam";district;"X1~";13834
-"French Southern Territories";TF;ATF;82;"Iles Eparses";district;"X4~";21356
-"French Southern Territories";TF;ATF;82;"Kerguelen";district;"X3~";13837
-"Gabon";GA;GAB;83;"Estuaire";Province;"1";13839
-"Gabon";GA;GAB;83;"Haut-Ogooué";Province;"2";13845
-"Gabon";GA;GAB;83;"Moyen-Ogooué";Province;"3";13841
-"Gabon";GA;GAB;83;"Ngounié";Province;"4";13844
-"Gabon";GA;GAB;83;"Nyanga";Province;"5";13846
-"Gabon";GA;GAB;83;"Ogooué-Ivindo";Province;"6";13842
-"Gabon";GA;GAB;83;"Ogooué-Lolo";Province;"7";13843
-"Gabon";GA;GAB;83;"Ogooué-Maritime";Province;"8";13840
-"Gabon";GA;GAB;83;"Woleu-Ntem";Province;"9";13838
-"Gambia";GM;GMB;84;"Banjul";city;"B";13880
-"Gambia";GM;GMB;84;"Lower River";division;"L";13887
-"Gambia";GM;GMB;84;"MacCarthy Island";division;"M";13877
-"Gambia";GM;GMB;84;"North Bank";division;"N";13885
-"Gambia";GM;GMB;84;"Upper River";division;"U";13881
-"Gambia";GM;GMB;84;"Western";division;"W";13882
-"Georgia";GE;GEO;1;"Abkhazia";autonomous republic;"AB";13902
-"Georgia";GE;GEO;1;"Ajaria";autonomous republic;"AJ";13896
-"Georgia";GE;GEO;1;"Guria";region;"GU";13897
-"Georgia";GE;GEO;1;"Imereti";region;"IM";13901
-"Georgia";GE;GEO;1;"Kakheti";region;"KA";13898
-"Georgia";GE;GEO;1;"Kvemo Kartli";region;"KK";13900
-"Georgia";GE;GEO;1;"Mtskheta-Mtianeti";region;"MM";13905
-"Georgia";GE;GEO;1;"Racha-Lechkhumi [and] Kvemo Svaneti";region;"RL";13899
-"Georgia";GE;GEO;1;"Samegrelo-Zemo Svaneti";region;"SZ";13906
-"Georgia";GE;GEO;1;"Samtskhe-Javakheti";region;"SJ";13903
-"Georgia";GE;GEO;1;"Shida Kartli";region;"SK";13904
-"Georgia";GE;GEO;1;"Tbilisi";city;"TB";13895
-"Germany";DE;DEU;85;"Baden-Württemberg";State;"BW";14337
-"Germany";DE;DEU;85;"Bayern";State;"BY";14044
-"Germany";DE;DEU;85;"Berlin";State;"BE";14338
-"Germany";DE;DEU;85;"Brandenburg";State;"BB";14045
-"Germany";DE;DEU;85;"Bremen";State;"HB";14339
-"Germany";DE;DEU;85;"Hamburg";State;"HH";14046
-"Germany";DE;DEU;85;"Hessen";State;"HE";14340
-"Germany";DE;DEU;85;"Mecklenburg-Vorpommern";State;"MV";14047
-"Germany";DE;DEU;85;"Niedersachsen";State;"NI";14341
-"Germany";DE;DEU;85;"Nordrhein-Westfalen";State;"NW";14048
-"Germany";DE;DEU;85;"Rheinland-Pfalz";State;"RP";14342
-"Germany";DE;DEU;85;"Saarland";State;"SL";14049
-"Germany";DE;DEU;85;"Sachsen";State;"SN";14343
-"Germany";DE;DEU;85;"Sachsen-Anhalt";State;"ST";14050
-"Germany";DE;DEU;85;"Schleswig-Holstein";State;"SH";14344
-"Germany";DE;DEU;85;"Thüringen";State;"TH";14051
-"Ghana";GH;GHA;86;"Ashanti";Region;"AH";14403
-"Ghana";GH;GHA;86;"Brong-Ahafo";Region;"BA";14400
-"Ghana";GH;GHA;86;"Central";Region;"CP";14404
-"Ghana";GH;GHA;86;"Eastern";Region;"EP";14405
-"Ghana";GH;GHA;86;"Greater Accra";Region;"AA";14399
-"Ghana";GH;GHA;86;"Northern";Region;"NP";14402
-"Ghana";GH;GHA;86;"Upper East";Region;"UE";14406
-"Ghana";GH;GHA;86;"Upper West";Region;"UW";14397
-"Ghana";GH;GHA;86;"Volta";Region;"TV";14401
-"Ghana";GH;GHA;86;"Western";Region;"WP";14398
-"Greece";GR;GRC;88;"Achaïa";department;"13";14414
-"Greece";GR;GRC;88;"Agio Oros";self-governed part;"69";14417
-"Greece";GR;GRC;88;"Aitolia kai Akarnania";department;"01";14423
-"Greece";GR;GRC;88;"Anatoliki Makedonia kai Thraki";administrative regions;"A";48444
-"Greece";GR;GRC;88;"Argolida";department;"11";14415
-"Greece";GR;GRC;88;"Arkadia";department;"12";14424
-"Greece";GR;GRC;88;"Arta";department;"31";14425
-"Greece";GR;GRC;88;"Attiki";administrative regions;"I";48445
-"Greece";GR;GRC;88;"Attiki";department;"A1";14416
-"Greece";GR;GRC;88;"Chalkidiki";department;"64";14421
-"Greece";GR;GRC;88;"Chania";department;"94";14432
-"Greece";GR;GRC;88;"Chios";department;"85";14422
-"Greece";GR;GRC;88;"Dodekanisos";department;"81";14426
-"Greece";GR;GRC;88;"Drama";department;"52";14427
-"Greece";GR;GRC;88;"Dytiki Ellada";administrative regions;"G";48446
-"Greece";GR;GRC;88;"Dytiki Makedonia";administrative regions;"C";48447
-"Greece";GR;GRC;88;"Evros";department;"71";14428
-"Greece";GR;GRC;88;"Evrytania";department;"05";14418
-"Greece";GR;GRC;88;"Evvoia";department;"04";14419
-"Greece";GR;GRC;88;"Florina";department;"63";14429
-"Greece";GR;GRC;88;"Fokida";department;"07";14430
-"Greece";GR;GRC;88;"Fthiotida";department;"06";14420
-"Greece";GR;GRC;88;"Grevena";department;"51";14431
-"Greece";GR;GRC;88;"Ileia";department;"14";14433
-"Greece";GR;GRC;88;"Imathia";department;"53";14450
-"Greece";GR;GRC;88;"Ioannina";department;"33";14451
-"Greece";GR;GRC;88;"Ionia Nisia";administrative regions;"F";48448
-"Greece";GR;GRC;88;"Ipeiros";administrative regions;"D";48449
-"Greece";GR;GRC;88;"Irakleio";department;"91";14434
-"Greece";GR;GRC;88;"Karditsa";department;"41";14435
-"Greece";GR;GRC;88;"Kastoria";department;"56";14452
-"Greece";GR;GRC;88;"Kavala";department;"55";14436
-"Greece";GR;GRC;88;"Kefallonia";department;"23";14453
-"Greece";GR;GRC;88;"Kentriki Makedonia";administrative regions;"B";48450
-"Greece";GR;GRC;88;"Kerkyra";department;"22";14454
-"Greece";GR;GRC;88;"Kilkis";department;"57";14455
-"Greece";GR;GRC;88;"Korinthia";department;"15";14438
-"Greece";GR;GRC;88;"Kozani";department;"58";14456
-"Greece";GR;GRC;88;"Kriti";administrative regions;"M";48451
-"Greece";GR;GRC;88;"Kyklades";department;"82";14437
-"Greece";GR;GRC;88;"Lakonia";department;"16";14439
-"Greece";GR;GRC;88;"Larisa";department;"42";14457
-"Greece";GR;GRC;88;"Lasithi";department;"92";14440
-"Greece";GR;GRC;88;"Lefkada";department;"24";14441
-"Greece";GR;GRC;88;"Lesvos";department;"83";14413
-"Greece";GR;GRC;88;"Magnisia";department;"43";14458
-"Greece";GR;GRC;88;"Messinia";department;"17";14442
-"Greece";GR;GRC;88;"Notio Aigaio";administrative regions;"L";48452
-"Greece";GR;GRC;88;"Pella";department;"59";14443
-"Greece";GR;GRC;88;"Peloponnisos";administrative regions;"J";48453
-"Greece";GR;GRC;88;"Pieria";department;"61";14412
-"Greece";GR;GRC;88;"Preveza";department;"34";14444
-"Greece";GR;GRC;88;"Rethymno";department;"93";14459
-"Greece";GR;GRC;88;"Rodopi";department;"73";14445
-"Greece";GR;GRC;88;"Samos";department;"84";14411
-"Greece";GR;GRC;88;"Serres";department;"62";14446
-"Greece";GR;GRC;88;"Sterea Ellada";administrative regions;"H";48454
-"Greece";GR;GRC;88;"Thesprotia";department;"32";14410
-"Greece";GR;GRC;88;"Thessalia";administrative regions;"E";48455
-"Greece";GR;GRC;88;"Thessaloniki";department;"54";14447
-"Greece";GR;GRC;88;"Trikala";department;"44";14409
-"Greece";GR;GRC;88;"Voiotia";department;"03";14448
-"Greece";GR;GRC;88;"Voreio Aigaio";administrative regions;"K";48456
-"Greece";GR;GRC;88;"Xanthi";department;"72";14408
-"Greece";GR;GRC;88;"Zakynthos";department;"21";14449
-"Greenland";GL;GRL;89;"Kommune Kujalleq (kl)";municipality;"KU";48225
-"Greenland";GL;GRL;89;"Kommuneqarfik Sermersooq (kl)";municipality;"SM";48226
-"Greenland";GL;GRL;89;"Qaasuitsup Kommunia (kl)";municipality;"QA";48227
-"Greenland";GL;GRL;89;"Qeqqata Kommunia (kl)";municipality;"QE";48228
-"Grenada";GD;GRD;90;"Saint Andrew";Parish;"01";14484
-"Grenada";GD;GRD;90;"Saint David";Parish;"02";14486
-"Grenada";GD;GRD;90;"Saint George";Parish;"03";14485
-"Grenada";GD;GRD;90;"Saint John";Parish;"04";14483
-"Grenada";GD;GRD;90;"Saint Mark";Parish;"05";14480
-"Grenada";GD;GRD;90;"Saint Patrick";Parish;"06";14482
-"Grenada";GD;GRD;90;"Southern Grenadine Islands";Dependency;"10";14481
-"Guatemala";GT;GTM;93;"Alta Verapaz";Department;"AV";14531
-"Guatemala";GT;GTM;93;"Baja Verapaz";Department;"BV";14526
-"Guatemala";GT;GTM;93;"Chimaltenango";Department;"CM";14532
-"Guatemala";GT;GTM;93;"Chiquimula";Department;"CQ";14527
-"Guatemala";GT;GTM;93;"El Progreso";Department;"PR";14533
-"Guatemala";GT;GTM;93;"Escuintla";Department;"ES";14528
-"Guatemala";GT;GTM;93;"Guatemala";Department;"GU";14529
-"Guatemala";GT;GTM;93;"Huehuetenango";Department;"HU";14534
-"Guatemala";GT;GTM;93;"Izabal";Department;"IZ";14535
-"Guatemala";GT;GTM;93;"Jalapa";Department;"JA";14536
-"Guatemala";GT;GTM;93;"Jutiapa";Department;"JU";14537
-"Guatemala";GT;GTM;93;"Petén";Department;"PE";14538
-"Guatemala";GT;GTM;93;"Quetzaltenango";Department;"QZ";14525
-"Guatemala";GT;GTM;93;"Quiché";Department;"QC";14539
-"Guatemala";GT;GTM;93;"Retalhuleu";Department;"RE";14524
-"Guatemala";GT;GTM;93;"Sacatepéquez";Department;"SA";14540
-"Guatemala";GT;GTM;93;"San Marcos";Department;"SM";14523
-"Guatemala";GT;GTM;93;"Santa Rosa";Department;"SR";14541
-"Guatemala";GT;GTM;93;"Sololá";Department;"SO";14522
-"Guatemala";GT;GTM;93;"Suchitepéquez";Department;"SU";14542
-"Guatemala";GT;GTM;93;"Totonicapán";Department;"TO";14521
-"Guatemala";GT;GTM;93;"Zacapa";Department;"ZA";14530
-"Guinea";GN;GIN;95;"Beyla";Perfecture;"BE";14565
-"Guinea";GN;GIN;95;"Boffa";Perfecture;"BF";14566
-"Guinea";GN;GIN;95;"Boké";governorates;"B";48437
-"Guinea";GN;GIN;95;"Boké";Perfecture;"BK";14567
-"Guinea";GN;GIN;95;"Conakry";special zone.;"C";14568
-"Guinea";GN;GIN;95;"Coyah";Perfecture;"CO";14569
-"Guinea";GN;GIN;95;"Dabola";Perfecture;"DB";14575
-"Guinea";GN;GIN;95;"Dalaba";Perfecture;"DL";14570
-"Guinea";GN;GIN;95;"Dinguiraye";Perfecture;"DI";14576
-"Guinea";GN;GIN;95;"Dubréka";Perfecture;"DU";14573
-"Guinea";GN;GIN;95;"Faranah";Perfecture;"FA";14577
-"Guinea";GN;GIN;95;"faranah";governorates;"F";48438
-"Guinea";GN;GIN;95;"Forécariah";Perfecture;"FO";14571
-"Guinea";GN;GIN;95;"Fria";Perfecture;"FR";14578
-"Guinea";GN;GIN;95;"Gaoual";Perfecture;"GA";14572
-"Guinea";GN;GIN;95;"Guékédou";Perfecture;"GU";14579
-"Guinea";GN;GIN;95;"Kankan";governorates;"K";48439
-"Guinea";GN;GIN;95;"Kankan";Perfecture;"KA";14580
-"Guinea";GN;GIN;95;"Kindia";Perfecture;"KD";14581
-"Guinea";GN;GIN;95;"Kindia";governorates;"D";48440
-"Guinea";GN;GIN;95;"Kissidougou";Perfecture;"KS";14592
-"Guinea";GN;GIN;95;"Koubia";Perfecture;"KB";14582
-"Guinea";GN;GIN;95;"Koundara";Perfecture;"KN";14583
-"Guinea";GN;GIN;95;"Kouroussa";Perfecture;"KO";14560
-"Guinea";GN;GIN;95;"Kérouané";Perfecture;"KE";14561
-"Guinea";GN;GIN;95;"Labé";governorates;"L";48441
-"Guinea";GN;GIN;95;"Labé";Perfecture;"LA";14584
-"Guinea";GN;GIN;95;"Lola";Perfecture;"LO";14585
-"Guinea";GN;GIN;95;"Lélouma";Perfecture;"LE";14593
-"Guinea";GN;GIN;95;"Macenta";Perfecture;"MC";14586
-"Guinea";GN;GIN;95;"Mali";Perfecture;"ML";14559
-"Guinea";GN;GIN;95;"Mamou";Perfecture;"MM";14587
-"Guinea";GN;GIN;95;"Mamou";governorates;"M";48442
-"Guinea";GN;GIN;95;"Mandiana";Perfecture;"MD";14558
-"Guinea";GN;GIN;95;"Nzérékoré";governorates;"N";48443
-"Guinea";GN;GIN;95;"Nzérékoré";Perfecture;"NZ";14588
-"Guinea";GN;GIN;95;"Pita";Perfecture;"PI";14557
-"Guinea";GN;GIN;95;"Siguiri";Perfecture;"SI";14589
-"Guinea";GN;GIN;95;"Tougué";Perfecture;"TO";14556
-"Guinea";GN;GIN;95;"Télimélé";Perfecture;"TE";14590
-"Guinea";GN;GIN;95;"Yomou";Perfecture;"YO";14591
-"Guinea-Bissau";GW;GNB;96;"Bafatá";region;"BA";14595
-"Guinea-Bissau";GW;GNB;96;"Biombo";region;"BM";14598
-"Guinea-Bissau";GW;GNB;96;"Bissau";autonomous sector;"BS";14597
-"Guinea-Bissau";GW;GNB;96;"Bolama";region;"BL";14601
-"Guinea-Bissau";GW;GNB;96;"Cacheu";region;"CA";14599
-"Guinea-Bissau";GW;GNB;96;"Gabú";region;"GA";14602
-"Guinea-Bissau";GW;GNB;96;"Leste";province;"L";48457
-"Guinea-Bissau";GW;GNB;96;"Norte";province;"N";48458
-"Guinea-Bissau";GW;GNB;96;"Oio";region;"OI";14596
-"Guinea-Bissau";GW;GNB;96;"Quinara";region;"QU";14594
-"Guinea-Bissau";GW;GNB;96;"Sul";province;"S";48459
-"Guinea-Bissau";GW;GNB;96;"Tombali";region;"TO";14600
-"Guyana";GY;GUY;97;"Barima-Waini";Region;"BA";14605
-"Guyana";GY;GUY;97;"Cuyuni-Mazaruni";Region;"CU";14612
-"Guyana";GY;GUY;97;"Demerara-Mahaica";Region;"DE";14606
-"Guyana";GY;GUY;97;"East Berbice-Corentyne";Region;"EB";14611
-"Guyana";GY;GUY;97;"Essequibo Islands-West Demerara";Region;"ES";14607
-"Guyana";GY;GUY;97;"Mahaica-Berbice";Region;"MA";14608
-"Guyana";GY;GUY;97;"Pomeroon-Supenaam";Region;"PM";14604
-"Guyana";GY;GUY;97;"Potaro-Siparuni";Region;"PT";14609
-"Guyana";GY;GUY;97;"Upper Demerara-Berbice";Region;"UD";14603
-"Guyana";GY;GUY;97;"Upper Takutu-Upper Essequibo";Region;"UT";14610
-"Haiti";HT;HTI;98;"Artibonite";Department;"AR";14621
-"Haiti";HT;HTI;98;"Centre";Department;"CE";14617
-"Haiti";HT;HTI;98;"Grande-Anse";Department;"GA";14620
-"Haiti";HT;HTI;98;"Nippes";Department;"NI";48705
-"Haiti";HT;HTI;98;"Nord";Department;"ND";14616
-"Haiti";HT;HTI;98;"Nord-Est";Department;"NE";14618
-"Haiti";HT;HTI;98;"Nord-Ouest";Department;"NO";14614
-"Haiti";HT;HTI;98;"Ouest";Department;"OU";14615
-"Haiti";HT;HTI;98;"Sud";Department;"SD";14613
-"Haiti";HT;HTI;98;"Sud-Est";Department;"SE";14619
-"Honduras";HN;HND;101;"Atlántida";Department;"AT";14635
-"Honduras";HN;HND;101;"Choluteca";Department;"CH";14624
-"Honduras";HN;HND;101;"Colón";Department;"CL";14625
-"Honduras";HN;HND;101;"Comayagua";Department;"CM";14636
-"Honduras";HN;HND;101;"Copán";Department;"CP";14626
-"Honduras";HN;HND;101;"Cortés";Department;"CR";14637
-"Honduras";HN;HND;101;"El Paraíso";Department;"EP";14638
-"Honduras";HN;HND;101;"Francisco Morazán";Department;"FM";14628
-"Honduras";HN;HND;101;"Gracias a Dios";Department;"GD";14629
-"Honduras";HN;HND;101;"Intibucá";Department;"IN";14623
-"Honduras";HN;HND;101;"Islas de la Bahía";Department;"IB";14630
-"Honduras";HN;HND;101;"La Paz";Department;"LP";14639
-"Honduras";HN;HND;101;"Lempira";Department;"LE";14631
-"Honduras";HN;HND;101;"Ocotepeque";Department;"OC";14640
-"Honduras";HN;HND;101;"Olancho";Department;"OL";14632
-"Honduras";HN;HND;101;"Santa Bárbara";Department;"SB";14633
-"Honduras";HN;HND;101;"Valle";Department;"VA";14622
-"Honduras";HN;HND;101;"Yoro";Department;"YO";14634
-"Hungary";HU;HUN;103;"Baranya";county;"BA";14646
-"Hungary";HU;HUN;103;"Borsod-Abaúj-Zemplén";county;"BZ";14660
-"Hungary";HU;HUN;103;"Budapest";capital city;"BU";14649
-"Hungary";HU;HUN;103;"Bács-Kiskun";county;"BK";14647
-"Hungary";HU;HUN;103;"Békés";county;"BE";14648
-"Hungary";HU;HUN;103;"Békéscsaba";city of county right;"BC";19442
-"Hungary";HU;HUN;103;"Csongrád";county;"CS";14650
-"Hungary";HU;HUN;103;"Debrecen";city of county right;"DE";19443
-"Hungary";HU;HUN;103;"Dunaújváros";city of county right;"DU";19444
-"Hungary";HU;HUN;103;"Eger";city of county right;"EG";19445
-"Hungary";HU;HUN;103;"Erd";County;"ER";21352
-"Hungary";HU;HUN;103;"Erd";County;"X1~";48133
-"Hungary";HU;HUN;103;"Fejér";county;"FE";14645
-"Hungary";HU;HUN;103;"Gyor";city of county right;"GY";19446
-"Hungary";HU;HUN;103;"Gyor-Moson-Sopron";county;"GS";14651
-"Hungary";HU;HUN;103;"Hajdú-Bihar";county;"HB";14661
-"Hungary";HU;HUN;103;"Heves";county;"HE";14652
-"Hungary";HU;HUN;103;"Hódmezovásárhely";city of county right;"HV";19447
-"Hungary";HU;HUN;103;"Jász-Nagykun-Szolnok";county;"JN";14653
-"Hungary";HU;HUN;103;"Kaposvár";city of county right;"KV";19448
-"Hungary";HU;HUN;103;"Kecskemét";city of county right;"KM";19449
-"Hungary";HU;HUN;103;"Komárom-Esztergom";county;"KE";14644
-"Hungary";HU;HUN;103;"Miskolc";city of county right;"MI";19450
-"Hungary";HU;HUN;103;"Nagykanizsa";city of county right;"NK";19451
-"Hungary";HU;HUN;103;"Nyíregyháza";city of county right;"NY";19452
-"Hungary";HU;HUN;103;"Nógrád";county;"NO";14654
-"Hungary";HU;HUN;103;"Pest";county;"PE";14643
-"Hungary";HU;HUN;103;"Pécs";city of county right;"PS";19453
-"Hungary";HU;HUN;103;"Salgótarján";city of county right;"ST";19454
-"Hungary";HU;HUN;103;"Somogy";county;"SO";14655
-"Hungary";HU;HUN;103;"Sopron";city of county right;"SN";19455
-"Hungary";HU;HUN;103;"Szabolcs-Szatmár-Bereg";county;"SZ";14656
-"Hungary";HU;HUN;103;"Szeged";city of county right;"SD";19456
-"Hungary";HU;HUN;103;"Szekszárd";city of county right;"SS";19458
-"Hungary";HU;HUN;103;"Szolnok";city of county right;"SK";19459
-"Hungary";HU;HUN;103;"Szombathely";city of county right;"SH";19460
-"Hungary";HU;HUN;103;"Székesfehérvár";city of county right;"SF";19457
-"Hungary";HU;HUN;103;"Tatabánya";city of county right;"TB";19461
-"Hungary";HU;HUN;103;"Tolna";county;"TO";14642
-"Hungary";HU;HUN;103;"Vas";county;"VA";14657
-"Hungary";HU;HUN;103;"Veszprém";county;"VE";14658
-"Hungary";HU;HUN;103;"Veszprém City";city of county right;"VM";19462
-"Hungary";HU;HUN;103;"Zala";county;"ZA";14641
-"Hungary";HU;HUN;103;"Zalaegerszeg";city of county right;"ZE";19463
-"Iceland";IS;ISL;104;"Austurland";Region;"7";14670
-"Iceland";IS;ISL;104;"Höfuðborgarsvæði utan Reykjavíkur";Region;"1";14666
-"Iceland";IS;ISL;104;"Norðurland eystra";Region;"6";14669
-"Iceland";IS;ISL;104;"Norðurland vestra";Region;"5";14664
-"Iceland";IS;ISL;104;"Reykjavík";City;"0";19009
-"Iceland";IS;ISL;104;"Suðurland";Region;"8";14668
-"Iceland";IS;ISL;104;"Suðurnes";Region;"2";14667
-"Iceland";IS;ISL;104;"Vestfirðir";Region;"4";14663
-"Iceland";IS;ISL;104;"Vesturland";Region;"3";14662
-"India";IN;IND;105;"Andaman and Nicobar Islands";union territory;"AN";14673
-"India";IN;IND;105;"Andhra Pradesh";state;"AP";14695
-"India";IN;IND;105;"Arunachal Pradesh";state;"AR";14674
-"India";IN;IND;105;"Assam";state;"AS";14675
-"India";IN;IND;105;"Bihar";state;"BR";14676
-"India";IN;IND;105;"Chandigarh";union territory;"CH";14697
-"India";IN;IND;105;"Chhattisgarh";state;"CT";14677
-"India";IN;IND;105;"Dadra and Nagar Haveli";union territory;"DN";14678
-"India";IN;IND;105;"Daman and Diu";union territory;"DD";14698
-"India";IN;IND;105;"Delhi";union territory;"DL";14679
-"India";IN;IND;105;"Goa";state;"GA";14699
-"India";IN;IND;105;"Gujarat";state;"GJ";14680
-"India";IN;IND;105;"Haryana";state;"HR";14681
-"India";IN;IND;105;"Himachal Pradesh";state;"HP";14672
-"India";IN;IND;105;"Jammu and Kashmir";state;"JK";14682
-"India";IN;IND;105;"Jharkhand";state;"JH";14700
-"India";IN;IND;105;"Karnataka";state;"KA";14683
-"India";IN;IND;105;"Kerala";state;"KL";14684
-"India";IN;IND;105;"Lakshadweep";union territory;"LD";14704
-"India";IN;IND;105;"Madhya Pradesh";state;"MP";14685
-"India";IN;IND;105;"Maharashtra";state;"MH";14686
-"India";IN;IND;105;"Manipur";state;"MN";14703
-"India";IN;IND;105;"Meghalaya";state;"ML";14687
-"India";IN;IND;105;"Mizoram";state;"MZ";14702
-"India";IN;IND;105;"Nagaland";state;"NL";14688
-"India";IN;IND;105;"Orissa";state;"OR";14689
-"India";IN;IND;105;"Pondicherry";union territory;"PY";14705
-"India";IN;IND;105;"Punjab";state;"PB";14690
-"India";IN;IND;105;"Rajasthan";state;"RJ";14691
-"India";IN;IND;105;"Sikkim";state;"SK";14701
-"India";IN;IND;105;"Tamil Nadu";state;"TN";14692
-"India";IN;IND;105;"Tripura";state;"TR";14693
-"India";IN;IND;105;"Uttar Pradesh";state;"UP";14694
-"India";IN;IND;105;"Uttaranchal";state;"UL";14671
-"India";IN;IND;105;"West Bengal";state;"WB";14696
-"Indonesia";ID;IDN;106;"Aceh";autonomous province;"AC";14720
-"Indonesia";ID;IDN;106;"Bali";province;"BA";14719
-"Indonesia";ID;IDN;106;"Bangka Belitung";province;"BB";14721
-"Indonesia";ID;IDN;106;"Banten";province;"BT";14723
-"Indonesia";ID;IDN;106;"Bengkulu";province;"BE";14722
-"Indonesia";ID;IDN;106;"Gorontalo";province;"GO";14711
-"Indonesia";ID;IDN;106;"Jakarta Raya";special district;"JK";14724
-"Indonesia";ID;IDN;106;"Jambi";province;"JA";14712
-"Indonesia";ID;IDN;106;"Jawa";geographic units;"JW";48462
-"Indonesia";ID;IDN;106;"Jawa Barat";province;"JB";14725
-"Indonesia";ID;IDN;106;"Jawa Tengah";province;"JT";14713
-"Indonesia";ID;IDN;106;"Jawa Timur";province;"JI";14726
-"Indonesia";ID;IDN;106;"Kalimantan";geographic units;"KA";48463
-"Indonesia";ID;IDN;106;"Kalimantan Barat";province;"KB";14714
-"Indonesia";ID;IDN;106;"Kalimantan Selatan";province;"KS";14715
-"Indonesia";ID;IDN;106;"Kalimantan Tengah";province;"KT";14727
-"Indonesia";ID;IDN;106;"Kalimantan Timur";province;"KI";14728
-"Indonesia";ID;IDN;106;"Kepulauan Riau";province;"KR";14733
-"Indonesia";ID;IDN;106;"Lampung";province;"LA";14729
-"Indonesia";ID;IDN;106;"Maluku";geographic units;"ML";48905
-"Indonesia";ID;IDN;106;"Maluku";province;"MA";14730
-"Indonesia";ID;IDN;106;"Maluku Utara";province;"MU";14710
-"Indonesia";ID;IDN;106;"Nusa Tenggara";geographic units;"NU";48465
-"Indonesia";ID;IDN;106;"Nusa Tenggara Barat";province;"NB";14731
-"Indonesia";ID;IDN;106;"Nusa Tenggara Timur";province;"NT";14709
-"Indonesia";ID;IDN;106;"Papua";province;"PA";14732
-"Indonesia";ID;IDN;106;"Papua";geographic units;"IJ";48466
-"Indonesia";ID;IDN;106;"Papua Barat";;"X1~";48084
-"Indonesia";ID;IDN;106;"Papua Barat";province;"PB";19010
-"Indonesia";ID;IDN;106;"Riau";province;"RI";14708
-"Indonesia";ID;IDN;106;"Sulawesi";geographic units;"SL";48467
-"Indonesia";ID;IDN;106;"Sulawesi Barat";province;"SR";19011
-"Indonesia";ID;IDN;106;"Sulawesi Selatan";province;"SN";14707
-"Indonesia";ID;IDN;106;"Sulawesi Tengah";province;"ST";14734
-"Indonesia";ID;IDN;106;"Sulawesi Tenggara";province;"SG";14736
-"Indonesia";ID;IDN;106;"Sulawesi Utara";province;"SA";14716
-"Indonesia";ID;IDN;106;"Sumatera";geographic units;"SM";48468
-"Indonesia";ID;IDN;106;"Sumatera Barat";province;"SB";14735
-"Indonesia";ID;IDN;106;"Sumatera Selatan";province;"SS";14717
-"Indonesia";ID;IDN;106;"Sumatera Utara";province;"SU";14706
-"Indonesia";ID;IDN;106;"Yogyakarta";special region;"YO";14718
-"Islamic Republic Of Iran";IR;IRN;107;"Ardabil";Province;"03";14748
-"Islamic Republic Of Iran";IR;IRN;107;"Az¯arbayjan-e Gharbi";Province;"02";14756
-"Islamic Republic Of Iran";IR;IRN;107;"Az¯arbayjan-e Sharqi";Province;"01";14749
-"Islamic Republic Of Iran";IR;IRN;107;"Bushehr";Province;"06";14757
-"Islamic Republic Of Iran";IR;IRN;107;"Chahar Mah¸all va Bakhtiari";Province;"08";14750
-"Islamic Republic Of Iran";IR;IRN;107;"Esfahan";Province;"04";14758
-"Islamic Republic Of Iran";IR;IRN;107;"Fars";Province;"14";14751
-"Islamic Republic Of Iran";IR;IRN;107;"Gilan";Province;"19";14759
-"Islamic Republic Of Iran";IR;IRN;107;"Golestan";Province;"27";14760
-"Islamic Republic Of Iran";IR;IRN;107;"Hamadan";Province;"24";14752
-"Islamic Republic Of Iran";IR;IRN;107;"Hormozgan";Province;"23";14761
-"Islamic Republic Of Iran";IR;IRN;107;"Ilam";Province;"05";14753
-"Islamic Republic Of Iran";IR;IRN;107;"Kerman";Province;"15";14762
-"Islamic Republic Of Iran";IR;IRN;107;"Kermanshah";Province;"17";14739
-"Islamic Republic Of Iran";IR;IRN;107;"Khorasan";;"09";14740
-"Islamic Republic Of Iran";IR;IRN;107;"Khorasan-e Janubi";Province;"29";19012
-"Islamic Republic Of Iran";IR;IRN;107;"Khorasan-e Razavi";Province;"30";19013
-"Islamic Republic Of Iran";IR;IRN;107;"Khorasan-e Shemali";Province;"31";19014
-"Islamic Republic Of Iran";IR;IRN;107;"Khuzestan";Province;"10";14741
-"Islamic Republic Of Iran";IR;IRN;107;"Kohkiluyeh va Buyer Ahmad";Province;"18";14742
-"Islamic Republic Of Iran";IR;IRN;107;"Kordestan";Province;"16";14743
-"Islamic Republic Of Iran";IR;IRN;107;"Lorestan";Province;"20";14744
-"Islamic Republic Of Iran";IR;IRN;107;"Markazi";Province;"22";14745
-"Islamic Republic Of Iran";IR;IRN;107;"Mazandaran";Province;"21";14746
-"Islamic Republic Of Iran";IR;IRN;107;"Qazvin";Province;"28";14747
-"Islamic Republic Of Iran";IR;IRN;107;"Qom";Province;"26";14738
-"Islamic Republic Of Iran";IR;IRN;107;"Semnan";Province;"12";14754
-"Islamic Republic Of Iran";IR;IRN;107;"Sistan va Baluchestan";Province;"13";14764
-"Islamic Republic Of Iran";IR;IRN;107;"Tehran";Province;"07";14755
-"Islamic Republic Of Iran";IR;IRN;107;"Yazd";Province;"25";14763
-"Islamic Republic Of Iran";IR;IRN;107;"Zanjan";Province;"11";14737
-"Iraq";IQ;IRQ;108;"Al Anbar";Province;"AN";14771
-"Iraq";IQ;IRQ;108;"Al Basrah";Province;"BA";14773
-"Iraq";IQ;IRQ;108;"Al Muthanná";Province;"MU";14777
-"Iraq";IQ;IRQ;108;"Al Qadisiyah";Province;"QA";14766
-"Iraq";IQ;IRQ;108;"An Najaf";Province;"NA";14768
-"Iraq";IQ;IRQ;108;"Arbil";Province;"AR";14769
-"Iraq";IQ;IRQ;108;"As Sulaymaniyah";Province;"SU";14779
-"Iraq";IQ;IRQ;108;"At Ta'mim";Province;"TS";14765
-"Iraq";IQ;IRQ;108;"Babil";Province;"BB";14772
-"Iraq";IQ;IRQ;108;"Baghdad";Province;"BG";14770
-"Iraq";IQ;IRQ;108;"Dahuk";Province;"DA";14774
-"Iraq";IQ;IRQ;108;"Dhi Qar";Province;"DQ";14781
-"Iraq";IQ;IRQ;108;"Diyalá";Province;"DI";14775
-"Iraq";IQ;IRQ;108;"Karbala'";Province;"KA";14776
-"Iraq";IQ;IRQ;108;"Maysan";Province;"MA";14782
-"Iraq";IQ;IRQ;108;"Ninawá";Province;"NI";14778
-"Iraq";IQ;IRQ;108;"Salah ad Din";Province;"SD";14767
-"Iraq";IQ;IRQ;108;"Wasit";Province;"WA";14780
-"Ireland";IE;IRL;109;"Carlow";County;"CW";14798
-"Ireland";IE;IRL;109;"Cavan";County;"CN";14795
-"Ireland";IE;IRL;109;"Clare";County;"CE";14799
-"Ireland";IE;IRL;109;"Connaught";province;"C";48469
-"Ireland";IE;IRL;109;"Cork";County;"CO";48897
-"Ireland";IE;IRL;109;"Cork";County;"C";14800
-"Ireland";IE;IRL;109;"Donegal";County;"DL";14796
-"Ireland";IE;IRL;109;"Dublin";County;"D";14801
-"Ireland";IE;IRL;109;"Galway";County;"G";14797
-"Ireland";IE;IRL;109;"Kerry";County;"KY";14802
-"Ireland";IE;IRL;109;"Kildare";County;"KE";14788
-"Ireland";IE;IRL;109;"Kilkenny";County;"KK";14803
-"Ireland";IE;IRL;109;"Laois";County;"LS";14807
-"Ireland";IE;IRL;109;"Leinster";province;"L";48470
-"Ireland";IE;IRL;109;"Leitrim";County;"LM";14804
-"Ireland";IE;IRL;109;"Limerick";County;"LK";14805
-"Ireland";IE;IRL;109;"Longford";County;"LD";14787
-"Ireland";IE;IRL;109;"Louth";County;"LH";14806
-"Ireland";IE;IRL;109;"Mayo";County;"MO";14808
-"Ireland";IE;IRL;109;"Meath";County;"MH";14789
-"Ireland";IE;IRL;109;"Monaghan";County;"MN";14786
-"Ireland";IE;IRL;109;"Munster";province;"M";48471
-"Ireland";IE;IRL;109;"Offaly";County;"OY";14790
-"Ireland";IE;IRL;109;"Roscommon";County;"RN";14809
-"Ireland";IE;IRL;109;"Sligo";County;"SO";14791
-"Ireland";IE;IRL;109;"Tipperary";County;"TA";14792
-"Ireland";IE;IRL;109;"Ulster";province;"U";48472
-"Ireland";IE;IRL;109;"Waterford";County;"WD";14784
-"Ireland";IE;IRL;109;"Westmeath";County;"WH";14793
-"Ireland";IE;IRL;109;"Wexford";County;"WX";14783
-"Ireland";IE;IRL;109;"Wicklow";County;"WW";14794
-"Israel";IL;ISR;111;"HaDarom";District;"D";14847
-"Israel";IL;ISR;111;"Haifa";District;"HA";14878
-"Israel";IL;ISR;111;"HaMerkaz";District;"M";14877
-"Israel";IL;ISR;111;"HaZafon";District;"Z";14848
-"Israel";IL;ISR;111;"Tel-Aviv";District;"TA";14850
-"Israel";IL;ISR;111;"Yerushalayim";District;"JM";14879
-"Italy";IT;ITA;112;"Abruzzo";region;"65";14895
-"Italy";IT;ITA;112;"Agrigento";Province;"AG";19465
-"Italy";IT;ITA;112;"Alessandria";Province;"AL";19466
-"Italy";IT;ITA;112;"Ancona";Province;"AN";19467
-"Italy";IT;ITA;112;"Aosta";Province;"AO";19468
-"Italy";IT;ITA;112;"Arezzo";Province;"AR";19469
-"Italy";IT;ITA;112;"Ascoli Piceno";Province;"AP";19470
-"Italy";IT;ITA;112;"Asti";Province;"AT";19471
-"Italy";IT;ITA;112;"Avellino";Province;"AV";19472
-"Italy";IT;ITA;112;"Bari";Province;"BA";19473
-"Italy";IT;ITA;112;"Barletta-Andria-Trani";Province;"BT";48088
-"Italy";IT;ITA;112;"Basilicata";region;"77";14897
-"Italy";IT;ITA;112;"Belluno";Province;"BL";19474
-"Italy";IT;ITA;112;"Benevento";Province;"BN";19475
-"Italy";IT;ITA;112;"Bergamo";Province;"BG";19476
-"Italy";IT;ITA;112;"Biella";Province;"BI";19477
-"Italy";IT;ITA;112;"Bologna";Province;"BO";19478
-"Italy";IT;ITA;112;"Bolzano";Province;"BZ";19479
-"Italy";IT;ITA;112;"Brescia";Province;"BS";19480
-"Italy";IT;ITA;112;"Brindisi";Province;"BR";19481
-"Italy";IT;ITA;112;"Cagliari";Province;"CA";19482
-"Italy";IT;ITA;112;"Calabria";region;"78";14896
-"Italy";IT;ITA;112;"Caltanissetta";Province;"CL";19483
-"Italy";IT;ITA;112;"Campania";region;"72";14898
-"Italy";IT;ITA;112;"Campobasso";Province;"CB";19484
-"Italy";IT;ITA;112;"Carbonia-Iglesias";Province;"CI";19485
-"Italy";IT;ITA;112;"Caserta";Province;"CE";19486
-"Italy";IT;ITA;112;"Catania";Province;"CT";19487
-"Italy";IT;ITA;112;"Catanzaro";Province;"CZ";19488
-"Italy";IT;ITA;112;"Chieti";Province;"CH";19489
-"Italy";IT;ITA;112;"Como";Province;"CO";19490
-"Italy";IT;ITA;112;"Cosenza";Province;"CS";19491
-"Italy";IT;ITA;112;"Cremona";Province;"CR";19492
-"Italy";IT;ITA;112;"Crotone";Province;"KR";19493
-"Italy";IT;ITA;112;"Cuneo";Province;"CN";19494
-"Italy";IT;ITA;112;"Emilia-Romagna";region;"45";14886
-"Italy";IT;ITA;112;"Enna";Province;"EN";19495
-"Italy";IT;ITA;112;"Fermo";Province;"FM";48086
-"Italy";IT;ITA;112;"Ferrara";Province;"FE";19496
-"Italy";IT;ITA;112;"Firenze";Province;"FI";19497
-"Italy";IT;ITA;112;"Foggia";Province;"FG";19498
-"Italy";IT;ITA;112;"Forli-Cesena";Province;"FC";19499
-"Italy";IT;ITA;112;"Forlì";;"FO";48085
-"Italy";IT;ITA;112;"Friuli-Venezia Giulia";region;"36";14885
-"Italy";IT;ITA;112;"Frosinone";Province;"FR";19500
-"Italy";IT;ITA;112;"Genova";Province;"GE";19501
-"Italy";IT;ITA;112;"Gorizia";Province;"GO";19502
-"Italy";IT;ITA;112;"Grosseto";Province;"GR";19503
-"Italy";IT;ITA;112;"Imperia";Province;"IM";19504
-"Italy";IT;ITA;112;"Isernia";Province;"IS";19505
-"Italy";IT;ITA;112;"L'Aquila";Province;"AQ";19507
-"Italy";IT;ITA;112;"La Spezia";Province;"SP";19506
-"Italy";IT;ITA;112;"Latina";Province;"LT";19508
-"Italy";IT;ITA;112;"Lazio";region;"62";14887
-"Italy";IT;ITA;112;"Lecce";Province;"LE";19509
-"Italy";IT;ITA;112;"Lecco";Province;"LC";19510
-"Italy";IT;ITA;112;"Liguria";region;"42";14899
-"Italy";IT;ITA;112;"Livorno";Province;"LI";19511
-"Italy";IT;ITA;112;"Lodi";Province;"LO";19512
-"Italy";IT;ITA;112;"Lombardia";region;"25";14888
-"Italy";IT;ITA;112;"Lucca";Province;"LU";19513
-"Italy";IT;ITA;112;"Macerata";Province;"MC";19514
-"Italy";IT;ITA;112;"Mantova";Province;"MN";19515
-"Italy";IT;ITA;112;"Marche";region;"57";14889
-"Italy";IT;ITA;112;"Massa-Carrara";Province;"MS";19516
-"Italy";IT;ITA;112;"Matera";Province;"MT";19517
-"Italy";IT;ITA;112;"Medio Campidano";Province;"VS";19518
-"Italy";IT;ITA;112;"Medio Campidano";Province;"MA";48224
-"Italy";IT;ITA;112;"Messina";Province;"ME";19519
-"Italy";IT;ITA;112;"Milano";Province;"MI";19520
-"Italy";IT;ITA;112;"Modena";Province;"MO";19521
-"Italy";IT;ITA;112;"Molise";region;"67";14884
-"Italy";IT;ITA;112;"Monza e Brianza";Province;"MB";48087
-"Italy";IT;ITA;112;"Napoli";Province;"NA";19522
-"Italy";IT;ITA;112;"Novara";Province;"NO";19523
-"Italy";IT;ITA;112;"Nuoro";Province;"NU";19524
-"Italy";IT;ITA;112;"Ogliastra";Province;"OG";19525
-"Italy";IT;ITA;112;"Olbia-Tempio";Province;"OT";19526
-"Italy";IT;ITA;112;"Olbia-Tempio";Province;"OL";48223
-"Italy";IT;ITA;112;"Oristano";Province;"OR";19527
-"Italy";IT;ITA;112;"Padova";Province;"PD";19528
-"Italy";IT;ITA;112;"Palermo";Province;"PA";19529
-"Italy";IT;ITA;112;"Parma";Province;"PR";19530
-"Italy";IT;ITA;112;"Pavia";Province;"PV";19531
-"Italy";IT;ITA;112;"Perugia";Province;"PG";19532
-"Italy";IT;ITA;112;"Pesaro e Urbino";Province;"PS";48222
-"Italy";IT;ITA;112;"Pesaro e Urbino";Province;"PU";19533
-"Italy";IT;ITA;112;"Pescara";Province;"PE";19534
-"Italy";IT;ITA;112;"Piacenza";Province;"PC";19535
-"Italy";IT;ITA;112;"Piemonte";region;"21";14900
-"Italy";IT;ITA;112;"Pisa";Province;"PI";19536
-"Italy";IT;ITA;112;"Pistoia";Province;"PT";19537
-"Italy";IT;ITA;112;"Pordenone";Province;"PN";19538
-"Italy";IT;ITA;112;"Potenza";Province;"PZ";19539
-"Italy";IT;ITA;112;"Prato";Province;"PO";19540
-"Italy";IT;ITA;112;"Puglia";region;"75";14890
-"Italy";IT;ITA;112;"Ragusa";Province;"RG";19541
-"Italy";IT;ITA;112;"Ravenna";Province;"RA";19542
-"Italy";IT;ITA;112;"Reggio Calabria";Province;"RC";19543
-"Italy";IT;ITA;112;"Reggio Emilia";Province;"RE";19544
-"Italy";IT;ITA;112;"Rieti";Province;"RI";19545
-"Italy";IT;ITA;112;"Rimini";Province;"RN";19546
-"Italy";IT;ITA;112;"Roma";Province;"RM";19547
-"Italy";IT;ITA;112;"Rovigo";Province;"RO";19548
-"Italy";IT;ITA;112;"Salerno";Province;"SA";19549
-"Italy";IT;ITA;112;"Sardegna";region;"88";14883
-"Italy";IT;ITA;112;"Sassari";Province;"SS";19550
-"Italy";IT;ITA;112;"Savona";Province;"SV";19551
-"Italy";IT;ITA;112;"Sicilia";region;"82";14891
-"Italy";IT;ITA;112;"Siena";Province;"SI";19552
-"Italy";IT;ITA;112;"Siracusa";Province;"SR";19553
-"Italy";IT;ITA;112;"Sondrio";Province;"SO";19554
-"Italy";IT;ITA;112;"Taranto";Province;"TA";19555
-"Italy";IT;ITA;112;"Teramo";Province;"TE";19556
-"Italy";IT;ITA;112;"Terni";Province;"TR";19557
-"Italy";IT;ITA;112;"Torino";Province;"TO";19558
-"Italy";IT;ITA;112;"Toscana";region;"52";14901
-"Italy";IT;ITA;112;"Trapani";Province;"TP";19559
-"Italy";IT;ITA;112;"Trentino-Alto Adige";region;"32";14892
-"Italy";IT;ITA;112;"Trento";Province;"TN";19560
-"Italy";IT;ITA;112;"Treviso";Province;"TV";19561
-"Italy";IT;ITA;112;"Trieste";Province;"TS";19562
-"Italy";IT;ITA;112;"Udine";Province;"UD";19563
-"Italy";IT;ITA;112;"Umbria";region;"55";14893
-"Italy";IT;ITA;112;"Valle d'Aosta";region;"23";14882
-"Italy";IT;ITA;112;"Varese";Province;"VA";19564
-"Italy";IT;ITA;112;"Veneto";region;"34";14894
-"Italy";IT;ITA;112;"Venezia";Province;"VE";19565
-"Italy";IT;ITA;112;"Verbano-Cusio-Ossola";Province;"VB";19566
-"Italy";IT;ITA;112;"Vercelli";Province;"VC";19567
-"Italy";IT;ITA;112;"Verona";Province;"VR";19568
-"Italy";IT;ITA;112;"Vibo Valentia";Province;"VV";19569
-"Italy";IT;ITA;112;"Vicenza";Province;"VI";19570
-"Italy";IT;ITA;112;"Viterbo";Province;"VT";19571
-"Jamaica";JM;JAM;113;"Clarendon";Parish;"13";14905
-"Jamaica";JM;JAM;113;"Hanover";Parish;"09";14915
-"Jamaica";JM;JAM;113;"Kingston";Parish;"01";14906
-"Jamaica";JM;JAM;113;"Manchester";Parish;"12";14914
-"Jamaica";JM;JAM;113;"Portland";Parish;"04";14907
-"Jamaica";JM;JAM;113;"Saint Andrew";Parish;"02";14908
-"Jamaica";JM;JAM;113;"Saint Ann";Parish;"06";14904
-"Jamaica";JM;JAM;113;"Saint Catherine";Parish;"14";14909
-"Jamaica";JM;JAM;113;"Saint Elizabeth";Parish;"11";14903
-"Jamaica";JM;JAM;113;"Saint James";Parish;"08";14910
-"Jamaica";JM;JAM;113;"Saint Mary";Parish;"05";14911
-"Jamaica";JM;JAM;113;"Saint Thomas";Parish;"03";14902
-"Jamaica";JM;JAM;113;"Trelawny";Parish;"07";14912
-"Jamaica";JM;JAM;113;"Westmoreland";Parish;"10";14913
-"Japan";JP;JPN;114;"Aiti [Aichi]";Perfecture;"23";14931
-"Japan";JP;JPN;114;"Akita";Perfecture;"05";14954
-"Japan";JP;JPN;114;"Aomori";Perfecture;"02";14932
-"Japan";JP;JPN;114;"Ehime";Perfecture;"38";14955
-"Japan";JP;JPN;114;"Gihu [Gifu]";Perfecture;"21";14936
-"Japan";JP;JPN;114;"Gunma";Perfecture;"10";14937
-"Japan";JP;JPN;114;"Hirosima [Hiroshima]";Perfecture;"34";14938
-"Japan";JP;JPN;114;"Hokkaidô [Hokkaido]";Territory;"01";14957
-"Japan";JP;JPN;114;"Hukui [Fukui]";Perfecture;"18";14934
-"Japan";JP;JPN;114;"Hukuoka [Fukuoka]";Perfecture;"40";14935
-"Japan";JP;JPN;114;"Hukusima [Fukushima]";Perfecture;"07";14956
-"Japan";JP;JPN;114;"Hyôgo [Hyogo]";Perfecture;"28";14939
-"Japan";JP;JPN;114;"Ibaraki";Perfecture;"08";14958
-"Japan";JP;JPN;114;"Isikawa [Ishikawa]";Perfecture;"17";14940
-"Japan";JP;JPN;114;"Iwate";Perfecture;"03";14941
-"Japan";JP;JPN;114;"Kagawa";Perfecture;"37";14942
-"Japan";JP;JPN;114;"Kagosima [Kagoshima]";Perfecture;"46";14959
-"Japan";JP;JPN;114;"Kanagawa";Perfecture;"14";14943
-"Japan";JP;JPN;114;"Kumamoto";Perfecture;"43";14960
-"Japan";JP;JPN;114;"Kyôto [Kyoto]";Urban Perfecture;"26";14945
-"Japan";JP;JPN;114;"Kôti [Kochi]";Perfecture;"39";14944
-"Japan";JP;JPN;114;"Mie";Perfecture;"24";14946
-"Japan";JP;JPN;114;"Miyagi";Perfecture;"04";14921
-"Japan";JP;JPN;114;"Miyazaki";Perfecture;"45";14947
-"Japan";JP;JPN;114;"Nagano";Perfecture;"20";14948
-"Japan";JP;JPN;114;"Nagasaki";Perfecture;"42";14961
-"Japan";JP;JPN;114;"Nara";Perfecture;"29";14949
-"Japan";JP;JPN;114;"Niigata";Perfecture;"15";14950
-"Japan";JP;JPN;114;"Okayama";Perfecture;"33";14951
-"Japan";JP;JPN;114;"Okinawa";Perfecture;"47";14952
-"Japan";JP;JPN;114;"Saga";Perfecture;"41";14953
-"Japan";JP;JPN;114;"Saitama";Perfecture;"11";14922
-"Japan";JP;JPN;114;"Siga [Shiga]";Perfecture;"25";14919
-"Japan";JP;JPN;114;"Simane [Shimane]";Perfecture;"32";14923
-"Japan";JP;JPN;114;"Sizuoka [Shizuoka]";Perfecture;"22";14924
-"Japan";JP;JPN;114;"Tiba [Chiba]";Perfecture;"12";14933
-"Japan";JP;JPN;114;"Tokusima [Tokushima]";Perfecture;"36";14925
-"Japan";JP;JPN;114;"Totigi [Tochigi]";Perfecture;"09";14918
-"Japan";JP;JPN;114;"Tottori";Perfecture;"31";14917
-"Japan";JP;JPN;114;"Toyama";Perfecture;"16";14927
-"Japan";JP;JPN;114;"Tôkyô [Tokyo]";Metropolis;"13";14926
-"Japan";JP;JPN;114;"Wakayama";Perfecture;"30";14928
-"Japan";JP;JPN;114;"Yamagata";Perfecture;"06";14916
-"Japan";JP;JPN;114;"Yamaguti [Yamaguchi]";Perfecture;"35";14929
-"Japan";JP;JPN;114;"Yamanasi [Yamanashi]";Perfecture;"19";14930
-"Japan";JP;JPN;114;"Ôita [Oita]";Perfecture;"44";14920
-"Japan";JP;JPN;114;"Ôsaka [Osaka]";Urban Perfecture;"27";14962
-"Jordan";JO;JOR;116;"Al Balqa'";Province;"BA";14979
-"Jordan";JO;JOR;116;"Al Karak";Province;"KA";14984
-"Jordan";JO;JOR;116;"Al Mafraq";Province;"MA";14981
-"Jordan";JO;JOR;116;"Al ‘Aqabah";Province;"AQ";14985
-"Jordan";JO;JOR;116;"At Tafilah";Province;"AT";14975
-"Jordan";JO;JOR;116;"Az Zarqā'";Province;"AZ";14976
-"Jordan";JO;JOR;116;"Irbid";Province;"IR";14986
-"Jordan";JO;JOR;116;"Jarash";Province;"JA";14980
-"Jordan";JO;JOR;116;"Ma`an";Province;"MN";14977
-"Jordan";JO;JOR;116;"Mādabā";Province;"MD";14983
-"Jordan";JO;JOR;116;"‘Ajlūn";Province;"AJ";14982
-"Jordan";JO;JOR;116;"‘Ammān (Al ‘A̅ şimah)";Province;"AM";14978
-"Kazakhstan";KZ;KAZ;117;"Almaty";city;"ALA";14993
-"Kazakhstan";KZ;KAZ;117;"Almaty oblysy";region;"ALM";20264
-"Kazakhstan";KZ;KAZ;117;"Aqmola oblysy";region;"AKM";14991
-"Kazakhstan";KZ;KAZ;117;"Aqtöbe oblysy";region;"AKT";14992
-"Kazakhstan";KZ;KAZ;117;"Astana";city;"AST";20265
-"Kazakhstan";KZ;KAZ;117;"Atyrau oblysy";region;"ATY";14994
-"Kazakhstan";KZ;KAZ;117;"Batys Qazaqstan oblysy";region;"ZAP";14988
-"Kazakhstan";KZ;KAZ;117;"Bayqongyr";city;"BAY";21376
-"Kazakhstan";KZ;KAZ;117;"Mangghystau oblysy";region;"MAN";14995
-"Kazakhstan";KZ;KAZ;117;"Ongtüstik Qazaqstan oblysy";region;"YUZ";14999
-"Kazakhstan";KZ;KAZ;117;"Pavlodar oblysy";region;"PAV";14998
-"Kazakhstan";KZ;KAZ;117;"Qaraghandy oblysy";region;"KAR";14997
-"Kazakhstan";KZ;KAZ;117;"Qostanay oblysy";region;"KUS";15000
-"Kazakhstan";KZ;KAZ;117;"Qyzylorda oblysy";region;"KZY";14990
-"Kazakhstan";KZ;KAZ;117;"Shyghys Qazaqstan oblysy";region;"VOS";14996
-"Kazakhstan";KZ;KAZ;117;"Soltüstik Qazaqstan oblysy";region;"SEV";14989
-"Kazakhstan";KZ;KAZ;117;"Zhambyl oblysy";region;"ZHA";14987
-"Kenya";KE;KEN;118;"Central";province;"200";15009
-"Kenya";KE;KEN;118;"Coast";province;"300";15005
-"Kenya";KE;KEN;118;"Eastern";province;"400";15006
-"Kenya";KE;KEN;118;"Nairobi";province;"110";15010
-"Kenya";KE;KEN;118;"North-Eastern";province;"500";15004
-"Kenya";KE;KEN;118;"Nyanza";province;"600";15001
-"Kenya";KE;KEN;118;"Rift Valley";province;"700";15007
-"Kenya";KE;KEN;118;"Western";province;"900";15003
-"Kiribati";KI;KIR;119;"Gilbert Islands";Island group;"G";19016
-"Kiribati";KI;KIR;119;"Line Islands";Island group;"L";15018
-"Kiribati";KI;KIR;119;"Phoenix Islands";Island group;"P";15033
-"Democratic People's Republic Of Korea";KP;PRK;121;"Chagang-do";province;"04";21370
-"Democratic People's Republic Of Korea";KP;PRK;121;"Chagang-do";province;"CHA";48098
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hamgyong-bukdo";province;"09";21369
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hamgyong-namdo";province;"08";21368
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hamgyongbuk-do";province;"HAB";48096
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hamgyongnam-do";province;"HAN";48095
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hwanghae-bukto";province;"06";21367
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hwanghae-namdo";province;"05";21366
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hwanghaebuk-do";province;"HWB";48092
-"Democratic People's Republic Of Korea";KP;PRK;121;"Hwanghaenam-do";province;"HWN";48091
-"Democratic People's Republic Of Korea";KP;PRK;121;"Kaesong-si";special city;"KAE";21373
-"Democratic People's Republic Of Korea";KP;PRK;121;"Kangwon-do";province;"KAN";48097
-"Democratic People's Republic Of Korea";KP;PRK;121;"Kangwon-do";province;"07";15053
-"Democratic People's Republic Of Korea";KP;PRK;121;"Najin Sonbong-si";special city;"NAJ";21374
-"Democratic People's Republic Of Korea";KP;PRK;121;"Nampo-si";special city;"NAM";21375
-"Democratic People's Republic Of Korea";KP;PRK;121;"Nason";Special City;"13";21371
-"Democratic People's Republic Of Korea";KP;PRK;121;"Pyongan-bukdo";province;"03";21363
-"Democratic People's Republic Of Korea";KP;PRK;121;"Pyongan-namdo";province;"02";21364
-"Democratic People's Republic Of Korea";KP;PRK;121;"Pyonganbuk-do";province;"PYB";48093
-"Democratic People's Republic Of Korea";KP;PRK;121;"Pyongannam-do";province;"PYN";48094
-"Democratic People's Republic Of Korea";KP;PRK;121;"Pyongyang";Capital City;"01";21372
-"Democratic People's Republic Of Korea";KP;PRK;121;"Pyongyang-si";special city;"PYO";48099
-"Democratic People's Republic Of Korea";KP;PRK;121;"Rason";;"X1~";48089
-"Democratic People's Republic Of Korea";KP;PRK;121;"Yanggang-do";province;"10";21365
-"Democratic People's Republic Of Korea";KP;PRK;121;"Yanggang-do";province;"YAN";48090
-"Republic of Korea";KR;KOR;120;"Busan Gwang'yeogsi [Pusan-Kwangyokshi]";metropolitan city;"26";20247
-"Republic of Korea";KR;KOR;120;"Chungcheongbugdo [Ch'ungch'ongbuk-do]";province;"43";20255
-"Republic of Korea";KR;KOR;120;"Chungcheongnamdo [Ch'ungch'ongnam-do]";province;"44";20256
-"Republic of Korea";KR;KOR;120;"Daegu Gwang'yeogsi [Taegu-Kwangyokshi]";metropolitan city;"27";20248
-"Republic of Korea";KR;KOR;120;"Daejeon Gwang'yeogsi [Taejon-Kwangyokshi]";metropolitan city;"30";20251
-"Republic of Korea";KR;KOR;120;"Gang'weondo [Kang-won-do]";province;"42";15042
-"Republic of Korea";KR;KOR;120;"Gwangju Gwang'yeogsi [Kwangju-Kwangyokshi]";metropolitan city;"29";20250
-"Republic of Korea";KR;KOR;120;"Gyeonggido [Kyonggi-do]";province;"41";20253
-"Republic of Korea";KR;KOR;120;"Gyeongsangbugdo [Kyongsangbuk-do]";province;"47";20259
-"Republic of Korea";KR;KOR;120;"Gyeongsangnamdo [Kyongsangnam-do]";province;"48";20260
-"Republic of Korea";KR;KOR;120;"Incheon Gwang'yeogsi [Inch'n-Kwangyokshi]";metropolitan city;"28";20249
-"Republic of Korea";KR;KOR;120;"Jejudo [Cheju-do]";province;"49";20261
-"Republic of Korea";KR;KOR;120;"Jeonrabugdo[Chollabuk-do]";province;"45";20257
-"Republic of Korea";KR;KOR;120;"Jeonranamdo [Chollanam-do]";province;"46";20258
-"Republic of Korea";KR;KOR;120;"Seoul Teugbyeolsi [Seoul-T'ukpyolshi]";capital metropolitan city;"11";20246
-"Republic of Korea";KR;KOR;120;"Ulsan Gwang'yeogsi [Ulsan-Kwangyokshi]";metropolitan city;"31";20252
-"Kuwait";KW;KWT;122;"Al Ahmadi";Governorate;"AH";15064
-"Kuwait";KW;KWT;122;"Al Farwaniyah";Governorate;"FA";15068
-"Kuwait";KW;KWT;122;"Al Jahrah";Governorate;"JA";15063
-"Kuwait";KW;KWT;122;"Al Kuwayt (Al ‘Āşimah)";Governorate;"KU";15066
-"Kuwait";KW;KWT;122;"Hawalli";Governorate;"HA";15067
-"Kuwait";KW;KWT;122;"Mubarak al-Kabir";Governorate;"MU";15065
-"Kyrgyzstan";KG;KGZ;123;"Batken";region;"B";15070
-"Kyrgyzstan";KG;KGZ;123;"Bishkek";city;"GB";15072
-"Kyrgyzstan";KG;KGZ;123;"Chü";region;"C";15078
-"Kyrgyzstan";KG;KGZ;123;"Jalal-Abad";region;"J";15077
-"Kyrgyzstan";KG;KGZ;123;"Naryn";region;"N";15071
-"Kyrgyzstan";KG;KGZ;123;"Osh";region;"O";15069
-"Kyrgyzstan";KG;KGZ;123;"Talas";region;"T";15075
-"Kyrgyzstan";KG;KGZ;123;"Ysyk-Köl";region;"Y";15074
-"Lao People's Democratic Republic";LA;LAO;124;"Attapu [Attopeu]";province;"AT";15080
-"Lao People's Democratic Republic";LA;LAO;124;"Bokèo";province;"BK";15081
-"Lao People's Democratic Republic";LA;LAO;124;"Bolikhamxai [Borikhane]";province;"BL";15089
-"Lao People's Democratic Republic";LA;LAO;124;"Champasak [Champassak]";province;"CH";15082
-"Lao People's Democratic Republic";LA;LAO;124;"Houaphan";province;"HO";15093
-"Lao People's Democratic Republic";LA;LAO;124;"Khammouan";province;"KH";15094
-"Lao People's Democratic Republic";LA;LAO;124;"Louang Namtha";province;"LM";15083
-"Lao People's Democratic Republic";LA;LAO;124;"Louangphabang [Louang Prabang]";province;"LP";15092
-"Lao People's Democratic Republic";LA;LAO;124;"Oudômxai [Oudomsai]";province;"OU";15084
-"Lao People's Democratic Republic";LA;LAO;124;"Phôngsali [Phong Saly]";province;"PH";15085
-"Lao People's Democratic Republic";LA;LAO;124;"Salavan [Saravane]";province;"SL";15091
-"Lao People's Democratic Republic";LA;LAO;124;"Savannakhét";province;"SV";15086
-"Lao People's Democratic Republic";LA;LAO;124;"Vientiane";province;"VI";15095
-"Lao People's Democratic Republic";LA;LAO;124;"Vientiane Prefecture";prefecture;"VT";15087
-"Lao People's Democratic Republic";LA;LAO;124;"Xaignabouli [Sayaboury]";province;"XA";15088
-"Lao People's Democratic Republic";LA;LAO;124;"Xaisômboun";special zone;"XN";15096
-"Lao People's Democratic Republic";LA;LAO;124;"Xiangkhoang [Xieng Khouang]";province;"XI";15079
-"Lao People's Democratic Republic";LA;LAO;124;"Xékong [Sékong]";province;"XE";15090
-"Latvia";LV;LVA;125;"Aglonas novads (Aglona)";District;"001";48896
-"Latvia";LV;LVA;125;"Aizkraukles Aprinkis";district;"AI";15106
-"Latvia";LV;LVA;125;"Aizkraukles novads (Aizkraukle)";District;"002";48728
-"Latvia";LV;LVA;125;"Aizputes novads (Aizpute)";District;"003";48729
-"Latvia";LV;LVA;125;"Aknīstes novads (Aknīste)";District;"004";48730
-"Latvia";LV;LVA;125;"Alojas novads (Aloja)";District;"005";48731
-"Latvia";LV;LVA;125;"Alsungas novads (Alsunga)";District;"006";48732
-"Latvia";LV;LVA;125;"Aluksnes Aprinkis";district;"AL";15107
-"Latvia";LV;LVA;125;"Alūksnes novads (Alūksne)";District;"007";48733
-"Latvia";LV;LVA;125;"Amatas novads (Amata)";District;"008";48734
-"Latvia";LV;LVA;125;"Apes novads (Ape)";District;"009";48735
-"Latvia";LV;LVA;125;"Auces novads (Auce)";District;"010";48736
-"Latvia";LV;LVA;125;"Babītes novads (Babīte)";District;"012";48738
-"Latvia";LV;LVA;125;"Baldones novads (Baldone)";District;"013";48739
-"Latvia";LV;LVA;125;"Baltinavas novads (Baltinava)";District;"014";48740
-"Latvia";LV;LVA;125;"Balvu Aprinkis";district;"BL";15108
-"Latvia";LV;LVA;125;"Balvu novads (Balvi)";District;"015";48741
-"Latvia";LV;LVA;125;"Bauskas Aprinkis";district;"BU";15109
-"Latvia";LV;LVA;125;"Bauskas novads (Bauska)";District;"016";48742
-"Latvia";LV;LVA;125;"Beverīnas novads (Beverīna)";District;"017";48743
-"Latvia";LV;LVA;125;"Brocēnu novads (Brocēni)";District;"018";48744
-"Latvia";LV;LVA;125;"Burtnieku novads (Burtnieki)";District;"019";48745
-"Latvia";LV;LVA;125;"Carnikavas novads (Carnikava)";District;"020";48746
-"Latvia";LV;LVA;125;"Cesu Aprinkis";district;"CE";15110
-"Latvia";LV;LVA;125;"Cesvaines novads (Cesvaine)";District;"021";48747
-"Latvia";LV;LVA;125;"Ciblas novads (Cibla)";District;"023";48749
-"Latvia";LV;LVA;125;"Cēsu novads (Cēsis)";District;"022";48748
-"Latvia";LV;LVA;125;"Dagdas novads (Dagda)";District;"024";48750
-"Latvia";LV;LVA;125;"Daugavpils";city;"DGV";15111
-"Latvia";LV;LVA;125;"Daugavpils Aprinkis";district;"DA";15112
-"Latvia";LV;LVA;125;"Daugavpils novads (Daugavpils)";District;"025";48751
-"Latvia";LV;LVA;125;"Dobeles Aprinkis";district;"DO";15113
-"Latvia";LV;LVA;125;"Dobeles novads (Dobele)";District;"026";48752
-"Latvia";LV;LVA;125;"Dundagas novads (Dundaga)";District;"027";48753
-"Latvia";LV;LVA;125;"Durbes novads (Durbe)";District;"028";48754
-"Latvia";LV;LVA;125;"Engures novads (Engure)";District;"029";48755
-"Latvia";LV;LVA;125;"Garkalnes novads (Garkalne)";District;"031";48757
-"Latvia";LV;LVA;125;"Grobiņas novads (Grobiņa)";District;"032";48758
-"Latvia";LV;LVA;125;"Gulbenes Aprinkis";district;"GU";15124
-"Latvia";LV;LVA;125;"Gulbenes novads (Gulbene)";District;"033";48759
-"Latvia";LV;LVA;125;"Iecavas novads (Iecava)";District;"034";48760
-"Latvia";LV;LVA;125;"Ikšķiles novads (Ikšķile)";District;"035";48761
-"Latvia";LV;LVA;125;"Ilūkstes novads (Ilūkste)";District;"036";48762
-"Latvia";LV;LVA;125;"Inčukalna novads (Inčukalns)";District;"037";48763
-"Latvia";LV;LVA;125;"Jaunjelgavas novads (Jaunjelgava)";District;"038";48764
-"Latvia";LV;LVA;125;"Jaunpiebalgas novads (Jaunpiebalga)";District;"039";48765
-"Latvia";LV;LVA;125;"Jaunpils novads (Jaunpils)";District;"040";48766
-"Latvia";LV;LVA;125;"Jekabpils Aprinkis";district;"JK";15114
-"Latvia";LV;LVA;125;"Jelgava";city;"JEL";15125
-"Latvia";LV;LVA;125;"Jelgavas Aprinkis";district;"JL";15126
-"Latvia";LV;LVA;125;"Jelgavas novads (Jelgava)";District;"041";48767
-"Latvia";LV;LVA;125;"Jurmala";city;"JUR";15127
-"Latvia";LV;LVA;125;"Jēkabpils";City;"JKB";48838
-"Latvia";LV;LVA;125;"Jēkabpils novads (Jēkabpils)";District;"042";48768
-"Latvia";LV;LVA;125;"Kandavas novads (Kandava)";District;"043";48769
-"Latvia";LV;LVA;125;"Kocēnu novads";District;"045";48771
-"Latvia";LV;LVA;125;"Kokneses novads (Koknese)";District;"046";48772
-"Latvia";LV;LVA;125;"Kraslavas Aprinkis";district;"KR";15115
-"Latvia";LV;LVA;125;"Krimuldas novads (Krimulda)";District;"048";48774
-"Latvia";LV;LVA;125;"Krustpils novads (Krustpils)";District;"049";48775
-"Latvia";LV;LVA;125;"Krāslavas novads (Krāslava)";District;"047";48773
-"Latvia";LV;LVA;125;"Kuldigas Aprinkis";district;"KU";15116
-"Latvia";LV;LVA;125;"Kuldīgas novads (Kuldīga)";District;"050";48776
-"Latvia";LV;LVA;125;"Kārsavas novads (Kārsava)";District;"044";48770
-"Latvia";LV;LVA;125;"Lielvārdes novads (Lielvārde)";District;"053";48779
-"Latvia";LV;LVA;125;"Liepaja";city;"LPX";15128
-"Latvia";LV;LVA;125;"Liepajas Aprinkis";district;"LE";15117
-"Latvia";LV;LVA;125;"Limbažu Aprinkis";district;"LM";15118
-"Latvia";LV;LVA;125;"Limbažu novads (Limbaži)";District;"054";48781
-"Latvia";LV;LVA;125;"Lubānas novads (Lubāna)";District;"057";48784
-"Latvia";LV;LVA;125;"Ludzas Aprinkis";district;"LU";15123
-"Latvia";LV;LVA;125;"Ludzas novads (Ludza)";District;"058";48785
-"Latvia";LV;LVA;125;"Līgatnes novads (Līgatne)";District;"055";48782
-"Latvia";LV;LVA;125;"Līvānu novads (Līvāni)";District;"056";48783
-"Latvia";LV;LVA;125;"Madonas Aprinkis";district;"MA";15119
-"Latvia";LV;LVA;125;"Madonas novads (Madona)";District;"059";48786
-"Latvia";LV;LVA;125;"Mazsalacas novads (Mazsalaca)";District;"060";48787
-"Latvia";LV;LVA;125;"Mālpils novads (Mālpils)";District;"061";48788
-"Latvia";LV;LVA;125;"Mārupes novads (Mārupe)";District;"062";48789
-"Latvia";LV;LVA;125;"Mērsraga novads";District;"063";48790
-"Latvia";LV;LVA;125;"Naukšēnu novads (Naukšēni)";District;"064";48791
-"Latvia";LV;LVA;125;"Neretas novads (Nereta)";District;"065";48792
-"Latvia";LV;LVA;125;"Nīcas novads (Nīca)";District;"066";48793
-"Latvia";LV;LVA;125;"Ogres Aprinkis";district;"OG";15098
-"Latvia";LV;LVA;125;"Ogres novads (Ogre)";District;"067";48794
-"Latvia";LV;LVA;125;"Olaines novads (Olaine)";District;"068";48795
-"Latvia";LV;LVA;125;"Ozolnieku novads (Ozolnieki)";District;"069";48796
-"Latvia";LV;LVA;125;"Preilu Aprinkis";district;"PR";15122
-"Latvia";LV;LVA;125;"Preiļu novads (Preiļi)";District;"073";48800
-"Latvia";LV;LVA;125;"Priekules novads (Priekule)";District;"074";48801
-"Latvia";LV;LVA;125;"Priekuļu novads (Priekuļi)";District;"075";48802
-"Latvia";LV;LVA;125;"Pārgaujas novads (Pārgauja)";District;"070";48797
-"Latvia";LV;LVA;125;"Pāvilostas novads (Pāvilosta)";District;"071";48798
-"Latvia";LV;LVA;125;"Pļaviņu novads (Pļaviņas)";District;"072";48799
-"Latvia";LV;LVA;125;"Raunas novads (Rauna)";District;"076";48803
-"Latvia";LV;LVA;125;"Rezekne";city;"REZ";15099
-"Latvia";LV;LVA;125;"Rezeknes Aprinkis";district;"RE";15100
-"Latvia";LV;LVA;125;"Riebiņu novads (Riebiņi)";District;"078";48805
-"Latvia";LV;LVA;125;"Riga";city;"RIX";15121
-"Latvia";LV;LVA;125;"Rigas Aprinkis";district;"RI";15101
-"Latvia";LV;LVA;125;"Rojas novads (Roja)";District;"079";48806
-"Latvia";LV;LVA;125;"Ropažu novads (Ropaži)";District;"080";48807
-"Latvia";LV;LVA;125;"Rucavas novads (Rucava)";District;"081";48808
-"Latvia";LV;LVA;125;"Rugāju novads (Rugāji)";District;"082";48809
-"Latvia";LV;LVA;125;"Rundāles novads (Rundāle)";District;"083";48810
-"Latvia";LV;LVA;125;"Rēzeknes novads (Rēzekne)";District;"077";48804
-"Latvia";LV;LVA;125;"Rūjienas novads (Rūjiena)";District;"084";48811
-"Latvia";LV;LVA;125;"Salacgrīvas novads (Salacgrīva)";District;"086";48813
-"Latvia";LV;LVA;125;"Salas novads (Sala)";District;"085";48812
-"Latvia";LV;LVA;125;"Salaspils novads (Salaspils)";District;"087";48814
-"Latvia";LV;LVA;125;"Saldus Aprinkis";district;"SA";15102
-"Latvia";LV;LVA;125;"Saldus novads (Saldus)";District;"088";48815
-"Latvia";LV;LVA;125;"Saulkrastu novads (Saulkrasti)";District;"089";48816
-"Latvia";LV;LVA;125;"Siguldas novads (Sigulda)";District;"091";48818
-"Latvia";LV;LVA;125;"Skrundas novads (Skrunda)";District;"093";48820
-"Latvia";LV;LVA;125;"Skrīveru novads (Skrīveri)";District;"092";48819
-"Latvia";LV;LVA;125;"Smiltenes novads (Smiltene)";District;"094";48821
-"Latvia";LV;LVA;125;"Stopiņu novads (Stopiņi)";District;"095";48822
-"Latvia";LV;LVA;125;"Strenču novads (Strenči)";District;"096";48823
-"Latvia";LV;LVA;125;"Sējas novads (Sēja)";District;"090";48817
-"Latvia";LV;LVA;125;"Talsu Aprinkis";district;"TA";15129
-"Latvia";LV;LVA;125;"Talsu novads (Talsi)";District;"097";48824
-"Latvia";LV;LVA;125;"Tukuma Aprinkis";district;"TU";15103
-"Latvia";LV;LVA;125;"Tukuma novads (Tukums)";District;"099";48826
-"Latvia";LV;LVA;125;"Tērvetes novads (Tērvete)";District;"098";48825
-"Latvia";LV;LVA;125;"Vaiņodes novads (Vaiņode)";District;"100";48827
-"Latvia";LV;LVA;125;"Valkas Aprinkis";district;"VK";15104
-"Latvia";LV;LVA;125;"Valkas novads (Valka)";District;"101";48828
-"Latvia";LV;LVA;125;"Valmiera";city;"VMR";48839
-"Latvia";LV;LVA;125;"Valmieras Aprinkis";district;"VM";15130
-"Latvia";LV;LVA;125;"Varakļānu novads (Varakļāni)";District;"102";48829
-"Latvia";LV;LVA;125;"Vecpiebalgas novads (Vecpiebalga)";District;"104";48831
-"Latvia";LV;LVA;125;"Vecumnieku novads (Vecumnieki)";District;"105";48832
-"Latvia";LV;LVA;125;"Ventspils";city;"VEN";15105
-"Latvia";LV;LVA;125;"Ventspils Aprinkis";district;"VE";15097
-"Latvia";LV;LVA;125;"Ventspils novads (Ventspils)";District;"106";48833
-"Latvia";LV;LVA;125;"Viesītes novads (Viesīte)";District;"107";48834
-"Latvia";LV;LVA;125;"Viļakas novads (Viļaka)";District;"108";48835
-"Latvia";LV;LVA;125;"Viļānu novads (Viļāni)";District;"109";48836
-"Latvia";LV;LVA;125;"Vārkavas novads (Vārkava)";District;"103";48830
-"Latvia";LV;LVA;125;"Zilupes novads (Zilupe)";District;"110";48837
-"Latvia";LV;LVA;125;"Ādažu novads (Ādaži)";District;"011";48737
-"Latvia";LV;LVA;125;"Ērgļu novads (Ērgļi)";District;"030";48756
-"Latvia";LV;LVA;125;"Ķeguma novads (Ķegums)";District;"051";48777
-"Latvia";LV;LVA;125;"Ķekavas novads (Ķekava)";District;"052";48778
-"Lebanon";LB;LBN;126;"Aakkar";Province;"AK";48255
-"Lebanon";LB;LBN;126;"Baalbek-Hermel";Province;"BH";48256
-"Lebanon";LB;LBN;126;"Beirut";Province;"BA";15134
-"Lebanon";LB;LBN;126;"El Béqaa";Province;"BI";15135
-"Lebanon";LB;LBN;126;"Jabal Loubnâne";Province;"JL";15133
-"Lebanon";LB;LBN;126;"Loubnâne ech Chemâli";Province;"AS";15131
-"Lebanon";LB;LBN;126;"Loubnâne ej Jnoûbi";Province;"JA";15136
-"Lebanon";LB;LBN;126;"Nabatîyé";Province;"NA";15132
-"Lesotho";LS;LSO;127;"Berea";District;"D";15138
-"Lesotho";LS;LSO;127;"Butha-Buthe";District;"B";15139
-"Lesotho";LS;LSO;127;"Leribe";District;"C";15145
-"Lesotho";LS;LSO;127;"Mafeteng";District;"E";15140
-"Lesotho";LS;LSO;127;"Maseru";District;"A";15146
-"Lesotho";LS;LSO;127;"Mohale's Hoek";District;"F";15141
-"Lesotho";LS;LSO;127;"Mokhotlong";District;"J";15142
-"Lesotho";LS;LSO;127;"Qacha's Nek";District;"H";15137
-"Lesotho";LS;LSO;127;"Quthing";District;"G";15143
-"Lesotho";LS;LSO;127;"Thaba-Tseka";District;"K";15144
-"Liberia";LR;LBR;128;"Bomi";County;"BM";15152
-"Liberia";LR;LBR;128;"Bong";County;"BG";15148
-"Liberia";LR;LBR;128;"Gbarpolu";County;"X1~";19021
-"Liberia";LR;LBR;128;"Grand Bassa";County;"GB";15153
-"Liberia";LR;LBR;128;"Grand Cape Mount";County;"CM";15156
-"Liberia";LR;LBR;128;"Grand Gedeh";County;"GG";15151
-"Liberia";LR;LBR;128;"Grand Kru";County;"GK";19023
-"Liberia";LR;LBR;128;"Lofa";County;"LO";15154
-"Liberia";LR;LBR;128;"Margibi";County;"MG";15158
-"Liberia";LR;LBR;128;"Maryland";County;"MY";15150
-"Liberia";LR;LBR;128;"Montserrado";County;"MO";15157
-"Liberia";LR;LBR;128;"Nimba";County;"NI";15155
-"Liberia";LR;LBR;128;"River Gee";County;"X2~";19022
-"Liberia";LR;LBR;128;"Rivercess";County;"RI";15149
-"Liberia";LR;LBR;128;"Sinoe";County;"SI";15147
-"Libya";LY;LBY;129;"Ajdabiya";;"AJ";15169
-"Libya";LY;LBY;129;"Al ?izam al Akh?ar";;"HZ";15180
-"Libya";LY;LBY;129;"Al Butnan";popularate;"BU";15171
-"Libya";LY;LBY;129;"Al Jabal al Akh?ar";popularate;"JA";15174
-"Libya";LY;LBY;129;"Al Jabal al Gharbī";popularate;"JG";48229
-"Libya";LY;LBY;129;"Al Jifarah";popularate;"JI";15181
-"Libya";LY;LBY;129;"Al Jufrah";popularate;"JU";15175
-"Libya";LY;LBY;129;"Al Kufrah";popularate;"KF";15176
-"Libya";LY;LBY;129;"Al Marj";popularate;"MJ";15182
-"Libya";LY;LBY;129;"Al Marqab";popularate;"MB";15160
-"Libya";LY;LBY;129;"Al Qatrun";;"QT";20297
-"Libya";LY;LBY;129;"Al Qubbah";;"QB";15163
-"Libya";LY;LBY;129;"Al Wāḩāt";popularate;"WA";15167
-"Libya";LY;LBY;129;"An Nuqat al Khams";popularate;"NQ";15185
-"Libya";LY;LBY;129;"Ash Shati'";District;"SH";15189
-"Libya";LY;LBY;129;"Az Zawiyah";popularate;"ZA";15168
-"Libya";LY;LBY;129;"Banghazi";popularate;"BA";15177
-"Libya";LY;LBY;129;"Bani Walid";;"BW";15170
-"Libya";LY;LBY;129;"Darnah";popularate;"DR";15178
-"Libya";LY;LBY;129;"Ghadamis";;"GD";15172
-"Libya";LY;LBY;129;"Gharyan";;"GR";15179
-"Libya";LY;LBY;129;"Ghat";popularate;"GT";15173
-"Libya";LY;LBY;129;"Jaghbub";;"JB";20286
-"Libya";LY;LBY;129;"Misratah";popularate;"MI";15161
-"Libya";LY;LBY;129;"Mizdah";;"MZ";15187
-"Libya";LY;LBY;129;"Murzuq";popularate;"MQ";15186
-"Libya";LY;LBY;129;"Nalut";popularate;"NL";15162
-"Libya";LY;LBY;129;"Sabha";popularate;"SB";15184
-"Libya";LY;LBY;129;"Sabratah Surman";;"SS";15164
-"Libya";LY;LBY;129;"Surt";popularate;"SR";15183
-"Libya";LY;LBY;129;"Tajura' wa an Nawahi Arba";;"TN";20303
-"Libya";LY;LBY;129;"Tarabulus";popularate;"TB";15165
-"Libya";LY;LBY;129;"Tarhunah-Masallatah";;"TM";15188
-"Libya";LY;LBY;129;"Wadi al ?ayat";popularate;"WD";15166
-"Libya";LY;LBY;129;"Wādī ash Shāţiʾ";popularate;"WS";48230
-"Libya";LY;LBY;129;"Yafran-Jadu";;"YJ";15159
-"Liechtenstein";LI;LIE;130;"Balzers";Commune;"01";15193
-"Liechtenstein";LI;LIE;130;"Eschen";Commune;"02";15194
-"Liechtenstein";LI;LIE;130;"Gamprin";Commune;"03";15192
-"Liechtenstein";LI;LIE;130;"Mauren";Commune;"04";15195
-"Liechtenstein";LI;LIE;130;"Planken";Commune;"05";15196
-"Liechtenstein";LI;LIE;130;"Ruggell";Commune;"06";15191
-"Liechtenstein";LI;LIE;130;"Schaan";Commune;"07";15197
-"Liechtenstein";LI;LIE;130;"Schellenberg";Commune;"08";15200
-"Liechtenstein";LI;LIE;130;"Triesen";Commune;"09";15198
-"Liechtenstein";LI;LIE;130;"Triesenberg";Commune;"10";15199
-"Liechtenstein";LI;LIE;130;"Vaduz";Commune;"11";15190
-"Lithuania";LT;LTU;131;"Alytaus Apskritis";County;"AL";15209
-"Lithuania";LT;LTU;131;"Kauno Apskritis";County;"KU";15205
-"Lithuania";LT;LTU;131;"Klaipedos Apskritis";County;"KL";15208
-"Lithuania";LT;LTU;131;"Marijampoles Apskritis";County;"MR";15206
-"Lithuania";LT;LTU;131;"Panevežio Apskritis";County;"PN";15202
-"Lithuania";LT;LTU;131;"Taurages Apskritis";County;"TA";15210
-"Lithuania";LT;LTU;131;"Telšiu Apskritis";County;"TE";15207
-"Lithuania";LT;LTU;131;"Utenos Apskritis";County;"UT";15203
-"Lithuania";LT;LTU;131;"Vilniaus Apskritis";County;"VL";15201
-"Lithuania";LT;LTU;131;"Šiauliu Apskritis";County;"SA";15204
-"Luxembourg";LU;LUX;132;"Diekirch";District;"D";15216
-"Luxembourg";LU;LUX;132;"Grevenmacher";District;"G";15215
-"Luxembourg";LU;LUX;132;"Luxembourg (fr)";District;"L";15220
-"Macao";MO;MAC;133;"Ilhas";;"I";48266
-"Macao";MO;MAC;133;"Macau";;"M";48267
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Aerodrom";municipality;"01";48906
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Aerodrom *";Municipality;"AD";20121
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Aracinovo";Municipality;"AR";20122
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Aračinovo";municipality;"02";48907
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Berovo";Municipality;"BR";15224
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Berovo";municipality;"03";48908
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bitola";municipality;"04";48909
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bitola";Municipality;"TL";15225
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bogdanci";municipality;"05";48910
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bogdanci";Municipality;"BG";20123
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bogovinje";municipality;"06";48911
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bogovinje";Municipality;"VJ";20124
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bosilovo";Municipality;"BS";20125
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Bosilovo";municipality;"07";48912
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Brvenica";Municipality;"BN";20126
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Brvenica";municipality;"08";48913
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Butel";municipality;"09";48914
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Butel *";Municipality;"BU";20127
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Cair *";Municipality;"CI";20128
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Caška";Municipality;"CA";20129
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Centar";municipality;"77";48915
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Centar *";Municipality;"CE";20130
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Centar Župa";Municipality;"CZ";20131
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Centar Župa";municipality;"78";48916
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Cešinovo-Obleševo";Municipality;"CH";20132
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Cucer Sandevo";Municipality;"CS";20133
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Debar";Municipality;"DB";15227
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Debar";municipality;"21";48921
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Debarca";municipality;"22";48922
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Debarca";Municipality;"DA";20138
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Delcevo";Municipality;"DL";15228
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Delčevo";municipality;"23";48923
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Hisar";municipality;"25";48924
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Hisar";Municipality;"DM";15229
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Kapija";Municipality;"DK";20134
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Kapija";municipality;"24";48925
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Dojran";Municipality;"SD";20135
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Dojran";municipality;"26";48926
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Dolneni";municipality;"27";48927
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Dolneni";Municipality;"DE";20136
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Drugovo";Municipality;"DR";20137
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Drugovo";municipality;"28";48928
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gazi Baba";municipality;"17";48929
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gazi Baba *";Municipality;"GB";20310
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gevgelija";municipality;"18";48930
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gevgelija";Municipality;"GV";15230
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gjorce Petrov *";Municipality;"GP";20311
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gjorče Petrov";municipality;"29";48931
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gostivar";municipality;"19";48932
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gostivar";Municipality;"GT";15233
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gradsko";Municipality;"GR";20312
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gradsko";municipality;"20";48933
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Ilinden";Municipality;"IL";20313
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Ilinden";municipality;"34";48934
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Jegunovce";Municipality;"JG";20314
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Jegunovce";municipality;"35";48935
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Karbinci";municipality;"37";48936
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Karbinci";Municipality;"KB";20315
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Karpoš";municipality;"38";48937
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Karpoš *";Municipality;"KX";20316
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kavadarci";municipality;"36";48938
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kavadarci";Municipality;"AV";15231
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kicevo";Municipality;"KH";15234
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kisela Voda";municipality;"39";48940
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kisela Voda *";Municipality;"VD";20139
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kičevo";municipality;"40";48939
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kocani";Municipality;"OC";15232
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Konce";Municipality;"KN";20140
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Konče";municipality;"41";48942
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kočani";municipality;"42";48941
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kratovo";municipality;"43";48943
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kratovo";Municipality;"KY";15235
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kriva Palanka";Municipality;"KZ";15249
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kriva Palanka";municipality;"44";48944
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Krivogaštani";municipality;"45";48945
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Krivogaštani";Municipality;"KG";20141
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kruševo";municipality;"46";48946
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kruševo";Municipality;"KS";15236
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kumanovo";municipality;"47";48947
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kumanovo";Municipality;"UM";15250
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Lipkovo";Municipality;"LI";20142
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Lipkovo";municipality;"48";48948
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Lozovo";Municipality;"LO";20143
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Lozovo";municipality;"49";48949
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonska Kamenica";municipality;"51";48950
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonska Kamenica";Municipality;"MK";20144
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonski Brod";municipality;"52";48951
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonski Brod";Municipality;"MD";20145
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Mavrovo i Rostuša";municipality;"50";48952
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Mavrovo-i-Rostuša";Municipality;"MR";20146
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Mogila";Municipality;"MG";20147
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Mogila";municipality;"53";48953
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Negotino";municipality;"54";48954
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Negotino";Municipality;"NG";15237
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Novaci";Municipality;"NV";20148
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Novaci";municipality;"55";48955
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Novo Selo";Municipality;"NS";20149
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Novo Selo";municipality;"56";48956
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Ohrid";municipality;"58";48957
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Ohrid";Municipality;"OD";15238
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Oslomej";Municipality;"OS";20150
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Oslomej";municipality;"57";48958
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Pehcevo";Municipality;"PH";20151
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Pehčevo";municipality;"60";48959
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Petrovec";municipality;"59";48960
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Petrovec";Municipality;"PE";20152
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Plasnica";municipality;"61";48961
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Plasnica";Municipality;"PN";20153
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Prilep";Municipality;"PP";15248
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Prilep";municipality;"62";48962
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Probištip";Municipality;"PT";15239
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Probištip";municipality;"63";48963
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Radoviš";Municipality;"RV";15247
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Radoviš";municipality;"64";48964
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Rankovce";Municipality;"RN";20154
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Rankovce";municipality;"65";48965
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Resen";municipality;"66";48966
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Resen";Municipality;"RE";15240
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Rosoman";municipality;"67";48967
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Rosoman";Municipality;"RM";20155
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Saraj";municipality;"68";48968
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Saraj *";Municipality;"AJ";20156
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Skopje";;"X1~";15246
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Sopište";municipality;"70";48969
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Sopište";Municipality;"SS";20157
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Staro Nagoricane";Municipality;"NA";20158
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Staro Nagoričane";municipality;"71";48970
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Struga";Municipality;"UG";15242
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Struga";municipality;"72";48971
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Strumica";municipality;"73";48972
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Strumica";Municipality;"RU";15251
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Studenicani";Municipality;"SU";20159
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Studeničani";municipality;"74";48973
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Sveti Nikole";Municipality;"SL";15243
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Sveti Nikole";municipality;"69";48974
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Tearce";municipality;"75";48977
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Tearce";Municipality;"TR";20160
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Tetovo";Municipality;"ET";15252
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Tetovo";municipality;"76";48978
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Valandovo";municipality;"10";48979
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Valandovo";Municipality;"VA";15244
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vasilevo";municipality;"11";48980
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vasilevo";Municipality;"VL";20161
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Veles";Municipality;"VE";15223
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Veles";municipality;"13";48981
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vevcani";Municipality;"VV";20162
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vevčani";municipality;"12";48982
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vinica";municipality;"14";48983
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vinica";Municipality;"NI";15245
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vraneštica";municipality;"15";48984
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vraneštica";Municipality;"VC";20163
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vrapcište";Municipality;"VH";20164
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Vrapčište";municipality;"16";48985
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Zajas";municipality;"31";48986
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Zajas";Municipality;"ZA";20165
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Zelenikovo";municipality;"32";48987
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Zelenikovo";Municipality;"ZK";20166
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Zrnovci";municipality;"33";48988
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Zrnovci";Municipality;"ZR";20167
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Čair";municipality;"79";48917
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Čaška";municipality;"80";48918
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Češinovo-Obleševo";municipality;"81";48919
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Čučer Sandevo";municipality;"82";48920
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Štip";municipality;"83";48975
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Štip";Municipality;"ST";15241
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Šuto Orizari";municipality;"84";48976
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Šuto Orizari *";Municipality;"SO";20169
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Želino";municipality;"30";48989
-"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Želino";Municipality;"ZE";20170
-"Madagascar";MG;MDG;135;"Antananarivo";Province;"T";15255
-"Madagascar";MG;MDG;135;"Antsiranana";Province;"D";15254
-"Madagascar";MG;MDG;135;"Fianarantsoa";Province;"F";15258
-"Madagascar";MG;MDG;135;"Mahajanga";Province;"M";15257
-"Madagascar";MG;MDG;135;"Toamasina";Province;"A";15253
-"Madagascar";MG;MDG;135;"Toliara";Province;"U";15256
-"Malawi";MW;MWI;136;"Balaka";District;"BA";15279
-"Malawi";MW;MWI;136;"Blantyre";District;"BL";15261
-"Malawi";MW;MWI;136;"Central Region";region;"C";48232
-"Malawi";MW;MWI;136;"Chikwawa";District;"CK";15280
-"Malawi";MW;MWI;136;"Chiradzulu";District;"CR";15262
-"Malawi";MW;MWI;136;"Chitipa";District;"CT";15281
-"Malawi";MW;MWI;136;"Dedza";District;"DE";15263
-"Malawi";MW;MWI;136;"Dowa";District;"DO";15264
-"Malawi";MW;MWI;136;"Karonga";District;"KR";15285
-"Malawi";MW;MWI;136;"Kasungu";District;"KS";15265
-"Malawi";MW;MWI;136;"Likoma";District;"LK";19024
-"Malawi";MW;MWI;136;"Lilongwe";District;"LI";15286
-"Malawi";MW;MWI;136;"Machinga";District;"MH";15267
-"Malawi";MW;MWI;136;"Mangochi";District;"MG";15268
-"Malawi";MW;MWI;136;"Mchinji";District;"MC";15284
-"Malawi";MW;MWI;136;"Mulanje";District;"MU";15269
-"Malawi";MW;MWI;136;"Mwanza";District;"MW";15270
-"Malawi";MW;MWI;136;"Mzimba";District;"MZ";15283
-"Malawi";MW;MWI;136;"Neno";district;"NE";48231
-"Malawi";MW;MWI;136;"Nkhata Bay";District;"NB";15282
-"Malawi";MW;MWI;136;"Nkhotakota";District;"NK";15272
-"Malawi";MW;MWI;136;"Northern Region";region;"N";48233
-"Malawi";MW;MWI;136;"Nsanje";District;"NS";15273
-"Malawi";MW;MWI;136;"Ntcheu";District;"NU";15287
-"Malawi";MW;MWI;136;"Ntchisi";District;"NI";15274
-"Malawi";MW;MWI;136;"Phalombe";District;"PH";15275
-"Malawi";MW;MWI;136;"Rumphi";District;"RU";15288
-"Malawi";MW;MWI;136;"Salima";District;"SA";15276
-"Malawi";MW;MWI;136;"Southern Region";region;"S";48234
-"Malawi";MW;MWI;136;"Thyolo";District;"TH";15277
-"Malawi";MW;MWI;136;"Zomba";District;"ZO";15278
-"Malaysia";MY;MYS;137;"Johor";state;"01";15290
-"Malaysia";MY;MYS;137;"Kedah";state;"02";15299
-"Malaysia";MY;MYS;137;"Kelantan";state;"03";15291
-"Malaysia";MY;MYS;137;"Melaka";state;"04";15293
-"Malaysia";MY;MYS;137;"Negeri Sembilan";state;"05";15301
-"Malaysia";MY;MYS;137;"Pahang";state;"06";15294
-"Malaysia";MY;MYS;137;"Perak";state;"08";15295
-"Malaysia";MY;MYS;137;"Perlis";state;"09";15302
-"Malaysia";MY;MYS;137;"Pulau Pinang";state;"07";15296
-"Malaysia";MY;MYS;137;"Sabah";state;"12";15297
-"Malaysia";MY;MYS;137;"Sarawak";state;"13";15303
-"Malaysia";MY;MYS;137;"Selangor";state;"10";15298
-"Malaysia";MY;MYS;137;"Terengganu";state;"11";15289
-"Malaysia";MY;MYS;137;"Wilayah Persekutuan Kuala Lumpur";federal territory;"14";15300
-"Malaysia";MY;MYS;137;"Wilayah Persekutuan Labuan";federal territory;"15";15292
-"Malaysia";MY;MYS;137;"Wilayah Persekutuan Putrajaya";federal territory;"16";19025
-"Maldives";MV;MDV;138;"Alif";administrative atoll;"02";15307
-"Maldives";MV;MDV;138;"Alif Dhaal";;"X1~";48268
-"Maldives";MV;MDV;138;"Alif Dhaal";;"00";15308
-"Maldives";MV;MDV;138;"Baa";administrative atoll;"20";15309
-"Maldives";MV;MDV;138;"Central";Province;"CE";48272
-"Maldives";MV;MDV;138;"Dhaalu";administrative atoll;"17";15310
-"Maldives";MV;MDV;138;"Faafu";administrative atoll;"14";15311
-"Maldives";MV;MDV;138;"Gaaf Alif";administrative atoll;"27";15312
-"Maldives";MV;MDV;138;"Gaafu Dhaalu";administrative atoll;"28";15313
-"Maldives";MV;MDV;138;"Gnaviyani";administrative atoll;"29";15306
-"Maldives";MV;MDV;138;"Haa Alif";administrative atoll;"07";15314
-"Maldives";MV;MDV;138;"Haa Dhaalu";administrative atoll;"23";15315
-"Maldives";MV;MDV;138;"Kaafu";administrative atoll;"26";15305
-"Maldives";MV;MDV;138;"Laamu";administrative atoll;"05";15316
-"Maldives";MV;MDV;138;"Lhaviyani";administrative atoll;"03";15321
-"Maldives";MV;MDV;138;"Male";capital;"MLE";15317
-"Maldives";MV;MDV;138;"Meemu";administrative atoll;"12";15324
-"Maldives";MV;MDV;138;"Noonu";administrative atoll;"25";15323
-"Maldives";MV;MDV;138;"North";Province;"NO";48275
-"Maldives";MV;MDV;138;"North Central";Province;"NC";48274
-"Maldives";MV;MDV;138;"Raa";administrative atoll;"13";15318
-"Maldives";MV;MDV;138;"Seenu";administrative atoll;"01";15319
-"Maldives";MV;MDV;138;"Shaviyani";administrative atoll;"24";15322
-"Maldives";MV;MDV;138;"South";Province;"SU";48269
-"Maldives";MV;MDV;138;"South Central";Province;"SC";48273
-"Maldives";MV;MDV;138;"Thaa";administrative atoll;"08";15304
-"Maldives";MV;MDV;138;"Upper North";Province;"UN";48271
-"Maldives";MV;MDV;138;"Upper South";Province;"US";48270
-"Maldives";MV;MDV;138;"Vaavu";administrative atoll;"04";15320
-"Mali";ML;MLI;139;"Bamako";district;"BKO";15327
-"Mali";ML;MLI;139;"Gao";region;"7";15329
-"Mali";ML;MLI;139;"Kayes";region;"1";15330
-"Mali";ML;MLI;139;"Kidal";region;"8";15328
-"Mali";ML;MLI;139;"Koulikoro";region;"2";15331
-"Mali";ML;MLI;139;"Mopti";region;"5";15326
-"Mali";ML;MLI;139;"Sikasso";region;"3";15333
-"Mali";ML;MLI;139;"Ségou";region;"4";15332
-"Mali";ML;MLI;139;"Tombouctou";region;"6";15325
-"Marshall Islands";MH;MHL;141;"Ailinglaplap";Municipality;"ALL";15362
-"Marshall Islands";MH;MHL;141;"Ailuk";Municipality;"ALK";15347
-"Marshall Islands";MH;MHL;141;"Arno";Municipality;"ARN";15348
-"Marshall Islands";MH;MHL;141;"Aur";Municipality;"AUR";15363
-"Marshall Islands";MH;MHL;141;"Ebon";Municipality;"EBO";15351
-"Marshall Islands";MH;MHL;141;"Enewetak";Municipality;"ENI";15365
-"Marshall Islands";MH;MHL;141;"Jabat";Municipality;"JAB";48101
-"Marshall Islands";MH;MHL;141;"Jaluit";Municipality;"JAL";15353
-"Marshall Islands";MH;MHL;141;"Kili";Municipality;"KIL";15367
-"Marshall Islands";MH;MHL;141;"Kwajalein";Municipality;"KWA";15355
-"Marshall Islands";MH;MHL;141;"Lae";Municipality;"LAE";15368
-"Marshall Islands";MH;MHL;141;"Lib";Municipality;"LIB";15356
-"Marshall Islands";MH;MHL;141;"Likiep";Municipality;"LIK";15357
-"Marshall Islands";MH;MHL;141;"Majuro";Municipality;"MAJ";15345
-"Marshall Islands";MH;MHL;141;"Maloelap";Municipality;"MAL";15358
-"Marshall Islands";MH;MHL;141;"Mejit";Municipality;"MEJ";15369
-"Marshall Islands";MH;MHL;141;"Mili";Municipality;"MIL";15359
-"Marshall Islands";MH;MHL;141;"Namdrik";Municipality;"NMK";15360
-"Marshall Islands";MH;MHL;141;"Namu";Municipality;"NMU";15344
-"Marshall Islands";MH;MHL;141;"Ralik chain";Chain of Islands;"L";48510
-"Marshall Islands";MH;MHL;141;"Ratak chain";Chain of Islands;"T";48674
-"Marshall Islands";MH;MHL;141;"Rongelap";Municipality;"RON";15361
-"Marshall Islands";MH;MHL;141;"Ujae";Municipality;"UJA";15371
-"Marshall Islands";MH;MHL;141;"Ujelang";Municipality;"UJL";15342
-"Marshall Islands";MH;MHL;141;"Utirik";Municipality;"UTI";15372
-"Marshall Islands";MH;MHL;141;"Wotho";Municipality;"WTH";15341
-"Marshall Islands";MH;MHL;141;"Wotje";Municipality;"WTJ";15340
-"Mauritania";MR;MRT;143;"Adrar";region;"07";15379
-"Mauritania";MR;MRT;143;"Assaba";region;"03";15378
-"Mauritania";MR;MRT;143;"Brakna";region;"05";15384
-"Mauritania";MR;MRT;143;"Dakhlet Nouâdhibou";region;"08";15380
-"Mauritania";MR;MRT;143;"Gorgol";region;"04";15387
-"Mauritania";MR;MRT;143;"Guidimaka";region;"10";15388
-"Mauritania";MR;MRT;143;"Hodh ech Chargui";region;"01";15386
-"Mauritania";MR;MRT;143;"Hodh el Gharbi";region;"02";15381
-"Mauritania";MR;MRT;143;"Inchiri";region;"12";15382
-"Mauritania";MR;MRT;143;"Nouakchott";district;"NKC";15389
-"Mauritania";MR;MRT;143;"Tagant";region;"09";15385
-"Mauritania";MR;MRT;143;"Tiris Zemmour";region;"11";15383
-"Mauritania";MR;MRT;143;"Trarza";region;"06";15377
-"Mauritius";MU;MUS;144;"Agalega Islands";dependency;"AG";19026
-"Mauritius";MU;MUS;144;"Beau Bassin-Rose Hill";city;"BR";19027
-"Mauritius";MU;MUS;144;"Black River";district;"BL";15392
-"Mauritius";MU;MUS;144;"Cargados Carajos Shoals [Saint Brandon Islands]";dependency;"CC";19028
-"Mauritius";MU;MUS;144;"Curepipe";city;"CU";19029
-"Mauritius";MU;MUS;144;"Flacq";district;"FL";15395
-"Mauritius";MU;MUS;144;"Grand Port";district;"GP";15393
-"Mauritius";MU;MUS;144;"Moka";district;"MO";15394
-"Mauritius";MU;MUS;144;"Pamplemousses";district;"PA";15396
-"Mauritius";MU;MUS;144;"Plaines Wilhems";district;"PW";15391
-"Mauritius";MU;MUS;144;"Port Louis City";district;"PL";15397
-"Mauritius";MU;MUS;144;"Port Louis District";city;"PU";19030
-"Mauritius";MU;MUS;144;"Quatre Bornes";city;"QB";19033
-"Mauritius";MU;MUS;144;"Rivière du Rempart";district;"RR";15399
-"Mauritius";MU;MUS;144;"Rodrigues Island";dependency;"RO";15398
-"Mauritius";MU;MUS;144;"Savanne";district;"SA";15390
-"Mauritius";MU;MUS;144;"Vacoas-Phoenix";city;"VP";19032
-"Mexico";MX;MEX;146;"Aguascalientes";state;"AGU";15423
-"Mexico";MX;MEX;146;"Baja California";state;"BCN";15412
-"Mexico";MX;MEX;146;"Baja California Sur";state;"BCS";15413
-"Mexico";MX;MEX;146;"Campeche";state;"CAM";15424
-"Mexico";MX;MEX;146;"Chiapas";state;"CHP";15414
-"Mexico";MX;MEX;146;"Chihuahua";state;"CHH";15425
-"Mexico";MX;MEX;146;"Coahuila";state;"COA";15415
-"Mexico";MX;MEX;146;"Colima";state;"COL";15416
-"Mexico";MX;MEX;146;"Distrito Federal";federal district;"DIF";15426
-"Mexico";MX;MEX;146;"Durango";state;"DUR";15417
-"Mexico";MX;MEX;146;"Guanajuato";state;"GUA";15418
-"Mexico";MX;MEX;146;"Guerrero";state;"GRO";15427
-"Mexico";MX;MEX;146;"Hidalgo";state;"HID";15419
-"Mexico";MX;MEX;146;"Jalisco";state;"JAL";15420
-"Mexico";MX;MEX;146;"Michoacán";state;"MIC";15421
-"Mexico";MX;MEX;146;"Morelos";state;"MOR";15422
-"Mexico";MX;MEX;146;"México";state;"MEX";15428
-"Mexico";MX;MEX;146;"Nayarit";state;"NAY";15429
-"Mexico";MX;MEX;146;"Nuevo León";state;"NLE";15403
-"Mexico";MX;MEX;146;"Oaxaca";state;"OAX";15430
-"Mexico";MX;MEX;146;"Puebla";state;"PUE";15404
-"Mexico";MX;MEX;146;"Querétaro";state;"QUE";15405
-"Mexico";MX;MEX;146;"Quintana Roo";state;"ROO";15432
-"Mexico";MX;MEX;146;"San Luis Potosí";state;"SLP";15406
-"Mexico";MX;MEX;146;"Sinaloa";state;"SIN";15407
-"Mexico";MX;MEX;146;"Sonora";state;"SON";15433
-"Mexico";MX;MEX;146;"Tabasco";state;"TAB";15408
-"Mexico";MX;MEX;146;"Tamaulipas";state;"TAM";15431
-"Mexico";MX;MEX;146;"Tlaxcala";state;"TLA";15409
-"Mexico";MX;MEX;146;"Veracruz";state;"VER";15410
-"Mexico";MX;MEX;146;"Yucatán";state;"YUC";15402
-"Mexico";MX;MEX;146;"Zacatecas";state;"ZAC";15411
-"Federated States Of Micronesia";FM;FSM;147;"Chuuk";State;"TRK";15437
-"Federated States Of Micronesia";FM;FSM;147;"Kosrae";State;"KSA";15436
-"Federated States Of Micronesia";FM;FSM;147;"Pohnpei";State;"PNI";15434
-"Federated States Of Micronesia";FM;FSM;147;"Yap";State;"YAP";15438
-"Republic of Moldova";MD;MDA;148;"Anenii Noi";district;"AN";15471
-"Republic of Moldova";MD;MDA;148;"Basarabeasca";district;"BS";15454
-"Republic of Moldova";MD;MDA;148;"Briceni";district;"BR";15472
-"Republic of Moldova";MD;MDA;148;"Bălţi";city;"BA";15453
-"Republic of Moldova";MD;MDA;148;"Cahul";district;"CA";15455
-"Republic of Moldova";MD;MDA;148;"Cantemir";district;"CT";15458
-"Republic of Moldova";MD;MDA;148;"Chisinau";city;"CU";15459
-"Republic of Moldova";MD;MDA;148;"Chisinau City";city;"CH";20309
-"Republic of Moldova";MD;MDA;148;"Cimişlia";district;"CM";15460
-"Republic of Moldova";MD;MDA;148;"Criuleni";district;"CR";15475
-"Republic of Moldova";MD;MDA;148;"Călăraşi";district;"CL";15473
-"Republic of Moldova";MD;MDA;148;"Căuşeni";district;"CS";15474
-"Republic of Moldova";MD;MDA;148;"Donduşeni";district;"DO";15461
-"Republic of Moldova";MD;MDA;148;"Drochia";district;"DR";15476
-"Republic of Moldova";MD;MDA;148;"Dubăsari";district;"DU";15444
-"Republic of Moldova";MD;MDA;148;"Edinet";district;"ED";15477
-"Republic of Moldova";MD;MDA;148;"Floreşti";district;"FL";15443
-"Republic of Moldova";MD;MDA;148;"Făleşti";district;"FA";15445
-"Republic of Moldova";MD;MDA;148;"Unitatea teritoriala autonoma (UTAG) Gagauzia";autonomous territorial unit;"GA";15446
-"Republic of Moldova";MD;MDA;148;"Glodeni";district;"GL";15478
-"Republic of Moldova";MD;MDA;148;"Hînceşti";district;"HI";15448
-"Republic of Moldova";MD;MDA;148;"Ialoveni";district;"IA";15442
-"Republic of Moldova";MD;MDA;148;"Leova";district;"LE";15449
-"Republic of Moldova";MD;MDA;148;"Lăpuşina";district;"LA";20171
-"Republic of Moldova";MD;MDA;148;"Nisporeni";district;"NI";15450
-"Republic of Moldova";MD;MDA;148;"Ocniţa";district;"OC";15479
-"Republic of Moldova";MD;MDA;148;"Orhei";district;"OR";15451
-"Republic of Moldova";MD;MDA;148;"Rezina";district;"RE";15441
-"Republic of Moldova";MD;MDA;148;"Rîşcani";district;"RI";15463
-"Republic of Moldova";MD;MDA;148;"Soroca";district;"SO";15466
-"Republic of Moldova";MD;MDA;148;"Străşeni";district;"ST";15467
-"Republic of Moldova";MD;MDA;148;"unitatea teritoriala din Stînga Nistrului";territorial unit;"SN";20172
-"Republic of Moldova";MD;MDA;148;"Sîngerei";district;"SI";15464
-"Republic of Moldova";MD;MDA;148;"Taraclia";district;"TA";15481
-"Republic of Moldova";MD;MDA;148;"Teleneşti";district;"TE";15468
-"Republic of Moldova";MD;MDA;148;"Tighina";city;"BD";15469
-"Republic of Moldova";MD;MDA;148;"Tighina";district;"TI";48215
-"Republic of Moldova";MD;MDA;148;"Ungheni";district;"UN";15470
-"Republic of Moldova";MD;MDA;148;"Şoldăneşti";district;"SD";15465
-"Republic of Moldova";MD;MDA;148;"Ştefan Vodă";district;"SV";15440
-"Monaco";MC;MCO;149;"Fontvieille";quarter;"FO";48841
-"Monaco";MC;MCO;149;"Jardin Exotique";quarter;"JE";48842
-"Monaco";MC;MCO;149;"La Colle";quarter;"CL";48843
-"Monaco";MC;MCO;149;"La Condamine";quarter;"CO";48840
-"Monaco";MC;MCO;149;"La Gare";quarter;"GA";48844
-"Monaco";MC;MCO;149;"La Source";quarter;"SO";48845
-"Monaco";MC;MCO;149;"Larvotto";quarter;"LA";48846
-"Monaco";MC;MCO;149;"Malbousquet";quarter;"MA";48847
-"Monaco";MC;MCO;149;"Monaco-Ville";quarter;"MO";48848
-"Monaco";MC;MCO;149;"Moneghetti";quarter;"MG";48849
-"Monaco";MC;MCO;149;"Monte-Carlo";quarter;"MC";48850
-"Monaco";MC;MCO;149;"Moulins";quarter;"MU";48851
-"Monaco";MC;MCO;149;"Port-Hercule";quarter;"PH";48852
-"Monaco";MC;MCO;149;"Saint-Roman";quarter;"SR";48853
-"Monaco";MC;MCO;149;"Sainte-Dévote";quarter;"SD";48854
-"Monaco";MC;MCO;149;"Spélugues";quarter;"SP";48855
-"Monaco";MC;MCO;149;"Vallon de la Rousse";quarter;"VR";48856
-"Mongolia";MN;MNG;150;"Arhangay";province;"073";15504
-"Mongolia";MN;MNG;150;"Bayan-Ölgiy";province;"071";15490
-"Mongolia";MN;MNG;150;"Bayanhongor";province;"069";15491
-"Mongolia";MN;MNG;150;"Bulgan";province;"067";15492
-"Mongolia";MN;MNG;150;"Darhan uul";municipality;"037";15493
-"Mongolia";MN;MNG;150;"Dornod";province;"061";15505
-"Mongolia";MN;MNG;150;"Dornogovi";province;"063";15494
-"Mongolia";MN;MNG;150;"Dundgovi";province;"059";15489
-"Mongolia";MN;MNG;150;"Dzavhan";province;"057";15503
-"Mongolia";MN;MNG;150;"Govi-Altay";province;"065";15495
-"Mongolia";MN;MNG;150;"Govi-Sümber";municipality;"064";15506
-"Mongolia";MN;MNG;150;"Hentiy";province;"039";15496
-"Mongolia";MN;MNG;150;"Hovd";province;"043";15497
-"Mongolia";MN;MNG;150;"Hövsgöl";province;"041";15488
-"Mongolia";MN;MNG;150;"Orhon";municipality;"035";15507
-"Mongolia";MN;MNG;150;"Selenge";province;"049";15487
-"Mongolia";MN;MNG;150;"Sühbaatar";province;"051";15500
-"Mongolia";MN;MNG;150;"Töv";province;"047";15501
-"Mongolia";MN;MNG;150;"Ulaanbaatar";municipality;"1";15486
-"Mongolia";MN;MNG;150;"Uvs";province;"046";15502
-"Mongolia";MN;MNG;150;"Ömnögovi";province;"053";15498
-"Mongolia";MN;MNG;150;"Övörhangay";province;"055";15499
-"Montenegro";ME;MNE;151;"Andrijevica";Commune;"01";42617
-"Montenegro";ME;MNE;151;"Bar";Commune;"02";42616
-"Montenegro";ME;MNE;151;"Berane";Commune;"03";42615
-"Montenegro";ME;MNE;151;"Bijelo Polje";Commune;"04";42614
-"Montenegro";ME;MNE;151;"Budva";Commune;"05";42613
-"Montenegro";ME;MNE;151;"Cetinje";Commune;"06";42598
-"Montenegro";ME;MNE;151;"Danilovgrad";Commune;"07";42612
-"Montenegro";ME;MNE;151;"Herceg-Novi";Commune;"08";42599
-"Montenegro";ME;MNE;151;"Kolašin";Commune;"09";42610
-"Montenegro";ME;MNE;151;"Kotor";Commune;"10";42609
-"Montenegro";ME;MNE;151;"Mojkovac";Commune;"11";42608
-"Montenegro";ME;MNE;151;"Nikšic´";Commune;"12";42607
-"Montenegro";ME;MNE;151;"Plav";Commune;"13";42606
-"Montenegro";ME;MNE;151;"Pljevlja";Commune;"14";42604
-"Montenegro";ME;MNE;151;"Plužine";Commune;"15";42605
-"Montenegro";ME;MNE;151;"Podgorica";Commune;"16";42603
-"Montenegro";ME;MNE;151;"Rožaje";Commune;"17";42602
-"Montenegro";ME;MNE;151;"Tivat";Commune;"19";42601
-"Montenegro";ME;MNE;151;"Ulcinj";Commune;"20";42600
-"Montenegro";ME;MNE;151;"Šavnik";Commune;"18";42597
-"Montenegro";ME;MNE;151;"Žabljak";Commune;"21";42611
-"Morocco";MA;MAR;153;"Agadir-Ida-Outanane";prefecture;"AGD";15554
-"Morocco";MA;MAR;153;"Al Haouz";province;"HAO";15543
-"Morocco";MA;MAR;153;"Al Hoceïma";province;"HOC";15516
-"Morocco";MA;MAR;153;"Aousserd";prefecture;"AOU";48475
-"Morocco";MA;MAR;153;"Assa-Zag";province;"ASZ";15541
-"Morocco";MA;MAR;153;"Azilal";province;"AZI";15583
-"Morocco";MA;MAR;153;"Aït Baha";province;"BAH";15518
-"Morocco";MA;MAR;153;"Aït Melloul";;"MEL";15555
-"Morocco";MA;MAR;153;"Ben Slimane";province;"BES";15572
-"Morocco";MA;MAR;153;"Beni Mellal";province;"BEM";15558
-"Morocco";MA;MAR;153;"Berkane";province;"BER";15526
-"Morocco";MA;MAR;153;"Boujdour (EH)";province;"BOD";20173
-"Morocco";MA;MAR;153;"Boulemane";province;"BOM";15576
-"Morocco";MA;MAR;153;"Casablanca [Dar el Beïda]*";prefecture;"CAS";15579
-"Morocco";MA;MAR;153;"Chaouia-Ouardigh";Region;"09";15529
-"Morocco";MA;MAR;153;"Chefchaouen";province;"CHE";15559
-"Morocco";MA;MAR;153;"Chichaoua";province;"CHI";15522
-"Morocco";MA;MAR;153;"Chtouka-Ait Baha";;"CHT";48100
-"Morocco";MA;MAR;153;"Connaught Salé";prefecture;"SAL";48482
-"Morocco";MA;MAR;153;"Doukkala-Abda";Region;"10";15565
-"Morocco";MA;MAR;153;"El Hajeb";province;"HAJ";15524
-"Morocco";MA;MAR;153;"El Jadida";province;"JDI";15575
-"Morocco";MA;MAR;153;"Errachidia";province;"ERR";15547
-"Morocco";MA;MAR;153;"Es Smara (EH)";province;"ESM";20174
-"Morocco";MA;MAR;153;"Essaouira";province;"ESI";15523
-"Morocco";MA;MAR;153;"Fahs-Beni Makada";prefecture;"FAH";48476
-"Morocco";MA;MAR;153;"Fes-Boulemane";Region;"05";15566
-"Morocco";MA;MAR;153;"Figuig";province;"FIG";15549
-"Morocco";MA;MAR;153;"Fès-Dar-Dbibegh";prefecture;"FES";15536
-"Morocco";MA;MAR;153;"Gharb-Chrarda-Beni Hssen";Region;"02";15530
-"Morocco";MA;MAR;153;"Grand Casablanca";Region;"08";15564
-"Morocco";MA;MAR;153;"Guelmim";province;"GUE";15520
-"Morocco";MA;MAR;153;"Guelmim-Es Smar";Region;"14";15567
-"Morocco";MA;MAR;153;"Ifrane";province;"IFR";15525
-"Morocco";MA;MAR;153;"Inezgane-Ait Melloul";prefecture;"INE";48477
-"Morocco";MA;MAR;153;"Jrada";province;"JRA";15550
-"Morocco";MA;MAR;153;"Kelaat es Sraghna";province;"KES";15544
-"Morocco";MA;MAR;153;"Khemisset";province;"KHE";15552
-"Morocco";MA;MAR;153;"Khenifra";province;"KHN";15548
-"Morocco";MA;MAR;153;"Khouribga";province;"KHO";15573
-"Morocco";MA;MAR;153;"Kénitra";province;"KEN";15578
-"Morocco";MA;MAR;153;"L'Oriental";Rerion;"04";15569
-"Morocco";MA;MAR;153;"Laayoune-Boujdour-Sakia El Hamra";Region;"15";21378
-"Morocco";MA;MAR;153;"Laayoune-Boujdour-Sakia El Hamra";;"X1~";48276
-"Morocco";MA;MAR;153;"Larache";province;"LAR";15560
-"Morocco";MA;MAR;153;"Laâyoune*";province;"LAA";20175
-"Morocco";MA;MAR;153;"Marrakech*";;"MAR";15545
-"Morocco";MA;MAR;153;"Marrakech-Medina";prefecture;"MMD";48478
-"Morocco";MA;MAR;153;"Marrakech-Menara";prefecture;"MMN";48479
-"Morocco";MA;MAR;153;"Marrakech-Tensift-Al Haouz";Region;"11";15531
-"Morocco";MA;MAR;153;"Mediouna";province;"MED";15539
-"Morocco";MA;MAR;153;"Meknes-Tafilalet";Region;"06";15568
-"Morocco";MA;MAR;153;"Meknès";prefecture;"MEK";15546
-"Morocco";MA;MAR;153;"Mohammadia";prefecture;"MOH";48480
-"Morocco";MA;MAR;153;"Moulay Yacoub";;"MOU";15537
-"Morocco";MA;MAR;153;"Nador";province;"NAD";15527
-"Morocco";MA;MAR;153;"Nouaceur";province;"NOU";15580
-"Morocco";MA;MAR;153;"Ouarzazate";province;"OUA";15582
-"Morocco";MA;MAR;153;"Oued ed Dahab (EH)";province;"OUD";20176
-"Morocco";MA;MAR;153;"Oued ed Dahab-Lagouira";Region;"16";48474
-"Morocco";MA;MAR;153;"Oujda*";prefecture;"OUJ";15551
-"Morocco";MA;MAR;153;"Rabat";prefecture;"RAB";48481
-"Morocco";MA;MAR;153;"Rabat-Salé*";;"RBA";15532
-"Morocco";MA;MAR;153;"Rabat-Salé-Zemmour-Zaer";Region;"07";48277
-"Morocco";MA;MAR;153;"Safi";province;"SAF";15535
-"Morocco";MA;MAR;153;"Sefrou";;"SEF";15577
-"Morocco";MA;MAR;153;"Settat";province;"SET";15574
-"Morocco";MA;MAR;153;"Sidi Kacem";province;"SIK";15538
-"Morocco";MA;MAR;153;"Sidi Youssef Ben Ali";prefecture;"SYB";48483
-"Morocco";MA;MAR;153;"Skhirate-Témara";prefecture;"SKH";48484
-"Morocco";MA;MAR;153;"Souss-Massa-Draa";Region;"13";15570
-"Morocco";MA;MAR;153;"Tadla-Azilal";Region;"12";15533
-"Morocco";MA;MAR;153;"Tan-Tan";province;"TNT";15542
-"Morocco";MA;MAR;153;"Tanger";;"TNG";15584
-"Morocco";MA;MAR;153;"Tanger-Assilah";prefecture;"TNG";48485
-"Morocco";MA;MAR;153;"Tanger-Tetouan";Region;"01";15571
-"Morocco";MA;MAR;153;"Taounate";province;"TAO";15562
-"Morocco";MA;MAR;153;"Taourirt";province;"TAI";15528
-"Morocco";MA;MAR;153;"Taroudant";province;"TAR";15556
-"Morocco";MA;MAR;153;"Tata";province;"TAT";15521
-"Morocco";MA;MAR;153;"Taza";province;"TAZ";15563
-"Morocco";MA;MAR;153;"Taza-Al Hoceima-Taounate";Region;"03";15534
-"Morocco";MA;MAR;153;"Tiznit";province;"TIZ";15517
-"Morocco";MA;MAR;153;"Tétouan*";;"TET";15561
-"Morocco";MA;MAR;153;"Zagora";province;"ZAG";15557
-"Mozambique";MZ;MOZ;154;"Cabo Delgado";province;"P";15599
-"Mozambique";MZ;MOZ;154;"Gaza";province;"G";15602
-"Mozambique";MZ;MOZ;154;"Inhambane";province;"I";15589
-"Mozambique";MZ;MOZ;154;"Manica";province;"B";15590
-"Mozambique";MZ;MOZ;154;"Maputo";province;"L";15591
-"Mozambique";MZ;MOZ;154;"Maputo City";city;"MPM";15603
-"Mozambique";MZ;MOZ;154;"Nampula";province;"N";15604
-"Mozambique";MZ;MOZ;154;"Niassa";province;"A";15592
-"Mozambique";MZ;MOZ;154;"Sofala";province;"S";15605
-"Mozambique";MZ;MOZ;154;"Tete";province;"T";15593
-"Mozambique";MZ;MOZ;154;"Zambézia";province;"Q";15606
-"Myanmar";MM;MMR;155;"Ayeyarwady";division;"07";15608
-"Myanmar";MM;MMR;155;"Bago";division;"02";15609
-"Myanmar";MM;MMR;155;"Chin";state;"14";15617
-"Myanmar";MM;MMR;155;"Kachin";state;"11";15610
-"Myanmar";MM;MMR;155;"Kayah";state;"12";15618
-"Myanmar";MM;MMR;155;"Kayin";state;"13";15611
-"Myanmar";MM;MMR;155;"Magway";division;"03";15612
-"Myanmar";MM;MMR;155;"Mandalay";division;"04";15620
-"Myanmar";MM;MMR;155;"Mon";state;"15";15613
-"Myanmar";MM;MMR;155;"Rakhine";state;"16";15619
-"Myanmar";MM;MMR;155;"Sagaing";division;"01";15614
-"Myanmar";MM;MMR;155;"Shan";state;"17";15615
-"Myanmar";MM;MMR;155;"Tanintharyi";division;"05";15607
-"Myanmar";MM;MMR;155;"Yangon";division;"06";15616
-"Namibia";NA;NAM;156;"Caprivi";Region;"CA";15625
-"Namibia";NA;NAM;156;"Erongo";Region;"ER";15626
-"Namibia";NA;NAM;156;"Hardap";Region;"HA";15623
-"Namibia";NA;NAM;156;"Karas";Region;"KA";15627
-"Namibia";NA;NAM;156;"Khomas";Region;"KH";15624
-"Namibia";NA;NAM;156;"Kunene";Region;"KU";15629
-"Namibia";NA;NAM;156;"Ohangwena";Region;"OW";15630
-"Namibia";NA;NAM;156;"Okavango";Region;"OK";15628
-"Namibia";NA;NAM;156;"Omaheke";Region;"OH";15622
-"Namibia";NA;NAM;156;"Omusati";Region;"OS";15631
-"Namibia";NA;NAM;156;"Oshana";Region;"ON";15632
-"Namibia";NA;NAM;156;"Oshikoto";Region;"OT";15621
-"Namibia";NA;NAM;156;"Otjozondjupa";Region;"OD";15633
-"Nauru";NR;NRU;157;"Aiwo";District;"01";15642
-"Nauru";NR;NRU;157;"Anabar";District;"02";15637
-"Nauru";NR;NRU;157;"Anetan";District;"03";15643
-"Nauru";NR;NRU;157;"Anibare";District;"04";15641
-"Nauru";NR;NRU;157;"Baiti";District;"05";15647
-"Nauru";NR;NRU;157;"Boe";District;"06";15644
-"Nauru";NR;NRU;157;"Buada";District;"07";15640
-"Nauru";NR;NRU;157;"Denigomodu";District;"08";15648
-"Nauru";NR;NRU;157;"Ewa";District;"09";15645
-"Nauru";NR;NRU;157;"Ijuw";District;"10";15639
-"Nauru";NR;NRU;157;"Meneng";District;"11";15646
-"Nauru";NR;NRU;157;"Nibok";District;"12";15636
-"Nauru";NR;NRU;157;"Uaboe";District;"13";15638
-"Nauru";NR;NRU;157;"Yaren";District;"14";15635
-"Nepal";NP;NPL;158;"Bagmati";zone;"BA";20177
-"Nepal";NP;NPL;158;"Bheri";zone;"BH";20178
-"Nepal";NP;NPL;158;"Dhawalagiri";zone;"DH";20179
-"Nepal";NP;NPL;158;"Gandaki";zone;"GA";20180
-"Nepal";NP;NPL;158;"Janakpur";zone;"JA";20181
-"Nepal";NP;NPL;158;"Karnali";zone;"KA";20182
-"Nepal";NP;NPL;158;"Kosi [Koshi]";zone;"KO";20183
-"Nepal";NP;NPL;158;"Lumbini";zone;"LU";20184
-"Nepal";NP;NPL;158;"Madhya Pashchimanchal";development regions;"2";48537
-"Nepal";NP;NPL;158;"Madhyamanchal";development regions;"1";48536
-"Nepal";NP;NPL;158;"Mahakali";zone;"MA";20185
-"Nepal";NP;NPL;158;"Mechi";zone;"ME";20186
-"Nepal";NP;NPL;158;"Narayani";zone;"NA";20187
-"Nepal";NP;NPL;158;"Pashchimanchal";development regions;"3";48538
-"Nepal";NP;NPL;158;"Purwanchal";development regions;"4";48539
-"Nepal";NP;NPL;158;"Rapti";zone;"RA";20188
-"Nepal";NP;NPL;158;"Sagarmatha";zone;"SA";20189
-"Nepal";NP;NPL;158;"Seti";zone;"SE";20190
-"Nepal";NP;NPL;158;"Sudur Pashchimanchal";development regions;"5";48540
-"Netherlands";NL;NLD;159;"Aruba (see also separate entry under AW)";country;"AW";48857
-"Netherlands";NL;NLD;159;"Bonaire (see also separate entry under BQ)";Special municipality;"BQ1";48860
-"Netherlands";NL;NLD;159;"Curaçao (see also separate entry under CW)";country;"CW";48858
-"Netherlands";NL;NLD;159;"Drenthe";Province;"DR";15727
-"Netherlands";NL;NLD;159;"Flevoland";Province;"FL";15731
-"Netherlands";NL;NLD;159;"Friesland";Province;"FR";15730
-"Netherlands";NL;NLD;159;"Gelderland";Province;"GE";15726
-"Netherlands";NL;NLD;159;"Groningen";Province;"GR";15732
-"Netherlands";NL;NLD;159;"Limburg";Province;"LI";15735
-"Netherlands";NL;NLD;159;"Noord-Brabant";Province;"NB";15729
-"Netherlands";NL;NLD;159;"Noord-Holland";Province;"NH";15736
-"Netherlands";NL;NLD;159;"Overijssel";Province;"OV";15733
-"Netherlands";NL;NLD;159;"Saba (see also separate entry under BQ)";Special municipality;"BQ2";48861
-"Netherlands";NL;NLD;159;"Sint Eustatius (see also separate entry under BQ)";Special municipality;"BQ3";48862
-"Netherlands";NL;NLD;159;"Sint Maarten (see also separate entry under SX)";country;"SX";48859
-"Netherlands";NL;NLD;159;"Utrecht";Province;"UT";15725
-"Netherlands";NL;NLD;159;"Zeeland";Province;"ZE";15728
-"Netherlands";NL;NLD;159;"Zuid-Holland";Province;"ZH";15734
-"New Zealand";NZ;NZL;162;"Auckland";Regional Council;"AUK";15748
-"New Zealand";NZ;NZL;162;"Bay of Plenty";Regional Council;"BOP";15753
-"New Zealand";NZ;NZL;162;"Canterbury";Regional Council;"CAN";15754
-"New Zealand";NZ;NZL;162;"Chatham  Islands Territory";Special Island Authority;"X1~";48138
-"New Zealand";NZ;NZL;162;"Chatham  Islands Territory";Special Island Authority;"CIT";19036
-"New Zealand";NZ;NZL;162;"Gisborne District";Unitary Authority;"GIS";15749
-"New Zealand";NZ;NZL;162;"Hawkes's Bay";Regional Council;"HKB";15755
-"New Zealand";NZ;NZL;162;"Manawatu-Wanganui";Regional Council;"MWT";15750
-"New Zealand";NZ;NZL;162;"Marlborough District";Unitary Authority;"MBH";15756
-"New Zealand";NZ;NZL;162;"Nelson City";Unitary Authority;"NSN";15757
-"New Zealand";NZ;NZL;162;"North Island";island;"N";48235
-"New Zealand";NZ;NZL;162;"Northland";Regional Council;"NTL";15747
-"New Zealand";NZ;NZL;162;"Otago";Regional Council;"OTA";15758
-"New Zealand";NZ;NZL;162;"South Island";island;"S";48236
-"New Zealand";NZ;NZL;162;"Southland";Regional Council;"STL";15759
-"New Zealand";NZ;NZL;162;"Taranaki";Regional Council;"TKI";15751
-"New Zealand";NZ;NZL;162;"Tasman District";Unitary Authority;"TAS";15760
-"New Zealand";NZ;NZL;162;"Waikato";Regional Council;"WKO";15746
-"New Zealand";NZ;NZL;162;"Wellington";Regional Council;"WGN";15761
-"New Zealand";NZ;NZL;162;"West Coast";Regional Council;"WTC";15762
-"Nicaragua";NI;NIC;163;"Atlántico Norte*";autonomous region;"AN";15779
-"Nicaragua";NI;NIC;163;"Atlántico Sur*";autonomous region;"AS";15771
-"Nicaragua";NI;NIC;163;"Boaco";department;"BO";15772
-"Nicaragua";NI;NIC;163;"Carazo";department;"CA";15766
-"Nicaragua";NI;NIC;163;"Chinandega";department;"CI";15770
-"Nicaragua";NI;NIC;163;"Chontales";department;"CO";15765
-"Nicaragua";NI;NIC;163;"Estelí";department;"ES";15773
-"Nicaragua";NI;NIC;163;"Granada";department;"GR";15777
-"Nicaragua";NI;NIC;163;"Jinotega";department;"JI";15769
-"Nicaragua";NI;NIC;163;"León";department;"LE";15774
-"Nicaragua";NI;NIC;163;"Madriz";department;"MD";15778
-"Nicaragua";NI;NIC;163;"Managua";department;"MN";15768
-"Nicaragua";NI;NIC;163;"Masaya";department;"MS";15764
-"Nicaragua";NI;NIC;163;"Matagalpa";department;"MT";15775
-"Nicaragua";NI;NIC;163;"Nueva Segovia";department;"NS";15767
-"Nicaragua";NI;NIC;163;"Rivas";department;"RI";15776
-"Nicaragua";NI;NIC;163;"Río San Juan";department;"SJ";15763
-"Niger";NE;NER;164;"Agadez";Region;"1";15782
-"Niger";NE;NER;164;"Diffa";Region;"2";15783
-"Niger";NE;NER;164;"Dosso";Region;"3";15784
-"Niger";NE;NER;164;"Maradi";Region;"4";15785
-"Niger";NE;NER;164;"Niamey";Capital District;"8";15786
-"Niger";NE;NER;164;"Tahoua";Region;"5";15787
-"Niger";NE;NER;164;"Tillabéri";Region;"6";15788
-"Niger";NE;NER;164;"Zinder";Region;"7";15789
-"Nigeria";NG;NGA;165;"Abia";state;"AB";21217
-"Nigeria";NG;NGA;165;"Abuja Federal Capital Territory";capital territory;"FC";15801
-"Nigeria";NG;NGA;165;"Adamawa";state;"AD";15802
-"Nigeria";NG;NGA;165;"Akwa Ibom";state;"AK";15803
-"Nigeria";NG;NGA;165;"Anambra";state;"AN";15804
-"Nigeria";NG;NGA;165;"Bauchi";state;"BA";15805
-"Nigeria";NG;NGA;165;"Bayelsa";state;"BY";15826
-"Nigeria";NG;NGA;165;"Benue";state;"BE";15817
-"Nigeria";NG;NGA;165;"Borno";state;"BO";15806
-"Nigeria";NG;NGA;165;"Cross River";state;"CR";15818
-"Nigeria";NG;NGA;165;"Delta";state;"DE";15799
-"Nigeria";NG;NGA;165;"Ebonyi";state;"EB";15819
-"Nigeria";NG;NGA;165;"Edo";state;"ED";15820
-"Nigeria";NG;NGA;165;"Ekiti";state;"EK";15807
-"Nigeria";NG;NGA;165;"Enugu";state;"EN";15821
-"Nigeria";NG;NGA;165;"Gombe";state;"GO";15822
-"Nigeria";NG;NGA;165;"Imo";state;"IM";15798
-"Nigeria";NG;NGA;165;"Jigawa";state;"JI";15823
-"Nigeria";NG;NGA;165;"Kaduna";state;"KD";15824
-"Nigeria";NG;NGA;165;"Kano";state;"KN";15828
-"Nigeria";NG;NGA;165;"Katsina";state;"KT";15825
-"Nigeria";NG;NGA;165;"Kebbi";state;"KE";15808
-"Nigeria";NG;NGA;165;"Kogi";state;"KO";15797
-"Nigeria";NG;NGA;165;"Kwara";state;"KW";15809
-"Nigeria";NG;NGA;165;"Lagos";state;"LA";15810
-"Nigeria";NG;NGA;165;"Nassarawa";state;"NA";15794
-"Nigeria";NG;NGA;165;"Niger";state;"NI";15811
-"Nigeria";NG;NGA;165;"Ogun";state;"OG";15812
-"Nigeria";NG;NGA;165;"Ondo";state;"ON";15795
-"Nigeria";NG;NGA;165;"Osun";state;"OS";15813
-"Nigeria";NG;NGA;165;"Oyo";state;"OY";15814
-"Nigeria";NG;NGA;165;"Plateau";state;"PL";15796
-"Nigeria";NG;NGA;165;"Rivers";state;"RI";15815
-"Nigeria";NG;NGA;165;"Sokoto";state;"SO";15816
-"Nigeria";NG;NGA;165;"Taraba";state;"TA";15793
-"Nigeria";NG;NGA;165;"Yobe";state;"YO";15827
-"Nigeria";NG;NGA;165;"Zamfara";state;"ZA";15792
-"Norway";NO;NOR;169;"Akershus";County;"02";15866
-"Norway";NO;NOR;169;"Aust-Agder";County;"09";15853
-"Norway";NO;NOR;169;"Buskerud";County;"06";15854
-"Norway";NO;NOR;169;"Finnmark";County;"20";15852
-"Norway";NO;NOR;169;"Hedmark";County;"04";15855
-"Norway";NO;NOR;169;"Hordaland";County;"12";15867
-"Norway";NO;NOR;169;"Jan Mayen (Arctic Region) (See also country code SJ)";;"22";19038
-"Norway";NO;NOR;169;"Møre og Romsdal";County;"15";15856
-"Norway";NO;NOR;169;"Nord-Trøndelag";County;"17";15851
-"Norway";NO;NOR;169;"Nordland";County;"18";15857
-"Norway";NO;NOR;169;"Oppland";County;"05";15858
-"Norway";NO;NOR;169;"Oslo";County;"03";15859
-"Norway";NO;NOR;169;"Rogaland";County;"11";15860
-"Norway";NO;NOR;169;"Sogn og Fjordane";County;"14";15861
-"Norway";NO;NOR;169;"Svalbard (Arctic Region) (See also country code SJ)";;"21";19039
-"Norway";NO;NOR;169;"Sør-Trøndelag";County;"16";15849
-"Norway";NO;NOR;169;"Telemark";County;"08";15862
-"Norway";NO;NOR;169;"Troms";County;"19";15863
-"Norway";NO;NOR;169;"Vest-Agder";County;"10";15848
-"Norway";NO;NOR;169;"Vestfold";County;"07";15864
-"Norway";NO;NOR;169;"Østfold";County;"01";15850
-"Oman";OM;OMN;170;"Ad Dakhiliyah";Region;"DA";15871
-"Oman";OM;OMN;170;"Al Batinah";Region;"BA";15873
-"Oman";OM;OMN;170;"Al Buraymi";Governorate;"X1~";48137
-"Oman";OM;OMN;170;"Al Buraymi";Governorate;"BU";21361
-"Oman";OM;OMN;170;"Al Wustá";Region;"WU";15872
-"Oman";OM;OMN;170;"Ash Sharqiyah";Region;"SH";15870
-"Oman";OM;OMN;170;"Az̧ Z̧āhirah";Region;"ZA";15868
-"Oman";OM;OMN;170;"Dhofar";Governorate;"JA";15869
-"Oman";OM;OMN;170;"Masqat";Governorate;"MA";15875
-"Oman";OM;OMN;170;"Musandam";Governorate;"MU";15874
-"Oman";OM;OMN;170;"Z̧ufār";governorate;"ZU";48237
-"Pakistan";PK;PAK;171;"Azad Kashmir";Pakistan administered area;"JK";15882
-"Pakistan";PK;PAK;171;"Baluchistan (en)";province;"BA";15881
-"Pakistan";PK;PAK;171;"Federally Administered Tribal Areas";territory;"TA";15878
-"Pakistan";PK;PAK;171;"Gilgit-Baltistan";administered areas;"GB";48707
-"Pakistan";PK;PAK;171;"Islamabad";federal capital territory;"IS";15883
-"Pakistan";PK;PAK;171;"Khyber Pakhtunkhwa";province;"KP";48709
-"Pakistan";PK;PAK;171;"North-West Frontier";province;"NW";15879
-"Pakistan";PK;PAK;171;"Northern Areas";Pakistan administered area;"NA";15877
-"Pakistan";PK;PAK;171;"Punjab";province;"PB";15876
-"Pakistan";PK;PAK;171;"Sindh";province;"SD";15880
-"Palau";PW;PLW;172;"Aimeliik";State;"002";15887
-"Palau";PW;PLW;172;"Airai";State;"004";15898
-"Palau";PW;PLW;172;"Angaur";State;"010";15889
-"Palau";PW;PLW;172;"Hatobohei";State;"050";15886
-"Palau";PW;PLW;172;"Kayangel";State;"100";15890
-"Palau";PW;PLW;172;"Koror";State;"150";15891
-"Palau";PW;PLW;172;"Melekeok";State;"212";15888
-"Palau";PW;PLW;172;"Ngaraard";State;"214";15892
-"Palau";PW;PLW;172;"Ngarchelong";State;"218";15899
-"Palau";PW;PLW;172;"Ngardmau";State;"222";15893
-"Palau";PW;PLW;172;"Ngatpang";State;"224";15894
-"Palau";PW;PLW;172;"Ngchesar";State;"226";15895
-"Palau";PW;PLW;172;"Ngeremlengui";State;"227";15885
-"Palau";PW;PLW;172;"Ngiwal";State;"228";15896
-"Palau";PW;PLW;172;"Peleliu";State;"350";15897
-"Palau";PW;PLW;172;"Sonsorol";State;"370";15884
-"Occupied Palestinian Territory";PS;PSE;173;"Bethlehem Bayt Laḩm";governorates;"BTH";48863
-"Occupied Palestinian Territory";PS;PSE;173;"Deir El Balah Dayr al Balaḩ";governorates;"DEB";48864
-"Occupied Palestinian Territory";PS;PSE;173;"Gaza Ghazzah";governorates;"GZA";48865
-"Occupied Palestinian Territory";PS;PSE;173;"Hebron Al Khalīl";governorates;"HBN";48866
-"Occupied Palestinian Territory";PS;PSE;173;"Jenin Janīn";governorates;"JEN";48867
-"Occupied Palestinian Territory";PS;PSE;173;"Jericho – Al Aghwar Arīḩā wa al Aghwār";governorates;"JRH";48868
-"Occupied Palestinian Territory";PS;PSE;173;"Jerusalem Al Quds";governorates;"JEM";48869
-"Occupied Palestinian Territory";PS;PSE;173;"Khan Yunis Khān Yūnis";governorates;"KYS";48870
-"Occupied Palestinian Territory";PS;PSE;173;"Nablus Nāblus";governorates;"NBS";48871
-"Occupied Palestinian Territory";PS;PSE;173;"North Gaza Shamāl Ghazzah";governorates;"NGZ";48872
-"Occupied Palestinian Territory";PS;PSE;173;"Qalqilya Qalqīlyah";governorates;"QQA";48873
-"Occupied Palestinian Territory";PS;PSE;173;"Rafah Rafaḩ";governorates;"RFH";48874
-"Occupied Palestinian Territory";PS;PSE;173;"Ramallah Rām Allāh wa al Bīrah";governorates;"RBH";48875
-"Occupied Palestinian Territory";PS;PSE;173;"Salfit Salfīt";governorates;"SLT";48876
-"Occupied Palestinian Territory";PS;PSE;173;"Tubas Ţūbās";governorates;"TBS";48877
-"Occupied Palestinian Territory";PS;PSE;173;"Tulkarm Ţūlkarm";governorates;"TKM";48878
-"Panama";PA;PAN;175;"Bocas del Toro";province;"1";15928
-"Panama";PA;PAN;175;"Chiriquí";province;"4";15920
-"Panama";PA;PAN;175;"Coclé";province;"2";15929
-"Panama";PA;PAN;175;"Colón";province;"3";15921
-"Panama";PA;PAN;175;"Comarca de San Blas";Comarca;"0";15925
-"Panama";PA;PAN;175;"Darién";province;"5";15922
-"Panama";PA;PAN;175;"Emberá";indigenous region;"EM";15926
-"Panama";PA;PAN;175;"Herrera";province;"6";15923
-"Panama";PA;PAN;175;"Los Santos";province;"7";15917
-"Panama";PA;PAN;175;"Ngöbe-Buglé";indigenous region;"NB";15919
-"Panama";PA;PAN;175;"Panamá";province;"8";15916
-"Panama";PA;PAN;174;"Kuna Yala";indigenous region;"KY";48238
-"Panama";PA;PAN;175;"Veraguas";province;"9";15927
-"Papua New Guinea";PG;PNG;176;"Bougainville";autonomous region;"NSB";48706
-"Papua New Guinea";PG;PNG;176;"Central";province;"CPM";15935
-"Papua New Guinea";PG;PNG;176;"Chimbu";province;"CPK";15931
-"Papua New Guinea";PG;PNG;176;"East New Britain";province;"EBR";15946
-"Papua New Guinea";PG;PNG;176;"East Sepik";province;"ESW";15937
-"Papua New Guinea";PG;PNG;176;"Eastern Highlands";province;"EHG";15936
-"Papua New Guinea";PG;PNG;176;"Enga";province;"EPW";15934
-"Papua New Guinea";PG;PNG;176;"Gulf";province;"GPK";15947
-"Papua New Guinea";PG;PNG;176;"Madang";province;"MPM";15939
-"Papua New Guinea";PG;PNG;176;"Manus";province;"MRL";15933
-"Papua New Guinea";PG;PNG;176;"Milne Bay";province;"MBA";15940
-"Papua New Guinea";PG;PNG;176;"Morobe";province;"MPL";15941
-"Papua New Guinea";PG;PNG;176;"National Capital District (Port Moresby)";district;"NCD";15948
-"Papua New Guinea";PG;PNG;176;"New Ireland";province;"NIK";15932
-"Papua New Guinea";PG;PNG;176;"North Solomons";province;"NSA";15942
-"Papua New Guinea";PG;PNG;176;"Northern";province;"NPP";15949
-"Papua New Guinea";PG;PNG;176;"Sandaun [West Sepik]";province;"SAN";15943
-"Papua New Guinea";PG;PNG;176;"Southern Highlands";province;"SHM";15944
-"Papua New Guinea";PG;PNG;176;"West New Britain";province;"WBK";15945
-"Papua New Guinea";PG;PNG;176;"Western";province;"WPD";15938
-"Papua New Guinea";PG;PNG;176;"Western Highlands";province;"WHM";15950
-"Paraguay";PY;PRY;177;"Alto Paraguay";department;"16";15963
-"Paraguay";PY;PRY;177;"Alto Paraná";department;"10";15964
-"Paraguay";PY;PRY;177;"Amambay";department;"13";15965
-"Paraguay";PY;PRY;177;"Asunción";capital;"ASU";15954
-"Paraguay";PY;PRY;177;"Boquerón";department;"19";15953
-"Paraguay";PY;PRY;177;"Caaguazú";department;"5";15955
-"Paraguay";PY;PRY;177;"Caazapá";department;"6";15966
-"Paraguay";PY;PRY;177;"Canindeyú";department;"14";15956
-"Paraguay";PY;PRY;177;"Central";department;"11";15952
-"Paraguay";PY;PRY;177;"Concepción";department;"1";15957
-"Paraguay";PY;PRY;177;"Cordillera";department;"3";15958
-"Paraguay";PY;PRY;177;"Guairá";department;"4";15967
-"Paraguay";PY;PRY;177;"Itapúa";department;"7";15959
-"Paraguay";PY;PRY;177;"Misiones";department;"8";15968
-"Paraguay";PY;PRY;177;"Paraguarí";department;"9";15951
-"Paraguay";PY;PRY;177;"Presidente Hayes";department;"15";15961
-"Paraguay";PY;PRY;177;"San Pedro";department;"2";15962
-"Paraguay";PY;PRY;177;"Ñeembucú";department;"12";15960
-"Peru";PE;PER;178;"Amazonas";department;"AMA";15982
-"Peru";PE;PER;178;"Ancash";department;"ANC";15981
-"Peru";PE;PER;178;"Apurímac";department;"APU";15983
-"Peru";PE;PER;178;"Arequipa";department;"ARE";15972
-"Peru";PE;PER;178;"Ayacucho";department;"AYA";15984
-"Peru";PE;PER;178;"Cajamarca";department;"CAJ";15985
-"Peru";PE;PER;178;"Cusco [Cuzco]";department;"CUS";15989
-"Peru";PE;PER;178;"El Callao";constitutional province;"CAL";15992
-"Peru";PE;PER;178;"Huancavelica";department;"HUV";15986
-"Peru";PE;PER;178;"Huánuco";department;"HUC";15987
-"Peru";PE;PER;178;"Ica";department;"ICA";15971
-"Peru";PE;PER;178;"Junín";department;"JUN";15988
-"Peru";PE;PER;178;"La Libertad";department;"LAL";15990
-"Peru";PE;PER;178;"Lambayeque";department;"LAM";15973
-"Peru";PE;PER;178;"Lima";department;"LIM";15969
-"Peru";PE;PER;178;"Loreto";department;"LOR";15974
-"Peru";PE;PER;178;"Madre de Dios";department;"MDD";15970
-"Peru";PE;PER;178;"Moquegua";department;"MOQ";15975
-"Peru";PE;PER;178;"Municipalidad Metropolitana de Lima";municipality;"LMA";42646
-"Peru";PE;PER;178;"Municipalidad Metropolitana de Lima";municipality;"X1~";48136
-"Peru";PE;PER;178;"Pasco";department;"PAS";15991
-"Peru";PE;PER;178;"Piura";department;"PIU";15976
-"Peru";PE;PER;178;"Puno";department;"PUN";15977
-"Peru";PE;PER;178;"San Martín";department;"SAM";15994
-"Peru";PE;PER;178;"Tacna";department;"TAC";15978
-"Peru";PE;PER;178;"Tumbes";department;"TUM";15979
-"Peru";PE;PER;178;"Ucayali";department;"UCA";15993
-"Philippines";PH;PHL;180;"Abra";province;"ABR";17214
-"Philippines";PH;PHL;180;"Agusan del Norte";province;"AGN";16310
-"Philippines";PH;PHL;180;"Agusan del Sur";province;"AGS";17293
-"Philippines";PH;PHL;180;"Aklan";province;"AKL";16347
-"Philippines";PH;PHL;180;"Albay";province;"ALB";16303
-"Philippines";PH;PHL;180;"Antique";province;"ANT";16348
-"Philippines";PH;PHL;180;"Apayao";province;"APA";17215
-"Philippines";PH;PHL;180;"Aurora";province;"AUR";17115
-"Philippines";PH;PHL;180;"Autonomous Region in Muslim Mindanao (ARMM)";region;"14";17207
-"Philippines";PH;PHL;180;"Basilan";province;"BAS";17237
-"Philippines";PH;PHL;180;"Bataan";province;"BAN";16312
-"Philippines";PH;PHL;180;"Batanes";province;"BTN";16307
-"Philippines";PH;PHL;180;"Batangas";province;"BTG";17233
-"Philippines";PH;PHL;180;"Benguet";province;"BEN";16315
-"Philippines";PH;PHL;180;"Bicol (Region V)";region;"05";17201
-"Philippines";PH;PHL;180;"Biliran";province;"BIL";17217
-"Philippines";PH;PHL;180;"Bohol";province;"BOH";17303
-"Philippines";PH;PHL;180;"Bukidnon";province;"BUK";16333
-"Philippines";PH;PHL;180;"Bulacan";province;"BUL";17295
-"Philippines";PH;PHL;180;"Cagayan";province;"CAG";17291
-"Philippines";PH;PHL;180;"Cagayan Valley (Region II)";region;"02";16298
-"Philippines";PH;PHL;180;"CALABARZON (Region IV-A)";region;"40";48239
-"Philippines";PH;PHL;180;"Camarines Norte";province;"CAN";16304
-"Philippines";PH;PHL;180;"Camarines Sur";province;"CAS";17289
-"Philippines";PH;PHL;180;"Camiguin";province;"CAM";16334
-"Philippines";PH;PHL;180;"Capiz";province;"CAP";17239
-"Philippines";PH;PHL;180;"Caraga (Region XIII)";region;"13";16299
-"Philippines";PH;PHL;180;"Catanduanes";province;"CAT";16305
-"Philippines";PH;PHL;180;"Cavite";province;"CAV";16340
-"Philippines";PH;PHL;180;"Cebu";province;"CEB";17304
-"Philippines";PH;PHL;180;"Central Luzon (Region III)";region;"03";17202
-"Philippines";PH;PHL;180;"Central Visayas (Region VII)";region;"07";17203
-"Philippines";PH;PHL;180;"Compostela Valley";province;"COM";17230
-"Philippines";PH;PHL;180;"Cordillera Administrative Region (CAR)";region;"15";17204
-"Philippines";PH;PHL;180;"Cotabato";province;"NCO";17298
-"Philippines";PH;PHL;180;"Davao (Region XI)";region;"11";48240
-"Philippines";PH;PHL;180;"Davao del Norte";province;"DAV";16336
-"Philippines";PH;PHL;180;"Davao del Sur";province;"DAS";17231
-"Philippines";PH;PHL;180;"Davao Oriental";province;"DAO";16337
-"Philippines";PH;PHL;180;"Dinagat Islands";province;"DIN";16521
-"Philippines";PH;PHL;180;"Dinagat Islands";;"X1~";48135
-"Philippines";PH;PHL;180;"Eastern Samar";province;"EAS";16318
-"Philippines";PH;PHL;180;"Eastern Visayas (Region VIII)";region;"08";17205
-"Philippines";PH;PHL;180;"Guimaras";province;"GUI";16349
-"Philippines";PH;PHL;180;"Ifugao";province;"IFU";16316
-"Philippines";PH;PHL;180;"Ilocos (Region I)";region;"01";17206
-"Philippines";PH;PHL;180;"Ilocos Norte";province;"ILN";16321
-"Philippines";PH;PHL;180;"Ilocos Sur";province;"ILS";17220
-"Philippines";PH;PHL;180;"Iloilo";province;"ILI";17240
-"Philippines";PH;PHL;180;"Isabela";province;"ISA";16308
-"Philippines";PH;PHL;180;"Kalinga";province;"KAL";17216
-"Philippines";PH;PHL;180;"La Union";province;"LUN";16322
-"Philippines";PH;PHL;180;"Laguna";province;"LAG";16341
-"Philippines";PH;PHL;180;"Lanao del Norte";province;"LAN";17300
-"Philippines";PH;PHL;180;"Lanao del Sur";province;"LAS";16301
-"Philippines";PH;PHL;180;"Leyte";province;"LEY";16765
-"Philippines";PH;PHL;180;"Maguindanao";province;"MAG";17287
-"Philippines";PH;PHL;180;"Marinduque";province;"MAD";17234
-"Philippines";PH;PHL;180;"Masbate";province;"MAS";17290
-"Philippines";PH;PHL;180;"MIMAROPA (Region IV-B)";region;"41";48241
-"Philippines";PH;PHL;180;"Mindoro Occidental";province;"MDC";16342
-"Philippines";PH;PHL;180;"Mindoro Oriental";province;"MDR";17235
-"Philippines";PH;PHL;180;"Misamis Occidental";province;"MSC";17229
-"Philippines";PH;PHL;180;"Misamis Oriental";province;"MSR";16335
-"Philippines";PH;PHL;180;"Mountain Province";province;"MOU";16317
-"Philippines";PH;PHL;180;"National Capital Region";region;"00";17208
-"Philippines";PH;PHL;180;"Negros Occidental";province;"NEC";16350
-"Philippines";PH;PHL;180;"Negros Oriental";province;"NER";17305
-"Philippines";PH;PHL;180;"Northern Mindanao (Region X)";region;"10";17209
-"Philippines";PH;PHL;180;"Northern Samar";province;"NSA";17218
-"Philippines";PH;PHL;180;"Nueva Ecija";province;"NUE";16313
-"Philippines";PH;PHL;180;"Nueva Vizcaya";province;"NUV";17292
-"Philippines";PH;PHL;180;"Palawan";province;"PLW";16343
-"Philippines";PH;PHL;180;"Pampanga";province;"PAM";16314
-"Philippines";PH;PHL;180;"Pangasinan";province;"PAN";16323
-"Philippines";PH;PHL;180;"Quezon";province;"QUE";17595
-"Philippines";PH;PHL;180;"Quirino";province;"QUI";16144
-"Philippines";PH;PHL;180;"Rizal";province;"RIZ";17583
-"Philippines";PH;PHL;180;"Romblon";province;"ROM";17082
-"Philippines";PH;PHL;180;"Sarangani";province;"SAR";17232
-"Philippines";PH;PHL;180;"Shariff Kabunsuan";;"X2~";21362
-"Philippines";PH;PHL;180;"Siquijor";province;"SIG";17306
-"Philippines";PH;PHL;180;"Soccsksargen (Region XII)";region;"12";48242
-"Philippines";PH;PHL;180;"Sorsogon";province;"SOR";16306
-"Philippines";PH;PHL;180;"South Cotabato";province;"SCO";16338
-"Philippines";PH;PHL;180;"Southern Leyte";province;"SLE";17219
-"Philippines";PH;PHL;180;"Sultan Kudarat";province;"SUK";17302
-"Philippines";PH;PHL;180;"Sulu";province;"SLU";16302
-"Philippines";PH;PHL;180;"Surigao del Norte";province;"SUN";16311
-"Philippines";PH;PHL;180;"Surigao del Sur";province;"SUR";17294
-"Philippines";PH;PHL;180;"Tarlac";province;"TAR";17296
-"Philippines";PH;PHL;180;"Tawi-Tawi";province;"TAW";17288
-"Philippines";PH;PHL;180;"Western Samar";province;"WSA";16320
-"Philippines";PH;PHL;180;"Western Visayas (Region VI)";region;"06";17213
-"Philippines";PH;PHL;180;"Zambales";province;"ZMB";17297
-"Philippines";PH;PHL;180;"Zamboanga del Norte";province;"ZAN";16346
-"Philippines";PH;PHL;180;"Zamboanga del Sur";province;"ZAS";17238
-"Philippines";PH;PHL;180;"Zamboanga Peninsula (Region IX)";region;"09";48243
-"Philippines";PH;PHL;180;"Zamboanga Sibuguey [Zamboanga Sibugay]";province;"ZSI";17672
-"Philippines";PH;PHL;180;"";;"MNL";48079
-"Poland";PL;POL;183;"Dolnoslaskie";Voivodship;"DS";17731
-"Poland";PL;POL;183;"Kujawsko-pomorskie";Voivodship;"KP";17732
-"Poland";PL;POL;183;"Lubelskie";Voivodship;"LU";17733
-"Poland";PL;POL;183;"Lubuskie";Voivodship;"LB";17740
-"Poland";PL;POL;183;"Lódzkie";Voivodship;"LD";17734
-"Poland";PL;POL;183;"Malopolskie";Voivodship;"MA";17744
-"Poland";PL;POL;183;"Mazowieckie";Voivodship;"MZ";17735
-"Poland";PL;POL;183;"Opolskie";Voivodship;"OP";17743
-"Poland";PL;POL;183;"Podkarpackie";Voivodship;"PK";17736
-"Poland";PL;POL;183;"Podlaskie";Voivodship;"PD";17742
-"Poland";PL;POL;183;"Pomorskie";Voivodship;"PM";17737
-"Poland";PL;POL;183;"Slaskie";Voivodship;"SL";17745
-"Poland";PL;POL;183;"Swietokrzyskie";Voivodship;"SK";17738
-"Poland";PL;POL;183;"Warminsko-mazurskie";Voivodship;"WN";17741
-"Poland";PL;POL;183;"Wielkopolskie";Voivodship;"WP";17739
-"Poland";PL;POL;183;"Zachodniopomorskie";Voivodship;"ZP";17730
-"Portugal";PT;PRT;184;"Aveiro";district;"01";19045
-"Portugal";PT;PRT;184;"Beja";district;"02";19046
-"Portugal";PT;PRT;184;"Braga";district;"03";19047
-"Portugal";PT;PRT;184;"Bragança";district;"04";19048
-"Portugal";PT;PRT;184;"Castelo Branco";district;"05";19049
-"Portugal";PT;PRT;184;"Coimbra";district;"06";19050
-"Portugal";PT;PRT;184;"Faro";district;"08";19052
-"Portugal";PT;PRT;184;"Guarda";district;"09";19053
-"Portugal";PT;PRT;184;"Leiria";district;"10";19054
-"Portugal";PT;PRT;184;"Lisboa";district;"11";19055
-"Portugal";PT;PRT;184;"Portalegre";district;"12";19056
-"Portugal";PT;PRT;184;"Porto";district;"13";19057
-"Portugal";PT;PRT;184;"Região Autónoma da Madeira";autonomous region;"30";17751
-"Portugal";PT;PRT;184;"Região Autónoma dos Açores";autonomous region;"20";17748
-"Portugal";PT;PRT;184;"Santarém";district;"14";19058
-"Portugal";PT;PRT;184;"Setúbal";district;"15";19059
-"Portugal";PT;PRT;184;"Viana do Castelo";district;"16";19060
-"Portugal";PT;PRT;184;"Vila Real";district;"17";19061
-"Portugal";PT;PRT;184;"Viseu";district;"18";19062
-"Portugal";PT;PRT;184;"Évora";district;"07";19051
-"Qatar";QA;QAT;186;"Ad Dawhah";Municipality;"DA";17769
-"Qatar";QA;QAT;186;"Al Ghuwayriyah";Municipality;"GH";17770
-"Qatar";QA;QAT;186;"Al Jumayliyah";Municipality;"JU";17764
-"Qatar";QA;QAT;186;"Al Khawr wa adh Dhakhīrah";Municipality;"KH";17765
-"Qatar";QA;QAT;186;"Al Wakrah";Municipality;"WA";17763
-"Qatar";QA;QAT;186;"Ar Rayyan";Municipality;"RA";17771
-"Qatar";QA;QAT;186;"Az̧ Z̧a‘āyin";Municipality;"ZA";48710
-"Qatar";QA;QAT;186;"Jariyan al Batnah";Municipality;"JB";17768
-"Qatar";QA;QAT;186;"Madinat ash Shamal";Municipality;"MS";17766
-"Qatar";QA;QAT;186;"Umm Sa'id";Municipality;"X1~";17767
-"Qatar";QA;QAT;186;"Umm Salal";Municipality;"US";17762
-"Romania";RO;ROU;189;"Alba";County;"AB";17794
-"Romania";RO;ROU;189;"Arad";County;"AR";17795
-"Romania";RO;ROU;189;"Arges";County;"AG";17796
-"Romania";RO;ROU;189;"Bacau";County;"BC";17797
-"Romania";RO;ROU;189;"Bihor";County;"BH";17798
-"Romania";RO;ROU;189;"Bistrita-Nasaud";County;"BN";17799
-"Romania";RO;ROU;189;"Botosani";County;"BT";17800
-"Romania";RO;ROU;189;"Braila";County;"BR";17801
-"Romania";RO;ROU;189;"Brasov";County;"BV";17783
-"Romania";RO;ROU;189;"Bucuresti";City;"B";17802
-"Romania";RO;ROU;189;"Buzau";County;"BZ";17784
-"Romania";RO;ROU;189;"Calarasi";County;"CL";17803
-"Romania";RO;ROU;189;"Caras-Severin";County;"CS";17785
-"Romania";RO;ROU;189;"Cluj";County;"CJ";17804
-"Romania";RO;ROU;189;"Constanta";County;"CT";17786
-"Romania";RO;ROU;189;"Covasna";County;"CV";17805
-"Romania";RO;ROU;189;"Dolj";County;"DJ";17788
-"Romania";RO;ROU;189;"Dâmbovita";County;"DB";17787
-"Romania";RO;ROU;189;"Galati";County;"GL";17806
-"Romania";RO;ROU;189;"Giurgiu";County;"GR";17789
-"Romania";RO;ROU;189;"Gorj";County;"GJ";17790
-"Romania";RO;ROU;189;"Harghita";County;"HR";17807
-"Romania";RO;ROU;189;"Hunedoara";County;"HD";17791
-"Romania";RO;ROU;189;"Ialomita";County;"IL";17782
-"Romania";RO;ROU;189;"Iasi";County;"IS";17792
-"Romania";RO;ROU;189;"Ilfov";County;"IF";17817
-"Romania";RO;ROU;189;"Maramures";County;"MM";17793
-"Romania";RO;ROU;189;"Mehedinti";County;"MH";17808
-"Romania";RO;ROU;189;"Mures";County;"MS";17821
-"Romania";RO;ROU;189;"Neamt";County;"NT";17809
-"Romania";RO;ROU;189;"Olt";County;"OT";17820
-"Romania";RO;ROU;189;"Prahova";County;"PH";17810
-"Romania";RO;ROU;189;"Salaj";County;"SJ";17811
-"Romania";RO;ROU;189;"Satu Mare";County;"SM";17819
-"Romania";RO;ROU;189;"Sibiu";County;"SB";17812
-"Romania";RO;ROU;189;"Suceava";County;"SV";17813
-"Romania";RO;ROU;189;"Teleorman";County;"TR";17822
-"Romania";RO;ROU;189;"Timis";County;"TM";17814
-"Romania";RO;ROU;189;"Tulcea";County;"TL";17815
-"Romania";RO;ROU;189;"Vaslui";County;"VS";17816
-"Romania";RO;ROU;189;"Vrancea";County;"VN";17781
-"Romania";RO;ROU;189;"Vâlcea";County;"VL";17818
-"Russian Federation";RU;RUS;190;"Respublika Adygeya";republic;"AD";17879
-"Russian Federation";RU;RUS;190;"Aginskiy Buryatskiy avtonomnyy okrug";autonomous district;"AGB";17880
-"Russian Federation";RU;RUS;190;"Respublika Altay";republic;"AL";17857
-"Russian Federation";RU;RUS;190;"Altayskiy kray";administrative territory;"ALT";17881
-"Russian Federation";RU;RUS;190;"Amurskaya oblast'";administrative region;"AMU";17882
-"Russian Federation";RU;RUS;190;"Arkhangel'skaya oblast'";administrative region;"ARK";17853
-"Russian Federation";RU;RUS;190;"Astrakhanskaya oblast'";administrative region;"AST";17883
-"Russian Federation";RU;RUS;190;"Respublika Bashkortostan";republic;"BA";17884
-"Russian Federation";RU;RUS;190;"Belgorodskaya oblast'";administrative region;"BEL";17854
-"Russian Federation";RU;RUS;190;"Bryanskaya oblast'";administrative region;"BRY";17885
-"Russian Federation";RU;RUS;190;"Respublika Buryatiya";republic;"BU";17886
-"Russian Federation";RU;RUS;190;"Chechenskaya Respublika";republic;"CE";17855
-"Russian Federation";RU;RUS;190;"Chelyabinskaya oblast'";administrative region;"CHE";17887
-"Russian Federation";RU;RUS;190;"Chitinskaya oblast'";administrative region;"CHI";17888
-"Russian Federation";RU;RUS;190;"Chukotskiy avtonomnyy okrug";autonomous district;"CHU";17889
-"Russian Federation";RU;RUS;190;"Chuvashskaya Respublika";republic;"CU";17856
-"Russian Federation";RU;RUS;190;"Respublika Dagestan";republic;"DA";17890
-"Russian Federation";RU;RUS;190;"Evenkiyskiy avtonomnyy okrug";autonomous district;"EVE";17891
-"Russian Federation";RU;RUS;190;"Ingushskaya Respublika [Respublika Ingushetiya]";republic;"IN";17894
-"Russian Federation";RU;RUS;190;"Irkutskaya oblast'";administrative region;"IRK";17895
-"Russian Federation";RU;RUS;190;"Ivanovskaya oblast'";administrative region;"IVA";17859
-"Russian Federation";RU;RUS;190;"Kabardino-Balkarskaya Respublika";republic;"KB";17899
-"Russian Federation";RU;RUS;190;"Kaliningradskaya oblast'";administrative region;"KGD";17900
-"Russian Federation";RU;RUS;190;"Respublika Kalmykiya";republic;"KL";17901
-"Russian Federation";RU;RUS;190;"Kaluzhskaya oblast'";administrative region;"KLU";17902
-"Russian Federation";RU;RUS;190;"Kamchatskaya oblast'";administrative territory;"KAM";17903
-"Russian Federation";RU;RUS;190;"Karachayevo-Cherkesskaya Respublika";republic;"KC";17904
-"Russian Federation";RU;RUS;190;"Respublika Kareliya";republic;"KR";17905
-"Russian Federation";RU;RUS;190;"Kemerovskaya oblast'";administrative region;"KEM";17843
-"Russian Federation";RU;RUS;190;"Khabarovskiy kray";administrative territory;"KHA";17892
-"Russian Federation";RU;RUS;190;"Respublika Khakasiya";republic;"KK";17893
-"Russian Federation";RU;RUS;190;"Khanty-Mansiyskiy avtonomnyy okrug [Yugra]";autonomous district;"KHM";17858
-"Russian Federation";RU;RUS;190;"Kirovskaya oblast'";administrative region;"KIR";17844
-"Russian Federation";RU;RUS;190;"Respublika Komi";republic;"KO";17845
-"Russian Federation";RU;RUS;190;"Komi-Permyak";;"X1~";17846
-"Russian Federation";RU;RUS;190;"Koryakskiy avtonomnyy okrug";autonomous district;"KOR";17860
-"Russian Federation";RU;RUS;190;"Kostromskaya oblast'";administrative region;"KOS";17847
-"Russian Federation";RU;RUS;190;"Krasnodarskiy kray";administrative territory;"KDA";17861
-"Russian Federation";RU;RUS;190;"Krasnoyarskiy kray";administrative territory;"KYA";17848
-"Russian Federation";RU;RUS;190;"Kurganskaya oblast'";administrative region;"KGN";17849
-"Russian Federation";RU;RUS;190;"Kurskaya oblast'";administrative region;"KRS";17862
-"Russian Federation";RU;RUS;190;"Leningradskaya oblast'";administrative region;"LEN";17850
-"Russian Federation";RU;RUS;190;"Lipetskaya oblast'";administrative region;"LIP";17863
-"Russian Federation";RU;RUS;190;"Magadanskaya oblast'";administrative region;"MAG";17851
-"Russian Federation";RU;RUS;190;"Respublika Mariy El";republic;"ME";17834
-"Russian Federation";RU;RUS;190;"Respublika Mordoviya";republic;"MO";17864
-"Russian Federation";RU;RUS;190;"Moskovskaya oblast'";administrative region;"MOS";17836
-"Russian Federation";RU;RUS;190;"Moskva";autonomous city;"MOW";17835
-"Russian Federation";RU;RUS;190;"Murmanskaya oblast'";administrative region;"MUR";17865
-"Russian Federation";RU;RUS;190;"Nenetskiy avtonomnyy okrug";autonomous district;"NEN";17837
-"Russian Federation";RU;RUS;190;"Nizhegorodskaya oblast'";administrative region;"NIZ";17838
-"Russian Federation";RU;RUS;190;"Novgorodskaya oblast'";administrative region;"NGR";17866
-"Russian Federation";RU;RUS;190;"Novosibirskaya oblast'";administrative region;"NVS";17839
-"Russian Federation";RU;RUS;190;"Omskaya oblast'";administrative region;"OMS";17867
-"Russian Federation";RU;RUS;190;"Orenburgskaya oblast'";administrative region;"ORE";17840
-"Russian Federation";RU;RUS;190;"Orlovskaya oblast'";administrative region;"ORL";17841
-"Russian Federation";RU;RUS;190;"Penzenskaya oblast'";administrative region;"PNZ";17868
-"Russian Federation";RU;RUS;190;"Perm";administrative territory;"PER";17842
-"Russian Federation";RU;RUS;190;"Primorskiy kray";administrative territory;"PRI";17825
-"Russian Federation";RU;RUS;190;"Pskovskaya oblast'";administrative region;"PSK";17869
-"Russian Federation";RU;RUS;190;"Rostovskaya oblast'";administrative region;"ROS";17870
-"Russian Federation";RU;RUS;190;"Ryazanskaya oblast'";administrative region;"RYA";17826
-"Russian Federation";RU;RUS;190;"Respublika [Yakutiya] Sakha";republic;"SA";17827
-"Russian Federation";RU;RUS;190;"Sakhalinskaya oblast'";administrative region;"SAK";17828
-"Russian Federation";RU;RUS;190;"Samarskaya oblast'";administrative region;"SAM";17871
-"Russian Federation";RU;RUS;190;"Sankt-Peterburg";autonomous city;"SPE";17829
-"Russian Federation";RU;RUS;190;"Saratovskaya oblast'";administrative region;"SAR";17872
-"Russian Federation";RU;RUS;190;"Respublika [Alaniya] [Respublika Severnaya Osetiya-Alaniya] Severnaya Osetiya";republic;"SE";17852
-"Russian Federation";RU;RUS;190;"Smolenskaya oblast'";administrative region;"SMO";17830
-"Russian Federation";RU;RUS;190;"Stavropol'skiy kray";administrative territory;"STA";17831
-"Russian Federation";RU;RUS;190;"Sverdlovskaya oblast'";administrative region;"SVE";17832
-"Russian Federation";RU;RUS;190;"Tambovskaya oblast'";administrative region;"TAM";17833
-"Russian Federation";RU;RUS;190;"Respublika Tatarstan";republic;"TA";17824
-"Russian Federation";RU;RUS;190;"Taymyrskiy (Dolgano-Nenetskiy) avtonomnyy okrug";autonomous district;"TAY";17873
-"Russian Federation";RU;RUS;190;"Tomskaya oblast'";administrative region;"TOM";17906
-"Russian Federation";RU;RUS;190;"Tul'skaya oblast'";administrative region;"TUL";17875
-"Russian Federation";RU;RUS;190;"Tverskaya oblast'";administrative region;"TVE";17910
-"Russian Federation";RU;RUS;190;"Tyumenskaya oblast'";administrative region;"TYU";17874
-"Russian Federation";RU;RUS;190;"Respublika [Tuva] Tyva";republic;"TY";17909
-"Russian Federation";RU;RUS;190;"Udmurtskaya Respublika";republic;"UD";17876
-"Russian Federation";RU;RUS;190;"Ul'yanovskaya oblast'";administrative region;"ULY";17908
-"Russian Federation";RU;RUS;190;"Ust'-Ordynskiy Buryatskiy avtonomnyy okrug";autonomous district;"UOB";17911
-"Russian Federation";RU;RUS;190;"Vladimirskaya oblast'";administrative region;"VLA";17877
-"Russian Federation";RU;RUS;190;"Volgogradskaya oblast'";administrative region;"VGG";17907
-"Russian Federation";RU;RUS;190;"Vologodskaya oblast'";administrative region;"VLG";17823
-"Russian Federation";RU;RUS;190;"Voronezhskaya oblast'";administrative region;"VOR";17878
-"Russian Federation";RU;RUS;190;"Yamalo-Nenetskiy avtonomnyy okrug";autonomous district;"YAN";17896
-"Russian Federation";RU;RUS;190;"Yaroslavskaya oblast'";administrative region;"YAR";17897
-"Russian Federation";RU;RUS;190;"Yevreyskaya avtonomnaya oblast'";autonomous region;"YEV";17898
-"Russian Federation";RU;RUS;190;"Zabajkal'skij kraj";administrative territory;"ZAB";48221
-"Rwanda";RW;RWA;191;"Est";province;"02";19063
-"Rwanda";RW;RWA;191;"Nord";province;"03";19064
-"Rwanda";RW;RWA;191;"Ouest";province;"04";19065
-"Rwanda";RW;RWA;191;"Sud";province;"05";17912
-"Rwanda";RW;RWA;191;"Ville de Kigali";province;"01";17923
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Ascension";dependency;"AC";17926
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Ascension";geographical entities;"AC";48879
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Saint Helena";geographical entities;"HL";48880
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Saint Helena";administrative area;"SH";17930
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Tristan da Cunha";geographical entities;"TA";48881
-"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Tristan da Cunha";dependency;"TA";17925
-"Saint Kitts And Nevis";KN;KNA;193;"Christ Church Nichola Town";Parish;"01";17933
-"Saint Kitts And Nevis";KN;KNA;193;"Nevis";state;"N";48461
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Anne Sandy Point";Parish;"02";17940
-"Saint Kitts And Nevis";KN;KNA;193;"Saint George Basseterre";Parish;"03";17934
-"Saint Kitts And Nevis";KN;KNA;193;"Saint George Gingerland";Parish;"04";17941
-"Saint Kitts And Nevis";KN;KNA;193;"Saint James Windward";Parish;"05";17935
-"Saint Kitts And Nevis";KN;KNA;193;"Saint John Capisterre";Parish;"06";17932
-"Saint Kitts And Nevis";KN;KNA;193;"Saint John Figtree";Parish;"07";17936
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Kitts";state;"K";48460
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Mary Cayon";Parish;"08";17942
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Paul Capisterre";Parish;"09";17937
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Paul Charlestown";Parish;"10";17944
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Peter Basseterre";Parish;"11";17938
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Thomas Lowland";Parish;"12";17943
-"Saint Kitts And Nevis";KN;KNA;193;"Saint Thomas Middle Island";Parish;"13";17939
-"Saint Kitts And Nevis";KN;KNA;193;"Trinity Palmetto Point";Parish;"15";17931
-"Saint Vincent And The Grenadines";VC;VCT;195;"Charlotte";Parish;"01";17963
-"Saint Vincent And The Grenadines";VC;VCT;195;"Grenadines";Parish;"06";17958
-"Saint Vincent And The Grenadines";VC;VCT;195;"Saint Andrew";Parish;"02";17962
-"Saint Vincent And The Grenadines";VC;VCT;195;"Saint David";Parish;"03";17959
-"Saint Vincent And The Grenadines";VC;VCT;195;"Saint George";Parish;"04";17957
-"Saint Vincent And The Grenadines";VC;VCT;195;"Saint Patrick";Parish;"05";17960
-"Samoa";WS;WSM;196;"A'ana";District;"AA";20647
-"Samoa";WS;WSM;196;"Aiga-i-le-Tai";District;"AL";20648
-"Samoa";WS;WSM;196;"Atua";District;"AT";20649
-"Samoa";WS;WSM;196;"Fa'asaleleaga";District;"FA";20650
-"Samoa";WS;WSM;196;"Gaga'emauga";District;"GE";20651
-"Samoa";WS;WSM;196;"Gagaifomauga";District;"GI";20652
-"Samoa";WS;WSM;196;"Palauli";District;"PA";20653
-"Samoa";WS;WSM;196;"Satupa'itea";District;"SA";20654
-"Samoa";WS;WSM;196;"Tuamasaga";District;"TU";20655
-"Samoa";WS;WSM;196;"Va'a-o-Fonoti";District;"VF";20656
-"Samoa";WS;WSM;196;"Vaisigano";District;"VS";20657
-"San Marino";SM;SMR;197;"Acquaviva";Municipality;"01";17972
-"San Marino";SM;SMR;197;"Borgo Maggiore";Municipality;"06";17971
-"San Marino";SM;SMR;197;"Chiesanuova";Municipality;"02";17973
-"San Marino";SM;SMR;197;"Domagnano";Municipality;"03";17970
-"San Marino";SM;SMR;197;"Faetano";Municipality;"04";17974
-"San Marino";SM;SMR;197;"Fiorentino";Municipality;"05";17969
-"San Marino";SM;SMR;197;"Montegiardino";Municipality;"08";17975
-"San Marino";SM;SMR;197;"San Marino";Municipality;"07";17976
-"San Marino";SM;SMR;197;"Serravalle";Municipality;"09";17968
-"Sao Tome and Principe";ST;STP;198;"Príncipe";Municipality;"P";20324
-"Sao Tome and Principe";ST;STP;198;"São Tomé";Municipality;"S";20325
-"Saudi Arabia";SA;SAU;199;"?a'il";Region;"06";17981
-"Saudi Arabia";SA;SAU;199;"?Asir";Region;"14";17984
-"Saudi Arabia";SA;SAU;199;"Al Bāḩah";Region;"11";17980
-"Saudi Arabia";SA;SAU;199;"Al Jawf";Region;"12";17982
-"Saudi Arabia";SA;SAU;199;"Al Madinah";Region;"03";17979
-"Saudi Arabia";SA;SAU;199;"Al Qasim";Region;"05";17988
-"Saudi Arabia";SA;SAU;199;"Al Ḩudūd ash Shamālīyah";Region;"08";17985
-"Saudi Arabia";SA;SAU;199;"Ar Riyāḑ";Region;"01";17978
-"Saudi Arabia";SA;SAU;199;"Ash Sharqiyah";Region;"04";17989
-"Saudi Arabia";SA;SAU;199;"Jizan";Region;"09";17986
-"Saudi Arabia";SA;SAU;199;"Makkah";Region;"02";17987
-"Saudi Arabia";SA;SAU;199;"Najran";Region;"10";17983
-"Saudi Arabia";SA;SAU;199;"Tabuk";Region;"07";17977
-"Senegal";SN;SEN;200;"Dakar";region;"DK";17998
-"Senegal";SN;SEN;200;"Diourbel";region;"DB";17991
-"Senegal";SN;SEN;200;"Fatick";region;"FK";17997
-"Senegal";SN;SEN;200;"Kaffrine";region;"KA";48218
-"Senegal";SN;SEN;200;"Kaolack";region;"KL";17999
-"Senegal";SN;SEN;200;"Kolda";region;"KD";17993
-"Senegal";SN;SEN;200;"Kédougou";region;"KE";48219
-"Senegal";SN;SEN;200;"Louga";region;"LG";17996
-"Senegal";SN;SEN;200;"Matam";region;"MT";17994
-"Senegal";SN;SEN;200;"Saint-Louis";region;"SL";17992
-"Senegal";SN;SEN;200;"Sédhiou";region;"SE";48220
-"Senegal";SN;SEN;200;"Tambacounda";region;"TC";18000
-"Senegal";SN;SEN;200;"Thiès";region;"TH";17995
-"Senegal";SN;SEN;200;"Ziguinchor";region;"ZG";17990
-"Serbia";RS;SRB;201;"Belgrade";city;"00";47890
-"Serbia";RS;SRB;201;"Borski okrug";district;"14";19066
-"Serbia";RS;SRB;201;"Braničevski okrug";district;"11";19067
-"Serbia";RS;SRB;201;"Jablanički okrug";district;"23";19068
-"Serbia";RS;SRB;201;"Južnobanatski okrug";district;"06";19069
-"Serbia";RS;SRB;201;"Južnobanatski okrug";district;"04";19070
-"Serbia";RS;SRB;201;"Kolubarski okrug";district;"09";19071
-"Serbia";RS;SRB;201;"Kosovski okrug";district;"25";18004
-"Serbia";RS;SRB;201;"Kosovsko-Mitrovački okrug";district;"28";19074
-"Serbia";RS;SRB;201;"Kosovsko-Pomoravski okrug";district;"29";19073
-"Serbia";RS;SRB;201;"Mačvanski okrug";district;"08";19075
-"Serbia";RS;SRB;201;"Moravički okrug";district;"17";19076
-"Serbia";RS;SRB;201;"Nišavski okrug";district;"20";19077
-"Serbia";RS;SRB;201;"Pećki okrug";district;"26";19079
-"Serbia";RS;SRB;201;"Pirotski okrug";district;"22";19080
-"Serbia";RS;SRB;201;"Podunavski okrug";district;"10";19081
-"Serbia";RS;SRB;201;"Pomoravski okrug";district;"13";19082
-"Serbia";RS;SRB;201;"Prizrenski okrug";district;"27";19083
-"Serbia";RS;SRB;201;"Pčinjski okrug";district;"24";19078
-"Serbia";RS;SRB;201;"Rasinski okrug";district;"19";19084
-"Serbia";RS;SRB;201;"Raška okrug";district;"18";19085
-"Serbia";RS;SRB;201;"Severnobanatski okrug";district;"03";19087
-"Serbia";RS;SRB;201;"Severnobački okrug";district;"01";19086
-"Serbia";RS;SRB;201;"Srednjebanatski okrug";district;"02";19088
-"Serbia";RS;SRB;201;"Sremski okrug";district;"07";19089
-"Serbia";RS;SRB;201;"Toplièki okrug";district;"21";19091
-"Serbia";RS;SRB;201;"Zajeèarski okrug";district;"15";19092
-"Serbia";RS;SRB;201;"Zapadnobaèki okrug";district;"05";19093
-"Serbia";RS;SRB;201;"Zlatiborski okrug";district;"16";19094
-"Serbia";RS;SRB;201;"Šumadijski okrug";district;"12";19090
-"Seychelles";SC;SYC;202;"Anse aux Pins";District;"01";18014
-"Seychelles";SC;SYC;202;"Anse Boileau";District;"02";18017
-"Seychelles";SC;SYC;202;"Anse Royale";District;"05";18015
-"Seychelles";SC;SYC;202;"Anse Étoile";District;"03";18018
-"Seychelles";SC;SYC;202;"Au Cap";District;"04";18019
-"Seychelles";SC;SYC;202;"Baie Lazare";District;"06";18006
-"Seychelles";SC;SYC;202;"Baie Sainte Anne";District;"07";18020
-"Seychelles";SC;SYC;202;"Beau Vallon";District;"08";18021
-"Seychelles";SC;SYC;202;"Bel Air";District;"09";18025
-"Seychelles";SC;SYC;202;"Bel Ombre";District;"10";18022
-"Seychelles";SC;SYC;202;"Cascade";District;"11";18029
-"Seychelles";SC;SYC;202;"English River";District;"16";18023
-"Seychelles";SC;SYC;202;"Glacis";District;"12";18024
-"Seychelles";SC;SYC;202;"Grand Anse Mahe";District;"13";18028
-"Seychelles";SC;SYC;202;"Grand Anse Praslin";District;"14";18007
-"Seychelles";SC;SYC;202;"La Digue";District;"15";18027
-"Seychelles";SC;SYC;202;"Les Mamelles";District;"24";48216
-"Seychelles";SC;SYC;202;"Mont Buxton";District;"17";18009
-"Seychelles";SC;SYC;202;"Mont Fleuri";District;"18";18030
-"Seychelles";SC;SYC;202;"Plaisance";District;"19";18026
-"Seychelles";SC;SYC;202;"Pointe La Rue";District;"20";18011
-"Seychelles";SC;SYC;202;"Port Glaud";District;"21";18012
-"Seychelles";SC;SYC;202;"Roche Caiman";District;"25";48217
-"Seychelles";SC;SYC;202;"Saint Louis";District;"22";18013
-"Seychelles";SC;SYC;202;"Takamaka";District;"23";18005
-"Sierra Leone";SL;SLE;203;"Eastern";province;"E";18044
-"Sierra Leone";SL;SLE;203;"Northern";province;"N";18033
-"Sierra Leone";SL;SLE;203;"Southern";province;"S";18045
-"Sierra Leone";SL;SLE;203;"Western Area (Freetown)";area;"W";18034
-"Singapore";SG;SGP;205;"Central Singapore";District;"01";48250
-"Singapore";SG;SGP;205;"North East";District;"02";48251
-"Singapore";SG;SGP;205;"North West";District;"03";48252
-"Singapore";SG;SGP;205;"Singapore - No State";;"X1~";48078
-"Singapore";SG;SGP;205;"South East";District;"04";48253
-"Singapore";SG;SGP;205;"South West";District;"05";48254
-"Slovakia";SK;SVK;206;"Banskobystrický kraj";Region;"BC";18060
-"Slovakia";SK;SVK;206;"Bratislavský kraj";Region;"BL";18053
-"Slovakia";SK;SVK;206;"Košický kraj";Region;"KI";18059
-"Slovakia";SK;SVK;206;"Nitriansky kraj";Region;"NI";18054
-"Slovakia";SK;SVK;206;"Prešovský kraj";Region;"PV";18055
-"Slovakia";SK;SVK;206;"Trenciansky kraj";Region;"TC";18052
-"Slovakia";SK;SVK;206;"Trnavský kraj";Region;"TA";18056
-"Slovakia";SK;SVK;206;"Žilinský kraj";Region;"ZI";18057
-"Slovenia";SI;SVN;207;"Ajdovšcina";;"001";20197
-"Slovenia";SI;SVN;207;"Apače";commune;"195";48197
-"Slovenia";SI;SVN;207;"Beltinci";;"002";20198
-"Slovenia";SI;SVN;207;"Benedikt";;"148";20199
-"Slovenia";SI;SVN;207;"Bistrica ob Sotli";;"149";20200
-"Slovenia";SI;SVN;207;"Bled";;"003";20201
-"Slovenia";SI;SVN;207;"Bloke";;"150";20202
-"Slovenia";SI;SVN;207;"Bohinj";;"004";20203
-"Slovenia";SI;SVN;207;"Borovnica";;"005";20204
-"Slovenia";SI;SVN;207;"Bovec";;"006";20205
-"Slovenia";SI;SVN;207;"Braslovce";;"151";20206
-"Slovenia";SI;SVN;207;"Brda";;"007";20207
-"Slovenia";SI;SVN;207;"Brezovica";;"008";20208
-"Slovenia";SI;SVN;207;"Brežice";;"009";19899
-"Slovenia";SI;SVN;207;"Cankova";;"152";19900
-"Slovenia";SI;SVN;207;"Celje";;"011";19901
-"Slovenia";SI;SVN;207;"Cerklje na Gorenjskem";;"012";19902
-"Slovenia";SI;SVN;207;"Cerknica";;"013";19903
-"Slovenia";SI;SVN;207;"Cerkno";;"014";19904
-"Slovenia";SI;SVN;207;"Cerkvenjak";;"153";19905
-"Slovenia";SI;SVN;207;"Cirkulane";commune;"197";48198
-"Slovenia";SI;SVN;207;"Crenšovci";;"015";19906
-"Slovenia";SI;SVN;207;"Crna na Koroškem";;"016";19907
-"Slovenia";SI;SVN;207;"Crnomelj";;"017";19908
-"Slovenia";SI;SVN;207;"Destrnik";;"018";19909
-"Slovenia";SI;SVN;207;"Divaca";;"019";19910
-"Slovenia";SI;SVN;207;"Dobje";;"154";19911
-"Slovenia";SI;SVN;207;"Dobrepolje";;"020";19912
-"Slovenia";SI;SVN;207;"Dobrna";;"155";19913
-"Slovenia";SI;SVN;207;"Dobrova-Polhov Gradec";;"021";19914
-"Slovenia";SI;SVN;207;"Dobrovnik/Dobronak";;"156";19915
-"Slovenia";SI;SVN;207;"Dol pri Ljubljani";;"022";19916
-"Slovenia";SI;SVN;207;"Dolenjske Toplice";;"157";19917
-"Slovenia";SI;SVN;207;"Domžale";;"023";19918
-"Slovenia";SI;SVN;207;"Dornava";;"024";19919
-"Slovenia";SI;SVN;207;"Dravograd";;"025";19920
-"Slovenia";SI;SVN;207;"Duplek";;"026";19921
-"Slovenia";SI;SVN;207;"Gorenja vas-Poljane";;"027";19922
-"Slovenia";SI;SVN;207;"Gorišnica";;"028";19923
-"Slovenia";SI;SVN;207;"Gorje";commune;"207";48212
-"Slovenia";SI;SVN;207;"Gornja Radgona";;"029";19924
-"Slovenia";SI;SVN;207;"Gornji Grad";;"030";19925
-"Slovenia";SI;SVN;207;"Gornji Petrovci";;"031";19926
-"Slovenia";SI;SVN;207;"Grad";;"158";19927
-"Slovenia";SI;SVN;207;"Grosuplje";;"032";19928
-"Slovenia";SI;SVN;207;"Hajdina";;"159";19929
-"Slovenia";SI;SVN;207;"Hoce-Slivnica";;"160";19930
-"Slovenia";SI;SVN;207;"Hodoš/Hodos";;"161";19931
-"Slovenia";SI;SVN;207;"Horjul";;"162";19932
-"Slovenia";SI;SVN;207;"Hrastnik";;"034";19933
-"Slovenia";SI;SVN;207;"Hrpelje-Kozina";;"035";19934
-"Slovenia";SI;SVN;207;"Idrija";;"036";19935
-"Slovenia";SI;SVN;207;"Ig";;"037";19936
-"Slovenia";SI;SVN;207;"Ilirska Bistrica";;"038";19937
-"Slovenia";SI;SVN;207;"Ivancna Gorica";;"039";19938
-"Slovenia";SI;SVN;207;"Izola/Isola";;"040";19939
-"Slovenia";SI;SVN;207;"Jesenice";;"041";19940
-"Slovenia";SI;SVN;207;"Jezersko";;"163";19941
-"Slovenia";SI;SVN;207;"Juršinci";;"042";19942
-"Slovenia";SI;SVN;207;"Kamnik";;"043";19943
-"Slovenia";SI;SVN;207;"Kanal";;"044";19944
-"Slovenia";SI;SVN;207;"Kidricevo";;"045";19945
-"Slovenia";SI;SVN;207;"Kobarid";;"046";19946
-"Slovenia";SI;SVN;207;"Kobilje";;"047";19947
-"Slovenia";SI;SVN;207;"Kocevje";;"048";19948
-"Slovenia";SI;SVN;207;"Komen";;"049";19949
-"Slovenia";SI;SVN;207;"Komenda";;"164";19950
-"Slovenia";SI;SVN;207;"Koper/Capodistria";;"050";19951
-"Slovenia";SI;SVN;207;"Kosanjevica na Krki";commune;"196";48199
-"Slovenia";SI;SVN;207;"Kostel";;"165";19952
-"Slovenia";SI;SVN;207;"Kozje";;"051";19953
-"Slovenia";SI;SVN;207;"Kranj";;"052";19954
-"Slovenia";SI;SVN;207;"Kranjska Gora";;"053";19955
-"Slovenia";SI;SVN;207;"Križevci";;"166";19956
-"Slovenia";SI;SVN;207;"Krško";;"054";19957
-"Slovenia";SI;SVN;207;"Kungota";;"055";19958
-"Slovenia";SI;SVN;207;"Kuzma";;"056";19959
-"Slovenia";SI;SVN;207;"Laško";;"057";19960
-"Slovenia";SI;SVN;207;"Lenart";;"058";19961
-"Slovenia";SI;SVN;207;"Lendava/Lendva";;"059";19962
-"Slovenia";SI;SVN;207;"Litija";;"060";19963
-"Slovenia";SI;SVN;207;"Ljubljana";;"061";19964
-"Slovenia";SI;SVN;207;"Ljubno";;"062";19965
-"Slovenia";SI;SVN;207;"Ljutomer";;"063";19966
-"Slovenia";SI;SVN;207;"Log-Dragomer";commune;"208";48213
-"Slovenia";SI;SVN;207;"Logatec";;"064";19967
-"Slovenia";SI;SVN;207;"Lovrenc na Pohorju";;"167";19970
-"Slovenia";SI;SVN;207;"Loška dolina";;"065";19968
-"Slovenia";SI;SVN;207;"Loški Potok";;"066";19969
-"Slovenia";SI;SVN;207;"Luce";;"067";19971
-"Slovenia";SI;SVN;207;"Lukovica";;"068";19972
-"Slovenia";SI;SVN;207;"Majšperk";;"069";19973
-"Slovenia";SI;SVN;207;"Makole";commune;"198";48200
-"Slovenia";SI;SVN;207;"Maribor";;"070";19974
-"Slovenia";SI;SVN;207;"Markovci";;"168";19975
-"Slovenia";SI;SVN;207;"Medvode";;"071";19976
-"Slovenia";SI;SVN;207;"Mengeš";;"072";19977
-"Slovenia";SI;SVN;207;"Metlika";;"073";19978
-"Slovenia";SI;SVN;207;"Mežica";;"074";19979
-"Slovenia";SI;SVN;207;"Miklavž na Dravskem polju";;"169";19980
-"Slovenia";SI;SVN;207;"Miren-Kostanjevica";;"075";19981
-"Slovenia";SI;SVN;207;"Mirna Pec";;"170";19982
-"Slovenia";SI;SVN;207;"Mislinja";;"076";19983
-"Slovenia";SI;SVN;207;"Mokronog-Trebelno";commune;"199";48201
-"Slovenia";SI;SVN;207;"Moravce";;"077";19984
-"Slovenia";SI;SVN;207;"Moravske Toplice";;"078";19985
-"Slovenia";SI;SVN;207;"Mozirje";;"079";19986
-"Slovenia";SI;SVN;207;"Murska Sobota";;"080";19987
-"Slovenia";SI;SVN;207;"Muta";;"081";19988
-"Slovenia";SI;SVN;207;"Naklo";;"082";19989
-"Slovenia";SI;SVN;207;"Nazarje";;"083";19990
-"Slovenia";SI;SVN;207;"Nova Gorica";;"084";19991
-"Slovenia";SI;SVN;207;"Novo mesto";;"085";19992
-"Slovenia";SI;SVN;207;"Odranci";;"086";19993
-"Slovenia";SI;SVN;207;"Oplotnica";;"171";19994
-"Slovenia";SI;SVN;207;"Ormož";;"087";19995
-"Slovenia";SI;SVN;207;"Osilnica";;"088";19996
-"Slovenia";SI;SVN;207;"Pesnica";;"089";19997
-"Slovenia";SI;SVN;207;"Piran/Pirano";;"090";19998
-"Slovenia";SI;SVN;207;"Pivka";;"091";19999
-"Slovenia";SI;SVN;207;"Podcetrtek";;"092";20000
-"Slovenia";SI;SVN;207;"Podlehnik";;"172";20001
-"Slovenia";SI;SVN;207;"Podvelka";;"093";20002
-"Slovenia";SI;SVN;207;"Poljčane";commune;"200";48202
-"Slovenia";SI;SVN;207;"Polzela";;"173";20003
-"Slovenia";SI;SVN;207;"Postojna";;"094";20004
-"Slovenia";SI;SVN;207;"Prebold";;"174";20005
-"Slovenia";SI;SVN;207;"Preddvor";;"095";20006
-"Slovenia";SI;SVN;207;"Prevalje";;"175";20007
-"Slovenia";SI;SVN;207;"Ptuj";;"096";20008
-"Slovenia";SI;SVN;207;"Puconci";;"097";20009
-"Slovenia";SI;SVN;207;"Race-Fram";;"098";20010
-"Slovenia";SI;SVN;207;"Radece";;"099";20011
-"Slovenia";SI;SVN;207;"Radenci";;"100";20012
-"Slovenia";SI;SVN;207;"Radlje ob Dravi";;"101";20013
-"Slovenia";SI;SVN;207;"Radovljica";;"102";20014
-"Slovenia";SI;SVN;207;"Ravne na Koroškem";;"103";20015
-"Slovenia";SI;SVN;207;"Razkrižje";;"176";20016
-"Slovenia";SI;SVN;207;"Renče-Vogrsko";commune;"201";48203
-"Slovenia";SI;SVN;207;"Rečica ob Savinji";commune;"209";48204
-"Slovenia";SI;SVN;207;"Ribnica";;"104";20017
-"Slovenia";SI;SVN;207;"Ribnica na Pohorju";;"177";20018
-"Slovenia";SI;SVN;207;"Rogatec";;"107";20021
-"Slovenia";SI;SVN;207;"Rogaška Slatina";;"106";20019
-"Slovenia";SI;SVN;207;"Rogašovci";;"105";20020
-"Slovenia";SI;SVN;207;"Ruše";;"108";20022
-"Slovenia";SI;SVN;207;"Selnica ob Dravi";;"178";20023
-"Slovenia";SI;SVN;207;"Semic";;"109";20024
-"Slovenia";SI;SVN;207;"Sevnica";;"110";20025
-"Slovenia";SI;SVN;207;"Sežana";;"111";20026
-"Slovenia";SI;SVN;207;"Slovenj Gradec";;"112";20027
-"Slovenia";SI;SVN;207;"Slovenska Bistrica";;"113";20028
-"Slovenia";SI;SVN;207;"Slovenske Konjice";;"114";20029
-"Slovenia";SI;SVN;207;"Sodražica";;"179";20030
-"Slovenia";SI;SVN;207;"Solcava";;"180";20031
-"Slovenia";SI;SVN;207;"Središče ob Dravi";commune;"202";48206
-"Slovenia";SI;SVN;207;"Starše";;"115";20032
-"Slovenia";SI;SVN;207;"Straža";commune;"203";48207
-"Slovenia";SI;SVN;207;"Sveta Ana";;"181";20033
-"Slovenia";SI;SVN;207;"Sveta Trojica v Slovenskih Goricah";commune;"204";48208
-"Slovenia";SI;SVN;207;"Sveti Andraž v Slovenskih goricah";;"182";20034
-"Slovenia";SI;SVN;207;"Sveti Jurij";;"116";20035
-"Slovenia";SI;SVN;207;"Sveti Jurij v Slovenskih Goricah";commune;"210";48205
-"Slovenia";SI;SVN;207;"Sveti Tomaž";commune;"205";48209
-"Slovenia";SI;SVN;207;"Tabor";;"184";20050
-"Slovenia";SI;SVN;207;"Tišina";;"010";20051
-"Slovenia";SI;SVN;207;"Tolmin";;"128";20052
-"Slovenia";SI;SVN;207;"Trbovlje";;"129";20053
-"Slovenia";SI;SVN;207;"Trebnje";;"130";20054
-"Slovenia";SI;SVN;207;"Trnovska vas";;"185";20055
-"Slovenia";SI;SVN;207;"Trzin";;"186";20057
-"Slovenia";SI;SVN;207;"Tržic";;"131";20056
-"Slovenia";SI;SVN;207;"Turnišce";;"132";20058
-"Slovenia";SI;SVN;207;"Velenje";;"133";20059
-"Slovenia";SI;SVN;207;"Velika Polana";;"187";20060
-"Slovenia";SI;SVN;207;"Velike Lašce";;"134";20061
-"Slovenia";SI;SVN;207;"Veržej";;"188";20062
-"Slovenia";SI;SVN;207;"Videm";;"135";20063
-"Slovenia";SI;SVN;207;"Vipava";;"136";20064
-"Slovenia";SI;SVN;207;"Vitanje";;"137";20065
-"Slovenia";SI;SVN;207;"Vodice";;"138";20066
-"Slovenia";SI;SVN;207;"Vojnik";;"139";20067
-"Slovenia";SI;SVN;207;"Vransko";;"189";20068
-"Slovenia";SI;SVN;207;"Vrhnika";;"140";20069
-"Slovenia";SI;SVN;207;"Vuzenica";;"141";20070
-"Slovenia";SI;SVN;207;"Zagorje ob Savi";;"142";20071
-"Slovenia";SI;SVN;207;"Zavrc";;"143";20072
-"Slovenia";SI;SVN;207;"Zrece";;"144";20073
-"Slovenia";SI;SVN;207;"Šalovci";;"033";20036
-"Slovenia";SI;SVN;207;"Šempeter-Vrtojba";;"183";20037
-"Slovenia";SI;SVN;207;"Šencur";;"117";20038
-"Slovenia";SI;SVN;207;"Šentilj";;"118";20039
-"Slovenia";SI;SVN;207;"Šentjernej";;"119";20040
-"Slovenia";SI;SVN;207;"Šentjur pri Celju";;"120";20041
-"Slovenia";SI;SVN;207;"Šentrupert";commune;"211";48210
-"Slovenia";SI;SVN;207;"Škocjan";;"121";20042
-"Slovenia";SI;SVN;207;"Škofja Loka";;"122";20043
-"Slovenia";SI;SVN;207;"Škofljica";;"123";20044
-"Slovenia";SI;SVN;207;"Šmarje pri Jelšah";;"124";20045
-"Slovenia";SI;SVN;207;"Šmarješke Toplice";commune;"206";48211
-"Slovenia";SI;SVN;207;"Šmartno ob Paki";;"125";20046
-"Slovenia";SI;SVN;207;"Šmartno pri Litiji";;"194";20047
-"Slovenia";SI;SVN;207;"Šmartno pri Litiji";commune;"194";48196
-"Slovenia";SI;SVN;207;"Šoštanj";;"126";20048
-"Slovenia";SI;SVN;207;"Štore";;"127";20049
-"Slovenia";SI;SVN;207;"Žalec";;"190";20074
-"Slovenia";SI;SVN;207;"Železniki";;"146";20075
-"Slovenia";SI;SVN;207;"Žetale";;"191";20076
-"Slovenia";SI;SVN;207;"Žiri";;"147";20077
-"Slovenia";SI;SVN;207;"Žirovnica";;"192";20078
-"Slovenia";SI;SVN;207;"Žužemberk";;"193";20079
-"Solomon Islands";SB;SLB;208;"Capital Territory (Honiara)";capital territory;"CT";18079
-"Solomon Islands";SB;SLB;208;"Central";province;"CE";18074
-"Solomon Islands";SB;SLB;208;"Choiseul";province;"CH";18075
-"Solomon Islands";SB;SLB;208;"Guadalcanal";province;"GU";18076
-"Solomon Islands";SB;SLB;208;"Isabel";province;"IS";18081
-"Solomon Islands";SB;SLB;208;"Makira";province;"MK";18080
-"Solomon Islands";SB;SLB;208;"Malaita";province;"ML";18082
-"Solomon Islands";SB;SLB;208;"Rennell and Bellona";province;"RB";18078
-"Solomon Islands";SB;SLB;208;"Temotu";province;"TE";18073
-"Solomon Islands";SB;SLB;208;"Western";province;"WE";18077
-"Somalia";SO;SOM;209;"Awdal";Region;"AW";18093
-"Somalia";SO;SOM;209;"Bakool";Region;"BK";18094
-"Somalia";SO;SOM;209;"Banaadir";Region;"BN";18098
-"Somalia";SO;SOM;209;"Bari";Region;"BR";18095
-"Somalia";SO;SOM;209;"Bay";Region;"BY";18097
-"Somalia";SO;SOM;209;"Galguduud";Region;"GA";18084
-"Somalia";SO;SOM;209;"Gedo";Region;"GE";18085
-"Somalia";SO;SOM;209;"Hiiraan";Region;"HI";18099
-"Somalia";SO;SOM;209;"Jubbada Dhexe";Region;"JD";18086
-"Somalia";SO;SOM;209;"Jubbada Hoose";Region;"JH";18087
-"Somalia";SO;SOM;209;"Mudug";Region;"MU";18096
-"Somalia";SO;SOM;209;"Nugaal";Region;"NU";18088
-"Somalia";SO;SOM;209;"Sanaag";Region;"SA";18090
-"Somalia";SO;SOM;209;"Shabeellaha Dhexe";Region;"SD";18100
-"Somalia";SO;SOM;209;"Shabeellaha Hoose";Region;"SH";18089
-"Somalia";SO;SOM;209;"Sool";Region;"SO";18083
-"Somalia";SO;SOM;209;"Togdheer";Region;"TO";18091
-"Somalia";SO;SOM;209;"Woqooyi Galbeed";Region;"WO";18092
-"South Africa";ZA;ZAF;210;"Eastern Cape";Province;"EC";18103
-"South Africa";ZA;ZAF;210;"Free State";Province;"FS";18104
-"South Africa";ZA;ZAF;210;"Gauteng";Province;"GT";18109
-"South Africa";ZA;ZAF;210;"Kwazulu-Natal";Province;"NL";18105
-"South Africa";ZA;ZAF;210;"Limpopo";Province;"LP";18106
-"South Africa";ZA;ZAF;210;"Mpumalanga";Province;"MP";18102
-"South Africa";ZA;ZAF;210;"North-West";Province;"NW";18101
-"South Africa";ZA;ZAF;210;"Northern Cape";Province;"NC";18107
-"South Africa";ZA;ZAF;210;"Western Cape";Province;"WC";18108
-"South Sudan";SS;SSD;703;"Central Equatoria";states;"EC";48882
-"South Sudan";SS;SSD;703;"Eastern Equatoria";states;"EE";48883
-"South Sudan";SS;SSD;703;"Jonglei";states;"JG";48884
-"South Sudan";SS;SSD;703;"Lakes";states;"LK";48885
-"South Sudan";SS;SSD;703;"Northern Bahr el-Ghazal";states;"BN";48886
-"South Sudan";SS;SSD;703;"Unity";states;"UY";48887
-"South Sudan";SS;SSD;703;"Upper Nile";states;"NU";48888
-"South Sudan";SS;SSD;703;"Warrap";states;"WR";48889
-"South Sudan";SS;SSD;703;"Western Bahr el-Ghazal";states;"BW";48890
-"South Sudan";SS;SSD;703;"Western Equatoria";states;"EW";48891
-"Spain";ES;ESP;212;"A Coruña";province;"C";18135
-"Spain";ES;ESP;212;"Albacete";province;"AB";18137
-"Spain";ES;ESP;212;"Alicante";province;"A";18136
-"Spain";ES;ESP;212;"Almería";province;"AL";18138
-"Spain";ES;ESP;212;"Andalucía";;"AN";19572
-"Spain";ES;ESP;212;"Asturias";province;"O";18122
-"Spain";ES;ESP;212;"Principado de Asturias";autonomous community;"AS";47901
-"Spain";ES;ESP;212;"Badajoz";province;"BA";18140
-"Spain";ES;ESP;212;"Baleares";province;"PM";18123
-"Spain";ES;ESP;212;"Barcelona";province;"B";18141
-"Spain";ES;ESP;212;"Burgos";province;"BU";18124
-"Spain";ES;ESP;212;"Canarias";;"CN";19574
-"Spain";ES;ESP;212;"Cantabria";autonomous community;"CB";47898
-"Spain";ES;ESP;212;"Cantabria";province;"S";18125
-"Spain";ES;ESP;212;"Castellón";province;"CS";18144
-"Spain";ES;ESP;212;"Castilla y León";autonomous community;"CL";19575
-"Spain";ES;ESP;212;"Castilla-La Mancha";autonomous community;"CM";19576
-"Spain";ES;ESP;212;"Catalunya";autonomous community;"CT";19577
-"Spain";ES;ESP;212;"Ceuta";Autonomous city;"CE";42631
-"Spain";ES;ESP;212;"Ciudad Real";province;"CR";18126
-"Spain";ES;ESP;212;"Cuenca";province;"CU";18154
-"Spain";ES;ESP;212;"Cáceres";province;"CC";18142
-"Spain";ES;ESP;212;"Cádiz";province;"CA";18143
-"Spain";ES;ESP;212;"Córdoba";province;"CO";18127
-"Spain";ES;ESP;212;"Extremadura";autonomous community;"EX";19578
-"Spain";ES;ESP;212;"Galicia";autonomous community;"GA";19579
-"Spain";ES;ESP;212;"Girona";province;"GI";18128
-"Spain";ES;ESP;212;"Granada";province;"GR";18129
-"Spain";ES;ESP;212;"Guadalajara";province;"GU";18155
-"Spain";ES;ESP;212;"Guipúzcoa";province;"SS";18130
-"Spain";ES;ESP;212;"Huelva";province;"H";18156
-"Spain";ES;ESP;212;"Huesca";province;"HU";18131
-"Spain";ES;ESP;212;"Illes Balears";autonomous community;"IB";48287
-"Spain";ES;ESP;212;"Jaén";province;"J";18132
-"Spain";ES;ESP;212;"La Rioja";province;"LO";18157
-"Spain";ES;ESP;212;"Las Palmas";province;"GC";18133
-"Spain";ES;ESP;212;"León";province;"LE";18158
-"Spain";ES;ESP;212;"Lleida";province;"L";18134
-"Spain";ES;ESP;212;"Lugo";province;"LU";18145
-"Spain";ES;ESP;212;"Madrid";province;"M";18159
-"Spain";ES;ESP;212;"Comunidad de Madrid";autonomous community;"MD";42628
-"Spain";ES;ESP;212;"Melilla";Autonomous city;"ML";42627
-"Spain";ES;ESP;212;"Murcia";province;"MU";18160
-"Spain";ES;ESP;212;"Región de Murcia";autonomous community;"MC";47866
-"Spain";ES;ESP;212;"Málaga";province;"MA";18146
-"Spain";ES;ESP;212;"Navarra";province;"NA";18148
-"Spain";ES;ESP;212;"Comunidad Foral de Navarra";autonomous community;"NC";42626
-"Spain";ES;ESP;212;"Ourense";province;"OR";18116
-"Spain";ES;ESP;212;"Palencia";province;"P";18149
-"Spain";ES;ESP;212;"País Vasco";autonomous community;"PV";19580
-"Spain";ES;ESP;212;"Pontevedra";province;"PO";18150
-"Spain";ES;ESP;212;"Salamanca";province;"SA";18161
-"Spain";ES;ESP;212;"Santa Cruz de Tenerife";province;"TF";18151
-"Spain";ES;ESP;212;"Segovia";province;"SG";18115
-"Spain";ES;ESP;212;"Sevilla";province;"SE";18152
-"Spain";ES;ESP;212;"Soria";province;"SO";18117
-"Spain";ES;ESP;212;"Tarragona";province;"T";18112
-"Spain";ES;ESP;212;"Teruel";province;"TE";18118
-"Spain";ES;ESP;212;"Toledo";province;"TO";18119
-"Spain";ES;ESP;212;"Valencia";province;"V";18111
-"Spain";ES;ESP;212;"Comunidad Valenciana";autonomous community;"VC";42625
-"Spain";ES;ESP;212;"Valladolid";province;"VA";18120
-"Spain";ES;ESP;212;"Vizcaya";province;"BI";18113
-"Spain";ES;ESP;212;"Zamora";province;"ZA";18114
-"Spain";ES;ESP;212;"Zaragoza";province;"Z";18110
-"Spain";ES;ESP;212;"Álava";province;"VI";18121
-"Spain";ES;ESP;212;"Ávila";province;"AV";18139
-"Spain";ES;ESP;212;"";;"AR";19573
-"Spain";ES;ESP;212;"";autonomous community;"RI";42629
-"Sri Lanka";LK;LKA;213;"Ampāra";district;"52";18178
-"Sri Lanka";LK;LKA;213;"Anurādhapura";district;"71";18175
-"Sri Lanka";LK;LKA;213;"Badulla";district;"81";18179
-"Sri Lanka";LK;LKA;213;"Basnāhira paḷāta";province;"1";48278
-"Sri Lanka";LK;LKA;213;"Dakuṇu paḷāta";province;"3";48279
-"Sri Lanka";LK;LKA;213;"Gampaha";district;"12";18176
-"Sri Lanka";LK;LKA;213;"Gālla";district;"31";18180
-"Sri Lanka";LK;LKA;213;"Hambantŏṭa";district;"33";18181
-"Sri Lanka";LK;LKA;213;"Kalutara";district;"13";18177
-"Sri Lanka";LK;LKA;213;"Kegalla";district;"92";18182
-"Sri Lanka";LK;LKA;213;"Kilinŏchchi";district;"42";18168
-"Sri Lanka";LK;LKA;213;"Kuruṇægala";district;"61";18186
-"Sri Lanka";LK;LKA;213;"Kŏḷamba";district;"11";18183
-"Sri Lanka";LK;LKA;213;"Madakalapuva";district;"51";18184
-"Sri Lanka";LK;LKA;213;"Madhyama paḷāta";province;"2";48280
-"Sri Lanka";LK;LKA;213;"Mahanuvara";district;"21";18167
-"Sri Lanka";LK;LKA;213;"Mannārama";district;"43";18185
-"Sri Lanka";LK;LKA;213;"Mattiya mākāṇam";province;"5";48281
-"Sri Lanka";LK;LKA;213;"Mulativ";district;"45";18163
-"Sri Lanka";LK;LKA;213;"Mātale";district;"22";18169
-"Sri Lanka";LK;LKA;213;"Mātara";district;"32";18164
-"Sri Lanka";LK;LKA;213;"Mŏṇarāgala";district;"82";18170
-"Sri Lanka";LK;LKA;213;"Nuvara Ĕliya";district;"23";18171
-"Sri Lanka";LK;LKA;213;"Puttalama";district;"62";18172
-"Sri Lanka";LK;LKA;213;"Pŏḷŏnnaruva";district;"72";18165
-"Sri Lanka";LK;LKA;213;"Ratnapura";district;"91";18166
-"Sri Lanka";LK;LKA;213;"Sabaragamuva paḷāta";province;"9";48282
-"Sri Lanka";LK;LKA;213;"Trikuṇāmalaya";district;"53";18173
-"Sri Lanka";LK;LKA;213;"Uturu paḷāta";province;"4";48284
-"Sri Lanka";LK;LKA;213;"Uturumæ̆da paḷāta";province;"7";48283
-"Sri Lanka";LK;LKA;213;"Vavuniyāva";district;"44";18162
-"Sri Lanka";LK;LKA;213;"Vayamba paḷāta";province;"6";48286
-"Sri Lanka";LK;LKA;213;"Yāpanaya";district;"41";18174
-"Sri Lanka";LK;LKA;213;"Ūva paḷāta";province;"8";48285
-"Sudan";SD;SDN;214;"A?ali an Nil";State;"23";18194
-"Sudan";SD;SDN;214;"Al Ba?r al A?mar";State;"26";48711
-"Sudan";SD;SDN;214;"Al Bah¸r al Ah¸mar";State;"RS";18206
-"Sudan";SD;SDN;214;"Al Bu?ayrat";State;"18";18207
-"Sudan";SD;SDN;214;"Al Jazirah";State;"07";48712
-"Sudan";SD;SDN;214;"Al Jazirah";State;"GZ";18193
-"Sudan";SD;SDN;214;"Al Khartum";State;"KH";18197
-"Sudan";SD;SDN;214;"Al Khartum";State;"03";48713
-"Sudan";SD;SDN;214;"Al Qa?arif";State;"06";48714
-"Sudan";SD;SDN;214;"Al Qaḑārif";State;"GD";18189
-"Sudan";SD;SDN;214;"Al Wa?dah";State;"22";18187
-"Sudan";SD;SDN;214;"An Nil";State;"04";48715
-"Sudan";SD;SDN;214;"An Nil";State;"NR";18200
-"Sudan";SD;SDN;214;"An Nil al Azraq";State;"NB";18201
-"Sudan";SD;SDN;214;"An Nil al Azraq";State;"24";48717
-"Sudan";SD;SDN;214;"An Nīl al Abyaḑ";State;"NW";18192
-"Sudan";SD;SDN;214;"An Nīl al Abyaḑ";State;"08";48716
-"Sudan";SD;SDN;214;"Ash Shamaliyah";State;"01";48718
-"Sudan";SD;SDN;214;"Ash Shamaliyah";State;"NO";18190
-"Sudan";SD;SDN;214;"Bahr al Jabal";State;"17";18195
-"Sudan";SD;SDN;214;"Gharb al Istiwa'iyah";State;"16";18208
-"Sudan";SD;SDN;214;"Gharb Ba?r al Ghazal";State;"14";18196
-"Sudan";SD;SDN;214;"Gharb Darfur";State;"DW";18209
-"Sudan";SD;SDN;214;"Gharb Darfur";State;"12";48719
-"Sudan";SD;SDN;214;"Gharb Kurdufan";;"10";18210
-"Sudan";SD;SDN;214;"Janub Darfur";State;"11";48720
-"Sudan";SD;SDN;214;"Janub Darfur";State;"DS";18211
-"Sudan";SD;SDN;214;"Janub Kurdufan";State;"KS";18198
-"Sudan";SD;SDN;214;"Janub Kurdufan";State;"13";48721
-"Sudan";SD;SDN;214;"Junqali";State;"20";18199
-"Sudan";SD;SDN;214;"Kassala";State;"KA";18212
-"Sudan";SD;SDN;214;"Kassala";State;"05";48722
-"Sudan";SD;SDN;214;"Shamal Ba?r al Ghazal";State;"15";18188
-"Sudan";SD;SDN;214;"Shamal Darfur";State;"DN";18202
-"Sudan";SD;SDN;214;"Shamal Darfur";State;"02";48723
-"Sudan";SD;SDN;214;"Shamal Kurdufan";State;"09";48724
-"Sudan";SD;SDN;214;"Shamal Kurdufan";State;"KN";18203
-"Sudan";SD;SDN;214;"Sharq al Istiwa'iyah";State;"19";18191
-"Sudan";SD;SDN;214;"Sharq Dārfūr";;"DE";48726
-"Sudan";SD;SDN;214;"Sinnar";State;"25";48725
-"Sudan";SD;SDN;214;"Sinnar";State;"SI";18204
-"Sudan";SD;SDN;214;"Warab";State;"21";18205
-"Sudan";SD;SDN;214;"Zalingei";;"DC";48727
-"Suriname";SR;SUR;215;"Brokopondo";District;"BR";18220
-"Suriname";SR;SUR;215;"Commewijne";District;"CM";18214
-"Suriname";SR;SUR;215;"Coronie";District;"CR";18215
-"Suriname";SR;SUR;215;"Marowijne";District;"MA";18221
-"Suriname";SR;SUR;215;"Nickerie";District;"NI";18216
-"Suriname";SR;SUR;215;"Para";District;"PR";18222
-"Suriname";SR;SUR;215;"Paramaribo";District;"PM";18217
-"Suriname";SR;SUR;215;"Saramacca";District;"SA";18218
-"Suriname";SR;SUR;215;"Sipaliwini";District;"SI";18213
-"Suriname";SR;SUR;215;"Wanica";District;"WA";18219
-"Swaziland";SZ;SWZ;217;"Hhohho";District;"HH";18226
-"Swaziland";SZ;SWZ;217;"Lubombo";District;"LU";18228
-"Swaziland";SZ;SWZ;217;"Manzini";District;"MA";18225
-"Swaziland";SZ;SWZ;217;"Shiselweni";District;"SH";18227
-"Sweden";SE;SWE;218;"Blekinge län [SE-10]";County;"K";18240
-"Sweden";SE;SWE;218;"Dalarnas län [SE-20]";County;"W";18248
-"Sweden";SE;SWE;218;"Gotlands län [SE-09]";County;"I";18249
-"Sweden";SE;SWE;218;"Gävleborgs län [SE-21]";County;"X";18241
-"Sweden";SE;SWE;218;"Hallands län [SE-13]";County;"N";18242
-"Sweden";SE;SWE;218;"Jämtlands län [SE-23]";County;"Z";18243
-"Sweden";SE;SWE;218;"Jönköpings län [SE-06]";County;"F";18250
-"Sweden";SE;SWE;218;"Kalmar län [SE-08]";County;"H";18244
-"Sweden";SE;SWE;218;"Kronobergs län [SE-07]";County;"G";18245
-"Sweden";SE;SWE;218;"Norrbottens län [SE-25]";County;"BD";18251
-"Sweden";SE;SWE;218;"Skåne län [SE-12]";County;"M";18247
-"Sweden";SE;SWE;218;"Stockholms län [SE-01]";County;"AB";18252
-"Sweden";SE;SWE;218;"Södermanlands län [SE-04]";County;"D";18231
-"Sweden";SE;SWE;218;"Uppsala län [SE-03]";County;"C";18232
-"Sweden";SE;SWE;218;"Värmlands län [SE-17]";County;"S";18233
-"Sweden";SE;SWE;218;"Västerbottens län [SE-24]";County;"AC";18254
-"Sweden";SE;SWE;218;"Västernorrlands län [SE-22]";County;"Y";18234
-"Sweden";SE;SWE;218;"Västmanlands län [SE-19]";County;"U";18253
-"Sweden";SE;SWE;218;"Västra Götalands län [SE-14]";County;"O";18235
-"Sweden";SE;SWE;218;"Örebro län [SE-18]";County;"T";18246
-"Sweden";SE;SWE;218;"Östergötlands län [SE-05]";County;"E";18230
-"Switzerland";CH;CHE;219;"Aargau (de)";Canton;"AG";18257
-"Switzerland";CH;CHE;219;"Appenzell Ausserrhoden (de)";Canton;"AR";18274
-"Switzerland";CH;CHE;219;"Appenzell Innerrhoden (de)";Canton;"AI";18258
-"Switzerland";CH;CHE;219;"Basel-Landschaft (de)";Canton;"BL";18275
-"Switzerland";CH;CHE;219;"Basel-Stadt (de)";Canton;"BS";18259
-"Switzerland";CH;CHE;219;"Bern (de)";Canton;"BE";18276
-"Switzerland";CH;CHE;219;"Fribourg (fr)";Canton;"FR";18260
-"Switzerland";CH;CHE;219;"Genève (fr)";Canton;"GE";18277
-"Switzerland";CH;CHE;219;"Glarus (de)";Canton;"GL";18261
-"Switzerland";CH;CHE;219;"Graubünden (de)";Canton;"GR";18265
-"Switzerland";CH;CHE;219;"Jura (fr)";Canton;"JU";18262
-"Switzerland";CH;CHE;219;"Luzern (de)";Canton;"LU";18266
-"Switzerland";CH;CHE;219;"Neuchâtel (fr)";Canton;"NE";18263
-"Switzerland";CH;CHE;219;"Nidwalden (de)";Canton;"NW";18267
-"Switzerland";CH;CHE;219;"Obwalden (de)";Canton;"OW";18264
-"Switzerland";CH;CHE;219;"Sankt Gallen (de)";Canton;"SG";18268
-"Switzerland";CH;CHE;219;"Schaffhausen (de)";Canton;"SH";18279
-"Switzerland";CH;CHE;219;"Schwyz (de)";Canton;"SZ";18269
-"Switzerland";CH;CHE;219;"Solothurn (de)";Canton;"SO";18270
-"Switzerland";CH;CHE;219;"Thurgau (de)";Canton;"TG";18280
-"Switzerland";CH;CHE;219;"Ticino (it)";Canton;"TI";18271
-"Switzerland";CH;CHE;219;"Uri (de)";Canton;"UR";18278
-"Switzerland";CH;CHE;219;"Valais (fr)";Canton;"VS";18272
-"Switzerland";CH;CHE;219;"Vaud (fr)";Canton;"VD";18255
-"Switzerland";CH;CHE;219;"Zug (de)";Canton;"ZG";18273
-"Switzerland";CH;CHE;219;"Zürich (de)";Canton;"ZH";18256
-"Syrian Arab Republic";SY;SYR;220;"?alab";Province;"HL";18285
-"Syrian Arab Republic";SY;SYR;220;"?amah";Province;"HM";18293
-"Syrian Arab Republic";SY;SYR;220;"?ims";Province;"HI";18284
-"Syrian Arab Republic";SY;SYR;220;"Al ?asakah";Province;"HA";18288
-"Syrian Arab Republic";SY;SYR;220;"Al Ladhiqiyah";Province;"LA";18289
-"Syrian Arab Republic";SY;SYR;220;"Al Qunaytirah";Province;"QU";18290
-"Syrian Arab Republic";SY;SYR;220;"Ar Raqqah";Province;"RA";18282
-"Syrian Arab Republic";SY;SYR;220;"As Suwayda'";Province;"SU";18291
-"Syrian Arab Republic";SY;SYR;220;"Dar?a";Province;"DR";18286
-"Syrian Arab Republic";SY;SYR;220;"Dayr az Zawr";Province;"DY";18292
-"Syrian Arab Republic";SY;SYR;220;"Dimashq";Province;"DI";18283
-"Syrian Arab Republic";SY;SYR;220;"Idlib";Province;"ID";18294
-"Syrian Arab Republic";SY;SYR;220;"Rif Dimashq";Province;"RD";18287
-"Syrian Arab Republic";SY;SYR;220;"Tartus";Province;"TA";18281
-"Province Of China Taiwan";TW;TWN;221;"Changhua";district;"CHA";18312
-"Province Of China Taiwan";TW;TWN;221;"Chiayi";district;"CYQ";18313
-"Province Of China Taiwan";TW;TWN;221;"Chiayi Municipality";municipality;"CYI";18308
-"Province Of China Taiwan";TW;TWN;221;"Hsinchu";district;"HSQ";18310
-"Province Of China Taiwan";TW;TWN;221;"Hsinchu Municipality";municipality;"HSZ";18309
-"Province Of China Taiwan";TW;TWN;221;"Hualien";district;"HUA";18314
-"Province Of China Taiwan";TW;TWN;221;"Ilan";district;"ILA";18311
-"Province Of China Taiwan";TW;TWN;221;"Kaohsiung";district;"KHQ";18315
-"Province Of China Taiwan";TW;TWN;221;"Kaohsiung Special Municipality";special municipality;"KHH";18320
-"Province Of China Taiwan";TW;TWN;221;"Keelung Municipality";municipality;"KEE";18316
-"Province Of China Taiwan";TW;TWN;221;"Miaoli";district;"MIA";18317
-"Province Of China Taiwan";TW;TWN;221;"Nantou";district;"NAN";18323
-"Province Of China Taiwan";TW;TWN;221;"Penghu";district;"PEN";18324
-"Province Of China Taiwan";TW;TWN;221;"Pingtung";district;"PIF";18318
-"Province Of China Taiwan";TW;TWN;221;"Taichung";district;"TXQ";18307
-"Province Of China Taiwan";TW;TWN;221;"Taichung Municipality";municipality;"TXG";18325
-"Province Of China Taiwan";TW;TWN;221;"Tainan";district;"TNQ";18306
-"Province Of China Taiwan";TW;TWN;221;"Tainan Municipality";municipality;"TNN";18319
-"Province Of China Taiwan";TW;TWN;221;"Taipei";district;"TPQ";18305
-"Province Of China Taiwan";TW;TWN;221;"Taipei Special Municipality";special municipality;"TPE";18326
-"Province Of China Taiwan";TW;TWN;221;"Taitung";district;"TTT";18304
-"Province Of China Taiwan";TW;TWN;221;"Taoyuan";district;"TAO";18303
-"Province Of China Taiwan";TW;TWN;221;"Yunlin";district;"YUN";18302
-"Tajikistan";TJ;TJK;222;"Gorno-Badakhshan";autonomous region;"GB";18331
-"Tajikistan";TJ;TJK;222;"Khatlon";region;"KT";18327
-"Tajikistan";TJ;TJK;222;"Sughd";region;"SU";18330
-"Tajikistan";TJ;TJK;222;"";city;"X1~";18329
-"United Republic of Tanzania";TZ;TZA;223;"Arusha";Region;"01";18349
-"United Republic of Tanzania";TZ;TZA;223;"Dar es Salaam";Region;"02";18350
-"United Republic of Tanzania";TZ;TZA;223;"Dodoma";Region;"03";18351
-"United Republic of Tanzania";TZ;TZA;223;"Iringa";Region;"04";18352
-"United Republic of Tanzania";TZ;TZA;223;"Kagera";Region;"05";18338
-"United Republic of Tanzania";TZ;TZA;223;"Kaskazini Pemba";Region;"06";18333
-"United Republic of Tanzania";TZ;TZA;223;"Kaskazini Unguja";Region;"07";19095
-"United Republic of Tanzania";TZ;TZA;223;"Kigoma";Region;"08";18339
-"United Republic of Tanzania";TZ;TZA;223;"Kilimanjaro";Region;"09";18340
-"United Republic of Tanzania";TZ;TZA;223;"Kusini Pemba";Region;"10";19096
-"United Republic of Tanzania";TZ;TZA;223;"Kusini Unguja";Region;"11";19097
-"United Republic of Tanzania";TZ;TZA;223;"Lindi";Region;"12";18353
-"United Republic of Tanzania";TZ;TZA;223;"Manyara";Region;"26";18341
-"United Republic of Tanzania";TZ;TZA;223;"Mara";Region;"13";18342
-"United Republic of Tanzania";TZ;TZA;223;"Mbeya";Region;"14";18337
-"United Republic of Tanzania";TZ;TZA;223;"Mjini Magharibi";Region;"15";19098
-"United Republic of Tanzania";TZ;TZA;223;"Morogoro";Region;"16";18343
-"United Republic of Tanzania";TZ;TZA;223;"Mtwara";Region;"17";18354
-"United Republic of Tanzania";TZ;TZA;223;"Mwanza";Region;"18";18344
-"United Republic of Tanzania";TZ;TZA;223;"Pwani";Region;"19";18345
-"United Republic of Tanzania";TZ;TZA;223;"Rukwa";Region;"20";18336
-"United Republic of Tanzania";TZ;TZA;223;"Ruvuma";Region;"21";18346
-"United Republic of Tanzania";TZ;TZA;223;"Shinyanga";Region;"22";18347
-"United Republic of Tanzania";TZ;TZA;223;"Singida";Region;"23";18335
-"United Republic of Tanzania";TZ;TZA;223;"Tabora";Region;"24";18348
-"United Republic of Tanzania";TZ;TZA;223;"Tanga";Region;"25";18334
-"Thailand";TH;THA;224;"Amnat Charoen";province;"37";18402
-"Thailand";TH;THA;224;"Ang Thong";province;"15";18403
-"Thailand";TH;THA;224;"Buri Ram";province;"31";18421
-"Thailand";TH;THA;224;"Chachoengsao";province;"24";18404
-"Thailand";TH;THA;224;"Chai Nat";province;"18";18422
-"Thailand";TH;THA;224;"Chaiyaphum";province;"36";18393
-"Thailand";TH;THA;224;"Chanthaburi";province;"22";18394
-"Thailand";TH;THA;224;"Chiang Mai";province;"50";18423
-"Thailand";TH;THA;224;"Chiang Rai";province;"57";18395
-"Thailand";TH;THA;224;"Chon Buri";province;"20";18424
-"Thailand";TH;THA;224;"Chumphon";province;"86";18396
-"Thailand";TH;THA;224;"Kalasin";province;"46";18425
-"Thailand";TH;THA;224;"Kamphaeng Phet";province;"62";18397
-"Thailand";TH;THA;224;"Kanchanaburi";province;"71";18398
-"Thailand";TH;THA;224;"Khon Kaen";province;"40";18426
-"Thailand";TH;THA;224;"Krabi";province;"81";18399
-"Thailand";TH;THA;224;"Krung Thep Maha Nakhon [Bangkok]";metropolitan administration;"10";18427
-"Thailand";TH;THA;224;"Lampang";province;"52";18400
-"Thailand";TH;THA;224;"Lamphun";province;"51";18401
-"Thailand";TH;THA;224;"Loei";province;"42";18366
-"Thailand";TH;THA;224;"Lop Buri";province;"16";18405
-"Thailand";TH;THA;224;"Mae Hong Son";province;"58";18406
-"Thailand";TH;THA;224;"Maha Sarakham";province;"44";18367
-"Thailand";TH;THA;224;"Mukdahan";province;"49";18407
-"Thailand";TH;THA;224;"Nakhon Nayok";province;"26";18368
-"Thailand";TH;THA;224;"Nakhon Pathom";province;"73";18408
-"Thailand";TH;THA;224;"Nakhon Phanom";province;"48";18409
-"Thailand";TH;THA;224;"Nakhon Ratchasima";province;"30";18369
-"Thailand";TH;THA;224;"Nakhon Sawan";province;"60";18410
-"Thailand";TH;THA;224;"Nakhon Si Thammarat";province;"80";18370
-"Thailand";TH;THA;224;"Nan";province;"55";18411
-"Thailand";TH;THA;224;"Narathiwat";province;"96";18412
-"Thailand";TH;THA;224;"Nong Bua Lam Phu";province;"39";18371
-"Thailand";TH;THA;224;"Nong Khai";province;"43";18384
-"Thailand";TH;THA;224;"Nonthaburi";province;"12";18372
-"Thailand";TH;THA;224;"Pathum Thani";province;"13";18385
-"Thailand";TH;THA;224;"Pattani";province;"94";18386
-"Thailand";TH;THA;224;"Phangnga";province;"82";18373
-"Thailand";TH;THA;224;"Phatthalung";province;"93";18387
-"Thailand";TH;THA;224;"Phatthaya";special administrative city;"S";20407
-"Thailand";TH;THA;224;"Phayao";province;"56";18374
-"Thailand";TH;THA;224;"Phetchabun";province;"67";18388
-"Thailand";TH;THA;224;"Phetchaburi";province;"76";18389
-"Thailand";TH;THA;224;"Phichit";province;"66";18357
-"Thailand";TH;THA;224;"Phitsanulok";province;"65";18390
-"Thailand";TH;THA;224;"Phra Nakhon Si Ayutthaya";province;"14";18358
-"Thailand";TH;THA;224;"Phrae";province;"54";18391
-"Thailand";TH;THA;224;"Phuket";province;"83";18392
-"Thailand";TH;THA;224;"Prachin Buri";province;"25";18359
-"Thailand";TH;THA;224;"Prachuap Khiri Khan";province;"77";18413
-"Thailand";TH;THA;224;"Ranong";province;"85";18414
-"Thailand";TH;THA;224;"Ratchaburi";province;"70";18360
-"Thailand";TH;THA;224;"Rayong";province;"21";18415
-"Thailand";TH;THA;224;"Roi Et";province;"45";18361
-"Thailand";TH;THA;224;"Sa Kaeo";province;"27";18416
-"Thailand";TH;THA;224;"Sakon Nakhon";province;"47";18417
-"Thailand";TH;THA;224;"Samut Prakan";province;"11";18362
-"Thailand";TH;THA;224;"Samut Sakhon";province;"74";18418
-"Thailand";TH;THA;224;"Samut Songkhram";province;"75";18363
-"Thailand";TH;THA;224;"Saraburi";province;"19";18419
-"Thailand";TH;THA;224;"Satun";province;"91";18420
-"Thailand";TH;THA;224;"Si Sa Ket";province;"33";18375
-"Thailand";TH;THA;224;"Sing Buri";province;"17";18364
-"Thailand";TH;THA;224;"Songkhla";province;"90";18376
-"Thailand";TH;THA;224;"Sukhothai";province;"64";18365
-"Thailand";TH;THA;224;"Suphan Buri";province;"72";18377
-"Thailand";TH;THA;224;"Surat Thani";province;"84";18356
-"Thailand";TH;THA;224;"Surin";province;"32";18378
-"Thailand";TH;THA;224;"Tak";province;"63";18379
-"Thailand";TH;THA;224;"Trang";province;"92";18428
-"Thailand";TH;THA;224;"Trat";province;"23";18380
-"Thailand";TH;THA;224;"Ubon Ratchathani";province;"34";18381
-"Thailand";TH;THA;224;"Udon Thani";province;"41";18430
-"Thailand";TH;THA;224;"Uthai Thani";province;"61";18382
-"Thailand";TH;THA;224;"Uttaradit";province;"53";18429
-"Thailand";TH;THA;224;"Yala";province;"95";18383
-"Thailand";TH;THA;224;"Yasothon";province;"35";18355
-"Timor-Leste";TL;TLS;226;"Aileu";District;"AL";13554
-"Timor-Leste";TL;TLS;226;"Ainaro";District;"AN";13553
-"Timor-Leste";TL;TLS;226;"Baucau";District;"BA";13562
-"Timor-Leste";TL;TLS;226;"Bobonaro";District;"BO";13556
-"Timor-Leste";TL;TLS;226;"Cova Lima";District;"CO";13557
-"Timor-Leste";TL;TLS;226;"Díli";District;"DI";13564
-"Timor-Leste";TL;TLS;226;"Ermera";District;"ER";13558
-"Timor-Leste";TL;TLS;226;"Lautem";District;"LA";13563
-"Timor-Leste";TL;TLS;226;"Liquiça";District;"LI";13559
-"Timor-Leste";TL;TLS;226;"Manatuto";District;"MT";13560
-"Timor-Leste";TL;TLS;226;"Manufahi";District;"MF";13552
-"Timor-Leste";TL;TLS;226;"Oecussi";District;"OE";13555
-"Timor-Leste";TL;TLS;226;"Viqueque";District;"VI";13561
-"Togo";TG;TGO;227;"Centre";Region;"C";18433
-"Togo";TG;TGO;227;"Kara";Region;"K";18432
-"Togo";TG;TGO;227;"Maritime (Région)";Region;"M";18435
-"Togo";TG;TGO;227;"Plateaux";Region;"P";18434
-"Togo";TG;TGO;227;"Savannes";Region;"S";18431
-"Tonga";TO;TON;229;"'Eua";Island group;"01";18442
-"Tonga";TO;TON;229;"Ha'apai";Island group;"02";18440
-"Tonga";TO;TON;229;"Niuas";Island group;"03";18443
-"Tonga";TO;TON;229;"Tongatapu";Island group;"04";18441
-"Tonga";TO;TON;229;"Vava'u";Island group;"05";18439
-"Trinidad and Tobago";TT;TTO;230;"Arima";municipality;"ARI";18446
-"Trinidad and Tobago";TT;TTO;230;"Chaguanas";municipality;"CHA";18456
-"Trinidad and Tobago";TT;TTO;230;"Couva-Tabaquite-Talparo";region;"CTT";18447
-"Trinidad and Tobago";TT;TTO;230;"Diego Martin";region;"DMN";18448
-"Trinidad and Tobago";TT;TTO;230;"Eastern Tobago";region;"ETO";20483
-"Trinidad and Tobago";TT;TTO;230;"Penal-Debe";region;"PED";18449
-"Trinidad and Tobago";TT;TTO;230;"Point Fortin";municipality;"PTF";18457
-"Trinidad and Tobago";TT;TTO;230;"Port of Spain";municipality;"POS";18450
-"Trinidad and Tobago";TT;TTO;230;"Princes Town";region;"PRT";18445
-"Trinidad and Tobago";TT;TTO;230;"Rio Claro-Mayaro";region;"RCM";18455
-"Trinidad and Tobago";TT;TTO;230;"San Fernando";municipality;"SFO";18451
-"Trinidad and Tobago";TT;TTO;230;"San Juan-Laventille";region;"SJL";18452
-"Trinidad and Tobago";TT;TTO;230;"Sangre Grande";region;"SGE";18458
-"Trinidad and Tobago";TT;TTO;230;"Siparia";region;"SIP";18453
-"Trinidad and Tobago";TT;TTO;230;"Tunapuna-Piarco";region;"TUP";18454
-"Trinidad and Tobago";TT;TTO;230;"Western Tobago";region;"WTO";20488
-"Tunisia";TN;TUN;231;"Ariana";Governorate;"12";18463
-"Tunisia";TN;TUN;231;"Ben Arous";Governorate;"13";18464
-"Tunisia";TN;TUN;231;"Bizerte";Governorate;"23";18470
-"Tunisia";TN;TUN;231;"Béja";Governorate;"31";18469
-"Tunisia";TN;TUN;231;"Gabès";Governorate;"81";18474
-"Tunisia";TN;TUN;231;"Gafsa";Governorate;"71";18475
-"Tunisia";TN;TUN;231;"Jendouba";Governorate;"32";18465
-"Tunisia";TN;TUN;231;"Kairouan";Governorate;"41";18477
-"Tunisia";TN;TUN;231;"Kasserine";Governorate;"42";18476
-"Tunisia";TN;TUN;231;"Kebili";Governorate;"73";18478
-"Tunisia";TN;TUN;231;"La Manouba";Governorate;"14";18467
-"Tunisia";TN;TUN;231;"Le Kef";Governorate;"33";18471
-"Tunisia";TN;TUN;231;"Mahdia";Governorate;"53";18472
-"Tunisia";TN;TUN;231;"Medenine";Governorate;"82";18466
-"Tunisia";TN;TUN;231;"Monastir";Governorate;"52";18473
-"Tunisia";TN;TUN;231;"Nabeul";Governorate;"21";18468
-"Tunisia";TN;TUN;231;"Sfax";Governorate;"61";18462
-"Tunisia";TN;TUN;231;"Sidi Bouzid";Governorate;"43";18479
-"Tunisia";TN;TUN;231;"Siliana";Governorate;"34";18461
-"Tunisia";TN;TUN;231;"Sousse";Governorate;"51";18480
-"Tunisia";TN;TUN;231;"Tataouine";Governorate;"83";18460
-"Tunisia";TN;TUN;231;"Tozeur";Governorate;"72";18481
-"Tunisia";TN;TUN;231;"Tunis";Governorate;"11";18482
-"Tunisia";TN;TUN;231;"Zaghouan";Governorate;"22";18459
-"Turkey";TR;TUR;232;"Adana";Province;"01";18551
-"Turkey";TR;TUR;232;"Adiyaman";Province;"02";18523
-"Turkey";TR;TUR;232;"Afyonkarahisar";Province;"03";18524
-"Turkey";TR;TUR;232;"Agri";Province;"04";18552
-"Turkey";TR;TUR;232;"Aksaray";Province;"68";18514
-"Turkey";TR;TUR;232;"Amasya";Province;"05";18515
-"Turkey";TR;TUR;232;"Ankara";Province;"06";18553
-"Turkey";TR;TUR;232;"Antalya";Province;"07";18516
-"Turkey";TR;TUR;232;"Ardahan";Province;"75";18517
-"Turkey";TR;TUR;232;"Artvin";Province;"08";18554
-"Turkey";TR;TUR;232;"Aydin";Province;"09";18518
-"Turkey";TR;TUR;232;"Balikesir";Province;"10";18519
-"Turkey";TR;TUR;232;"Bartin";Province;"74";18555
-"Turkey";TR;TUR;232;"Batman";Province;"72";18520
-"Turkey";TR;TUR;232;"Bayburt";Province;"69";18521
-"Turkey";TR;TUR;232;"Bilecik";Province;"11";18556
-"Turkey";TR;TUR;232;"Bingöl";Province;"12";18522
-"Turkey";TR;TUR;232;"Bitlis";Province;"13";18525
-"Turkey";TR;TUR;232;"Bolu";Province;"14";18526
-"Turkey";TR;TUR;232;"Burdur";Province;"15";18557
-"Turkey";TR;TUR;232;"Bursa";Province;"16";18527
-"Turkey";TR;TUR;232;"Denizli";Province;"20";18530
-"Turkey";TR;TUR;232;"Diyarbakir";Province;"21";18495
-"Turkey";TR;TUR;232;"Düzce";Province;"81";18531
-"Turkey";TR;TUR;232;"Edirne";Province;"22";18532
-"Turkey";TR;TUR;232;"Elazig";Province;"23";18541
-"Turkey";TR;TUR;232;"Erzincan";Province;"24";18505
-"Turkey";TR;TUR;232;"Erzurum";Province;"25";18506
-"Turkey";TR;TUR;232;"Eskisehir";Province;"26";18542
-"Turkey";TR;TUR;232;"Gaziantep";Province;"27";18507
-"Turkey";TR;TUR;232;"Giresun";Province;"28";18543
-"Turkey";TR;TUR;232;"Gümüshane";Province;"29";18508
-"Turkey";TR;TUR;232;"Hakkâri";Province;"30";18509
-"Turkey";TR;TUR;232;"Hatay";Province;"31";18510
-"Turkey";TR;TUR;232;"Igdir";Province;"76";18511
-"Turkey";TR;TUR;232;"Isparta";Province;"32";18545
-"Turkey";TR;TUR;232;"Istanbul";Province;"34";18512
-"Turkey";TR;TUR;232;"Izmir";Province;"35";18513
-"Turkey";TR;TUR;232;"Kahramanmaras";Province;"46";18546
-"Turkey";TR;TUR;232;"Karabük";Province;"78";18533
-"Turkey";TR;TUR;232;"Karaman";Province;"70";18534
-"Turkey";TR;TUR;232;"Kars";Province;"36";18547
-"Turkey";TR;TUR;232;"Kastamonu";Province;"37";18535
-"Turkey";TR;TUR;232;"Kayseri";Province;"38";18536
-"Turkey";TR;TUR;232;"Kilis";Province;"79";18548
-"Turkey";TR;TUR;232;"Kirikkale";Province;"71";18537
-"Turkey";TR;TUR;232;"Kirklareli";Province;"39";18486
-"Turkey";TR;TUR;232;"Kirsehir";Province;"40";18538
-"Turkey";TR;TUR;232;"Kocaeli";Province;"41";18539
-"Turkey";TR;TUR;232;"Konya";Province;"42";18540
-"Turkey";TR;TUR;232;"Kütahya";Province;"43";18559
-"Turkey";TR;TUR;232;"Malatya";Province;"44";18496
-"Turkey";TR;TUR;232;"Manisa";Province;"45";18497
-"Turkey";TR;TUR;232;"Mardin";Province;"47";18485
-"Turkey";TR;TUR;232;"Mersin";Province;"33";18544
-"Turkey";TR;TUR;232;"Mugla";Province;"48";18498
-"Turkey";TR;TUR;232;"Mus";Province;"49";18499
-"Turkey";TR;TUR;232;"Nevsehir";Province;"50";18560
-"Turkey";TR;TUR;232;"Nigde";Province;"51";18500
-"Turkey";TR;TUR;232;"Ordu";Province;"52";18501
-"Turkey";TR;TUR;232;"Osmaniye";Province;"80";18484
-"Turkey";TR;TUR;232;"Rize";Province;"53";18502
-"Turkey";TR;TUR;232;"Sakarya";Province;"54";18503
-"Turkey";TR;TUR;232;"Samsun";Province;"55";18561
-"Turkey";TR;TUR;232;"Sanliurfa";Province;"63";18504
-"Turkey";TR;TUR;232;"Siirt";Province;"56";18487
-"Turkey";TR;TUR;232;"Sinop";Province;"57";18564
-"Turkey";TR;TUR;232;"Sirnak";Province;"73";18488
-"Turkey";TR;TUR;232;"Sivas";Province;"58";18563
-"Turkey";TR;TUR;232;"Tekirdag";Province;"59";18489
-"Turkey";TR;TUR;232;"Tokat";Province;"60";18490
-"Turkey";TR;TUR;232;"Trabzon";Province;"61";18491
-"Turkey";TR;TUR;232;"Tunceli";Province;"62";18562
-"Turkey";TR;TUR;232;"Usak";Province;"64";18492
-"Turkey";TR;TUR;232;"Van";Province;"65";18493
-"Turkey";TR;TUR;232;"Yalova";Province;"77";18565
-"Turkey";TR;TUR;232;"Yozgat";Province;"66";18494
-"Turkey";TR;TUR;232;"Zonguldak";Province;"67";18483
-"Turkey";TR;TUR;232;"Çanakkale";Province;"17";18558
-"Turkey";TR;TUR;232;"Çankiri";Province;"18";18528
-"Turkey";TR;TUR;232;"Çorum";Province;"19";18529
-"Turkmenistan";TM;TKM;233;"Ahal";region;"A";18569
-"Turkmenistan";TM;TKM;233;"Balkan";region;"B";18568
-"Turkmenistan";TM;TKM;233;"Dasoguz";region;"D";18571
-"Turkmenistan";TM;TKM;233;"Lebap";region;"L";18572
-"Turkmenistan";TM;TKM;233;"Mary";region;"M";18566
-"Turkmenistan";TM;TKM;233;"";City;"S";18567
-"Turkmenistan";TM;TKM;233;"";City;"X~";48134
-"Tuvalu";TV;TUV;235;"Funafuti";Island Council;"FUN";18586
-"Tuvalu";TV;TUV;235;"Nanumanga";Island Council;"NMG";18580
-"Tuvalu";TV;TUV;235;"Nanumea";Island Council;"NMA";18581
-"Tuvalu";TV;TUV;235;"Niutao";Island Council;"NIT";18582
-"Tuvalu";TV;TUV;235;"Nui";Island Council;"NIU";18583
-"Tuvalu";TV;TUV;235;"Nukufetau";Island Council;"NKF";18579
-"Tuvalu";TV;TUV;235;"Nukulaelae";Island Council;"NKL";18584
-"Tuvalu";TV;TUV;235;"Vaitupu";Island Council;"VAI";18585
-"Uganda";UG;UGA;236;"Abim";District;"317";48102
-"Uganda";UG;UGA;236;"Adjumani";District;"301";20547
-"Uganda";UG;UGA;236;"Amolatar";District;"314";48103
-"Uganda";UG;UGA;236;"Amuria";District;"216";48104
-"Uganda";UG;UGA;236;"Amuru";District;"319";48105
-"Uganda";UG;UGA;236;"Apac";District;"302";20548
-"Uganda";UG;UGA;236;"Arua";District;"303";20549
-"Uganda";UG;UGA;236;"Budaka";District;"217";48106
-"Uganda";UG;UGA;236;"Bududa";District;"223";48122
-"Uganda";UG;UGA;236;"Bugiri";District;"201";20532
-"Uganda";UG;UGA;236;"Bukedea";District;"224";48121
-"Uganda";UG;UGA;236;"Bukwa";District;"218";48107
-"Uganda";UG;UGA;236;"Buliisa";District;"419";48124
-"Uganda";UG;UGA;236;"Bundibugyo";District;"401";20560
-"Uganda";UG;UGA;236;"Bushenyi";District;"402";20561
-"Uganda";UG;UGA;236;"Busia";District;"202";20533
-"Uganda";UG;UGA;236;"Butaleja";District;"219";48108
-"Uganda";UG;UGA;236;"Central";geographic regions;"C";48541
-"Uganda";UG;UGA;236;"Dokolo";District;"318";48109
-"Uganda";UG;UGA;236;"Eastern";geographic regions;"E";48542
-"Uganda";UG;UGA;236;"Gulu";District;"304";20550
-"Uganda";UG;UGA;236;"Hoima";District;"403";20562
-"Uganda";UG;UGA;236;"Ibanda";District;"416";48110
-"Uganda";UG;UGA;236;"Iganga";District;"203";20534
-"Uganda";UG;UGA;236;"Isingiro";District;"417";48111
-"Uganda";UG;UGA;236;"Jinja";District;"204";20535
-"Uganda";UG;UGA;236;"Kaabong";District;"315";48112
-"Uganda";UG;UGA;236;"Kabale";District;"404";20563
-"Uganda";UG;UGA;236;"Kabarole";District;"405";20564
-"Uganda";UG;UGA;236;"Kaberamaido";District;"213";20544
-"Uganda";UG;UGA;236;"Kalangala";District;"101";20519
-"Uganda";UG;UGA;236;"Kaliro";District;"220";48113
-"Uganda";UG;UGA;236;"Kampala";District;"102";20520
-"Uganda";UG;UGA;236;"Kamuli";District;"205";20536
-"Uganda";UG;UGA;236;"Kamwenge";District;"413";20572
-"Uganda";UG;UGA;236;"Kanungu";District;"414";20573
-"Uganda";UG;UGA;236;"Kapchorwa";District;"206";20537
-"Uganda";UG;UGA;236;"Kasese";District;"406";20565
-"Uganda";UG;UGA;236;"Katakwi";District;"207";20538
-"Uganda";UG;UGA;236;"Kayunga";District;"112";20530
-"Uganda";UG;UGA;236;"Kibaale";District;"407";20566
-"Uganda";UG;UGA;236;"Kiboga";District;"103";20521
-"Uganda";UG;UGA;236;"Kiruhura";District;"418";48114
-"Uganda";UG;UGA;236;"Kisoro";District;"408";20567
-"Uganda";UG;UGA;236;"Kitgum";District;"305";20551
-"Uganda";UG;UGA;236;"Koboko";District;"316";48115
-"Uganda";UG;UGA;236;"Kotido";District;"306";20552
-"Uganda";UG;UGA;236;"Kumi";District;"208";20539
-"Uganda";UG;UGA;236;"Kyenjojo";District;"415";20574
-"Uganda";UG;UGA;236;"Lira";District;"307";20553
-"Uganda";UG;UGA;236;"Luwero";District;"104";20522
-"Uganda";UG;UGA;236;"Lyantonde";District;"116";48123
-"Uganda";UG;UGA;236;"Manafwa";District;"221";48116
-"Uganda";UG;UGA;236;"Maracha";District;"320";48117
-"Uganda";UG;UGA;236;"Masaka";District;"105";20523
-"Uganda";UG;UGA;236;"Masindi";District;"409";20568
-"Uganda";UG;UGA;236;"Mayuge";District;"214";20545
-"Uganda";UG;UGA;236;"Mbale";District;"209";20540
-"Uganda";UG;UGA;236;"Mbarara";District;"410";20569
-"Uganda";UG;UGA;236;"Mityana";District;"114";48125
-"Uganda";UG;UGA;236;"Moroto";District;"308";20554
-"Uganda";UG;UGA;236;"Moyo";District;"309";20555
-"Uganda";UG;UGA;236;"Mpigi";District;"106";20524
-"Uganda";UG;UGA;236;"Mubende";District;"107";20525
-"Uganda";UG;UGA;236;"Mukono";District;"108";20526
-"Uganda";UG;UGA;236;"Nakapiripirit";District;"311";20557
-"Uganda";UG;UGA;236;"Nakaseke";District;"115";48118
-"Uganda";UG;UGA;236;"Nakasongola";District;"109";20527
-"Uganda";UG;UGA;236;"Namutumba";District;"222";48119
-"Uganda";UG;UGA;236;"Nebbi";District;"310";20556
-"Uganda";UG;UGA;236;"Northern";geographic regions;"N";48543
-"Uganda";UG;UGA;236;"Ntungamo";District;"411";20570
-"Uganda";UG;UGA;236;"Oyam";District;"321";48126
-"Uganda";UG;UGA;236;"Pader";District;"312";20558
-"Uganda";UG;UGA;236;"Pallisa";District;"210";20541
-"Uganda";UG;UGA;236;"Rakai";District;"110";20528
-"Uganda";UG;UGA;236;"Rukungiri";District;"412";20571
-"Uganda";UG;UGA;236;"Sembabule";District;"111";20529
-"Uganda";UG;UGA;236;"Sironko";District;"215";20546
-"Uganda";UG;UGA;236;"Soroti";District;"211";20542
-"Uganda";UG;UGA;236;"Tororo";District;"212";20543
-"Uganda";UG;UGA;236;"Wakiso";District;"113";20531
-"Uganda";UG;UGA;236;"Western";geographic regions;"W";48544
-"Uganda";UG;UGA;236;"Yumbe";District;"313";20559
-"Ukraine";UA;UKR;237;"Cherkas'ka Oblast'";region;"71";18594
-"Ukraine";UA;UKR;237;"Chernihivs'ka Oblast'";region;"74";18595
-"Ukraine";UA;UKR;237;"Chernivets'ka Oblast'";region;"77";18596
-"Ukraine";UA;UKR;237;"Dnipropetrovs'ka Oblast'";region;"12";18603
-"Ukraine";UA;UKR;237;"Donets'ka Oblast'";region;"14";18597
-"Ukraine";UA;UKR;237;"Ivano-Frankivs'ka Oblast'";region;"26";18598
-"Ukraine";UA;UKR;237;"Kharkivs'ka Oblast'";region;"63";18599
-"Ukraine";UA;UKR;237;"Khersons'ka Oblast'";region;"65";18600
-"Ukraine";UA;UKR;237;"Khmel'nyts'ka Oblast'";region;"68";18604
-"Ukraine";UA;UKR;237;"Kirovohrads'ka Oblast'";region;"35";18601
-"Ukraine";UA;UKR;237;"Kyïv";region;"30";18607
-"Ukraine";UA;UKR;237;"Kyïvs'ka Oblast'";region;"32";18608
-"Ukraine";UA;UKR;237;"L'vivs'ka Oblast'";region;"46";18609
-"Ukraine";UA;UKR;237;"Luhans'ka Oblast'";region;"09";18605
-"Ukraine";UA;UKR;237;"Mykolaïvs'ka Oblast'";region;"48";18610
-"Ukraine";UA;UKR;237;"Odes'ka Oblast'";region;"51";18606
-"Ukraine";UA;UKR;237;"Poltavs'ka Oblast'";region;"53";18611
-"Ukraine";UA;UKR;237;"Respublika Krym";Autonomous Republic;"43";18602
-"Ukraine";UA;UKR;237;"Rivnens'ka Oblast'";region;"56";18612
-"Ukraine";UA;UKR;237;"Sevastopol'";region;"40";18613
-"Ukraine";UA;UKR;237;"Sums'ka Oblast'";region;"59";18614
-"Ukraine";UA;UKR;237;"Ternopil's'ka Oblast'";region;"61";18615
-"Ukraine";UA;UKR;237;"Vinnyts'ka Oblast'";region;"05";18593
-"Ukraine";UA;UKR;237;"Volyns'ka Oblast'";region;"07";18617
-"Ukraine";UA;UKR;237;"Zakarpats'ka Oblast'";region;"21";18618
-"Ukraine";UA;UKR;237;"Zaporiz'ka Oblast'";region;"23";18616
-"Ukraine";UA;UKR;237;"Zhytomyrs'ka Oblast'";region;"18";18592
-"United Arab Emirates";AE;ARE;238;"Abu Z¸aby [Abu Dhabi]";Emirate;"AZ";18622
-"United Arab Emirates";AE;ARE;238;"Ajman";Emirate;"AJ";20215
-"United Arab Emirates";AE;ARE;238;"Al Fujayrah";Emirate;"FU";20218
-"United Arab Emirates";AE;ARE;238;"Ash Shariqah [Sharjah]";Emirate;"SH";20219
-"United Arab Emirates";AE;ARE;238;"Dubayy [Dubai]";Emirate;"DU";20217
-"United Arab Emirates";AE;ARE;238;"Ra’s al Khaymah";Emirate;"RK";18620
-"United Arab Emirates";AE;ARE;238;"Umm al Qaywayn";Emirate;"UQ";20220
-"United Kingdom";GB;GBR;239;"Aberdeen City";council area (Scotland);"ABE";47989
-"United Kingdom";GB;GBR;239;"Aberdeenshire";council area (Scotland);"ABD";47988
-"United Kingdom";GB;GBR;239;"Angus";council area (Scotland);"ANS";47987
-"United Kingdom";GB;GBR;239;"Antrim";district council area (Northern Ireland);"ANT";48015
-"United Kingdom";GB;GBR;239;"Ards";district council area (Northern Ireland);"ARD";48014
-"United Kingdom";GB;GBR;239;"Argyll and Bute";council area (Scotland);"AGB";47986
-"United Kingdom";GB;GBR;239;"Armagh";district council area (Northern Ireland);"ARM";48013
-"United Kingdom";GB;GBR;239;"Ballymena";district council area (Northern Ireland);"BLA";48012
-"United Kingdom";GB;GBR;239;"Ballymoney";district council area (Northern Ireland);"BLY";48011
-"United Kingdom";GB;GBR;239;"Banbridge";district council area (Northern Ireland);"BNB";48010
-"United Kingdom";GB;GBR;239;"Barking and Dagenham";borough;"BDG";19166
-"United Kingdom";GB;GBR;239;"Barnet";borough;"BNE";19167
-"United Kingdom";GB;GBR;239;"Barnsley";metropolitan district;"BNS";19168
-"United Kingdom";GB;GBR;239;"Bath and North East Somerset";unitary authority;"BAS";47935
-"United Kingdom";GB;GBR;239;"Bedfordshire";unitary authority;"BDF";47934
-"United Kingdom";GB;GBR;239;"Belfast";district council area (Northern Ireland);"BFS";48009
-"United Kingdom";GB;GBR;239;"Bexley";borough;"BEX";19172
-"United Kingdom";GB;GBR;239;"Birmingham";metropolitan district;"BIR";19173
-"United Kingdom";GB;GBR;239;"Blackburn with Darwen";unitary authority;"BBD";47933
-"United Kingdom";GB;GBR;239;"Blackpool";unitary authority;"BPL";47932
-"United Kingdom";GB;GBR;239;"Blaenau Gwent";unitary authority (Wales);"BGW";47956
-"United Kingdom";GB;GBR;239;"Bolton";metropolitan district;"BOL";19177
-"United Kingdom";GB;GBR;239;"Bournemouth";unitary authority;"BMH";47931
-"United Kingdom";GB;GBR;239;"Bracknell Forest";unitary authority;"BRC";47930
-"United Kingdom";GB;GBR;239;"Bradford";metropolitan district;"BRD";19180
-"United Kingdom";GB;GBR;239;"Brent";borough;"BEN";19181
-"United Kingdom";GB;GBR;239;"Bridgend [Pen-y-bont ar Ogwr GB-POG]";unitary authority (Wales);"BGE";47955
-"United Kingdom";GB;GBR;239;"Brighton and Hove";unitary authority;"BNH";47929
-"United Kingdom";GB;GBR;239;"City of Bristol";unitary authority;"BST";47928
-"United Kingdom";GB;GBR;239;"Bromley";borough;"BRY";19185
-"United Kingdom";GB;GBR;239;"Buckinghamshire";two-tier county;"BKM";47927
-"United Kingdom";GB;GBR;239;"Bury";metropolitan district;"BUR";19187
-"United Kingdom";GB;GBR;239;"Caerphilly [Caerffili GB-CAF]";unitary authority (Wales);"CAY";47954
-"United Kingdom";GB;GBR;239;"Calderdale";metropolitan district;"CLD";19189
-"United Kingdom";GB;GBR;239;"Cambridgeshire";two-tier county;"CAM";47926
-"United Kingdom";GB;GBR;239;"Camden";borough;"CMD";19191
-"United Kingdom";GB;GBR;239;"Cardiff [Caerdydd GB-CRD]";unitary authority (Wales);"CRF";47953
-"United Kingdom";GB;GBR;239;"Carmarthenshire [Sir Gaerfyrddin GB-GFY]";unitary authority (Wales);"CMN";47952
-"United Kingdom";GB;GBR;239;"Carrickfergus";district council area (Northern Ireland);"CKF";48008
-"United Kingdom";GB;GBR;239;"Castlereagh";district council area (Northern Ireland);"CSR";48007
-"United Kingdom";GB;GBR;239;"Ceredigion [Sir Ceredigion]";unitary authority (Wales);"CGN";47951
-"United Kingdom";GB;GBR;239;"Cheshire";;"CHS";47925
-"United Kingdom";GB;GBR;239;"Clackmannanshire";council area (Scotland);"CLK";47985
-"United Kingdom";GB;GBR;239;"Coleraine";district council area (Northern Ireland);"CLR";48006
-"United Kingdom";GB;GBR;239;"Conwy";unitary authority (Wales);"CWY";47950
-"United Kingdom";GB;GBR;239;"Cookstown";district council area (Northern Ireland);"CKT";48005
-"United Kingdom";GB;GBR;239;"Cornwall";unitary authority;"CON";47924
-"United Kingdom";GB;GBR;239;"Coventry";metropolitan district;"COV";19203
-"United Kingdom";GB;GBR;239;"Craigavon";district council area (Northern Ireland);"CGV";48004
-"United Kingdom";GB;GBR;239;"Croydon";borough;"CRY";19205
-"United Kingdom";GB;GBR;239;"Cumbria";two-tier county;"CMA";47923
-"United Kingdom";GB;GBR;239;"Darlington";unitary authority;"DAL";47922
-"United Kingdom";GB;GBR;239;"Denbighshire [Sir Ddinbych GB-DDB]";unitary authority (Wales);"DEN";47949
-"United Kingdom";GB;GBR;239;"Derby";unitary authority;"DER";47921
-"United Kingdom";GB;GBR;239;"Derbyshire";two-tier county;"DBY";47920
-"United Kingdom";GB;GBR;239;"Derry";district council area (Northern Ireland);"DRY";47997
-"United Kingdom";GB;GBR;239;"Devon";two-tier county;"DEV";47919
-"United Kingdom";GB;GBR;239;"Doncaster";metropolitan district;"DNC";19213
-"United Kingdom";GB;GBR;239;"Dorset";two-tier county;"DOR";47918
-"United Kingdom";GB;GBR;239;"Down";district council area (Northern Ireland);"DOW";48003
-"United Kingdom";GB;GBR;239;"Dudley";metropolitan district;"DUD";19216
-"United Kingdom";GB;GBR;239;"Dumfries and Galloway";council area (Scotland);"DGY";47984
-"United Kingdom";GB;GBR;239;"Dundee City";council area (Scotland);"DND";47983
-"United Kingdom";GB;GBR;239;"Dungannon and South Tyrone";district council area (Northern Ireland);"DGN";48002
-"United Kingdom";GB;GBR;239;"Durham";unitary authority;"DUR";47917
-"United Kingdom";GB;GBR;239;"Ealing";borough;"EAL";19221
-"United Kingdom";GB;GBR;239;"East Ayrshire";council area (Scotland);"EAY";47982
-"United Kingdom";GB;GBR;239;"East Dunbartonshire";council area (Scotland);"EDU";47981
-"United Kingdom";GB;GBR;239;"East Lothian";council area (Scotland);"ELN";47980
-"United Kingdom";GB;GBR;239;"East Renfrewshire";council area (Scotland);"ERW";47979
-"United Kingdom";GB;GBR;239;"East Riding of Yorkshire";unitary authority;"ERY";47916
-"United Kingdom";GB;GBR;239;"East Sussex";two-tier county;"ESX";47915
-"United Kingdom";GB;GBR;239;"City of Edinburgh";council area (Scotland);"EDH";47978
-"United Kingdom";GB;GBR;239;"Eilean Siar";council area (Scotland);"ELS";47977
-"United Kingdom";GB;GBR;239;"Enfield";borough;"ENF";19230
-"United Kingdom";GB;GBR;239;"Essex";two-tier county;"ESS";47914
-"United Kingdom";GB;GBR;239;"Falkirk";council area (Scotland);"FAL";47976
-"United Kingdom";GB;GBR;239;"Fermanagh";district council area (Northern Ireland);"FER";48001
-"United Kingdom";GB;GBR;239;"Fife";council area (Scotland);"FIF";47975
-"United Kingdom";GB;GBR;239;"Flintshire [Sir y Fflint GB-FFL]";unitary authority (Wales);"FLN";47948
-"United Kingdom";GB;GBR;239;"Gateshead";metropolitan district;"GAT";19236
-"United Kingdom";GB;GBR;239;"Glasgow City";council area (Scotland);"GLG";47974
-"United Kingdom";GB;GBR;239;"Gloucestershire";two-tier county;"GLS";47913
-"United Kingdom";GB;GBR;239;"Greenwich";borough;"GRE";19239
-"United Kingdom";GB;GBR;239;"Gwynedd";unitary authority (Wales);"GWN";47947
-"United Kingdom";GB;GBR;239;"Hackney";borough;"HCK";19241
-"United Kingdom";GB;GBR;239;"Halton";unitary authority;"HAL";47911
-"United Kingdom";GB;GBR;239;"Hammersmith and Fulham";borough;"HMF";19243
-"United Kingdom";GB;GBR;239;"Hampshire";two-tier county;"HAM";47910
-"United Kingdom";GB;GBR;239;"Haringey";borough;"HRY";19245
-"United Kingdom";GB;GBR;239;"Harrow";borough;"HRW";19246
-"United Kingdom";GB;GBR;239;"Hartlepool";unitary authority;"HPL";47909
-"United Kingdom";GB;GBR;239;"Havering";borough;"HAV";19248
-"United Kingdom";GB;GBR;239;"County of Herefordshire";unitary authority;"HEF";47908
-"United Kingdom";GB;GBR;239;"Hertfordshire";two-tier county;"HRT";47907
-"United Kingdom";GB;GBR;239;"Highland";council area (Scotland);"HLD";47973
-"United Kingdom";GB;GBR;239;"Hillingdon";borough;"HIL";19252
-"United Kingdom";GB;GBR;239;"Hounslow";borough;"HNS";19253
-"United Kingdom";GB;GBR;239;"Inverclyde";council area (Scotland);"IVC";47972
-"United Kingdom";GB;GBR;239;"Isle of Anglesey [Sir Ynys Môn GB-YNM]";unitary authority (Wales);"AGY";47957
-"United Kingdom";GB;GBR;239;"Isle of Wight";unitary authority;"IOW";47906
-"United Kingdom";GB;GBR;239;"Isles of Scilly";;"IOS";19257
-"United Kingdom";GB;GBR;239;"Islington";borough;"ISL";19258
-"United Kingdom";GB;GBR;239;"Kensington and Chelsea";borough;"KEC";19259
-"United Kingdom";GB;GBR;239;"Kent";two-tier county;"KEN";47905
-"United Kingdom";GB;GBR;239;"City of Kingston upon Hull";unitary authority;"KHL";47904
-"United Kingdom";GB;GBR;239;"Kingston upon Thames";borough;"KTT";19262
-"United Kingdom";GB;GBR;239;"Kirklees";metropolitan district;"KIR";19263
-"United Kingdom";GB;GBR;239;"Knowsley";metropolitan district;"KWL";19264
-"United Kingdom";GB;GBR;239;"Lambeth";borough;"LBH";19265
-"United Kingdom";GB;GBR;239;"Lancashire";two-tier county;"LAN";48070
-"United Kingdom";GB;GBR;239;"Larne";district council area (Northern Ireland);"LRN";48000
-"United Kingdom";GB;GBR;239;"Leeds";metropolitan district;"LDS";19268
-"United Kingdom";GB;GBR;239;"Leicester";unitary authority;"LCE";48069
-"United Kingdom";GB;GBR;239;"Leicestershire";two-tier county;"LEC";48068
-"United Kingdom";GB;GBR;239;"Lewisham";borough;"LEW";19271
-"United Kingdom";GB;GBR;239;"Limavady";district council area (Northern Ireland);"LMV";47999
-"United Kingdom";GB;GBR;239;"Lincolnshire";two-tier county;"LIN";48067
-"United Kingdom";GB;GBR;239;"Lisburn";district council area (Northern Ireland);"LSB";47998
-"United Kingdom";GB;GBR;239;"Liverpool";metropolitan district;"LIV";19275
-"United Kingdom";GB;GBR;239;"City of London";city corporation;"LND";47912
-"United Kingdom";GB;GBR;239;"Luton";unitary authority;"LUT";48065
-"United Kingdom";GB;GBR;239;"Magherafelt";district council area (Northern Ireland);"MFT";47996
-"United Kingdom";GB;GBR;239;"Manchester";metropolitan district;"MAN";48066
-"United Kingdom";GB;GBR;239;"Medway";unitary authority;"MDW";48064
-"United Kingdom";GB;GBR;239;"Merthyr Tydfil [Merthyr Tudful GB-MTU]";unitary authority (Wales);"MTY";47946
-"United Kingdom";GB;GBR;239;"Merton";borough;"MRT";19282
-"United Kingdom";GB;GBR;239;"Middlesbrough";unitary authority;"MDB";48062
-"United Kingdom";GB;GBR;239;"Midlothian";council area (Scotland);"MLN";47971
-"United Kingdom";GB;GBR;239;"Milton Keynes";unitary authority;"MIK";48061
-"United Kingdom";GB;GBR;239;"Monmouthshire [Sir Fynwy GB-FYN]";unitary authority (Wales);"MON";47945
-"United Kingdom";GB;GBR;239;"Moray";council area (Scotland);"MRY";47970
-"United Kingdom";GB;GBR;239;"Moyle";district council area (Northern Ireland);"MYL";47995
-"United Kingdom";GB;GBR;239;"Neath Port Talbot [Castell-nedd Port Talbot GB-CTL]";unitary authority (Wales);"NTL";47944
-"United Kingdom";GB;GBR;239;"Newcastle upon Tyne";metropolitan district;"NET";19290
-"United Kingdom";GB;GBR;239;"Newham";borough;"NWM";19291
-"United Kingdom";GB;GBR;239;"Newport [Casnewydd GB-CNW]";unitary authority (Wales);"NWP";47943
-"United Kingdom";GB;GBR;239;"Newry and Mourne";district council area (Northern Ireland);"NYM";47994
-"United Kingdom";GB;GBR;239;"Newtownabbey";district council area (Northern Ireland);"NTA";47993
-"United Kingdom";GB;GBR;239;"Norfolk";two-tier county;"NFK";48060
-"United Kingdom";GB;GBR;239;"North Ayrshire";council area (Scotland);"NAY";47969
-"United Kingdom";GB;GBR;239;"North Down";district council area (Northern Ireland);"NDN";47992
-"United Kingdom";GB;GBR;239;"North East Lincolnshire";unitary authority;"NEL";48059
-"United Kingdom";GB;GBR;239;"North Lanarkshire";council area (Scotland);"NLK";47968
-"United Kingdom";GB;GBR;239;"North Lincolnshire";unitary authority;"NLN";48058
-"United Kingdom";GB;GBR;239;"North Somerset";unitary authority;"NSM";48057
-"United Kingdom";GB;GBR;239;"North Tyneside";metropolitan district;"NTY";19302
-"United Kingdom";GB;GBR;239;"North Yorkshire";two-tier county;"NYK";48056
-"United Kingdom";GB;GBR;239;"Northamptonshire";two-tier county;"NTH";48055
-"United Kingdom";GB;GBR;239;"Northumberland";unitary authority;"NBL";48054
-"United Kingdom";GB;GBR;239;"Nottingham";unitary authority;"NGM";48053
-"United Kingdom";GB;GBR;239;"Nottinghamshire";two-tier county;"NTT";48052
-"United Kingdom";GB;GBR;239;"Oldham";metropolitan district;"OLD";19308
-"United Kingdom";GB;GBR;239;"Omagh";district council area (Northern Ireland);"OMH";47991
-"United Kingdom";GB;GBR;239;"Orkney Islands";council area (Scotland);"ORK";47967
-"United Kingdom";GB;GBR;239;"Oxfordshire";two-tier county;"OXF";48051
-"United Kingdom";GB;GBR;239;"Pembrokeshire [Sir Benfro GB-BNF]";unitary authority (Wales);"PEM";47942
-"United Kingdom";GB;GBR;239;"Perth and Kinross";council area (Scotland);"PKN";47966
-"United Kingdom";GB;GBR;239;"Peterborough";unitary authority;"PTE";48050
-"United Kingdom";GB;GBR;239;"Plymouth";unitary authority;"PLY";48049
-"United Kingdom";GB;GBR;239;"Poole";unitary authority;"POL";48048
-"United Kingdom";GB;GBR;239;"Portsmouth";unitary authority;"POR";48047
-"United Kingdom";GB;GBR;239;"Powys";unitary authority (Wales);"POW";47941
-"United Kingdom";GB;GBR;239;"Reading";unitary authority;"RDG";48046
-"United Kingdom";GB;GBR;239;"Redbridge";borough;"RDB";19320
-"United Kingdom";GB;GBR;239;"Redcar and Cleveland";unitary authority;"RCC";48045
-"United Kingdom";GB;GBR;239;"Renfrewshire";council area (Scotland);"RFW";47965
-"United Kingdom";GB;GBR;239;"Cynon Rhondda";unitary authority (Wales);"RCT";47940
-"United Kingdom";GB;GBR;239;"Richmond upon Thames";borough;"RIC";19324
-"United Kingdom";GB;GBR;239;"Rochdale";metropolitan district;"RCH";19325
-"United Kingdom";GB;GBR;239;"Rotherham";metropolitan district;"ROT";19326
-"United Kingdom";GB;GBR;239;"Rutland";unitary authority;"RUT";48044
-"United Kingdom";GB;GBR;239;"Salford";metropolitan district;"SLF";19328
-"United Kingdom";GB;GBR;239;"Sandwell";metropolitan district;"SAW";19329
-"United Kingdom";GB;GBR;239;"The Scottish Borders";council area (Scotland);"SCB";47964
-"United Kingdom";GB;GBR;239;"Sefton";metropolitan district;"SFT";19331
-"United Kingdom";GB;GBR;239;"Sheffield";metropolitan district;"SHF";19332
-"United Kingdom";GB;GBR;239;"Shetland Islands";council area (Scotland);"ZET";47963
-"United Kingdom";GB;GBR;239;"Shropshire";unitary authority;"SHR";48043
-"United Kingdom";GB;GBR;239;"Slough";unitary authority;"SLG";48042
-"United Kingdom";GB;GBR;239;"Solihull";metropolitan district;"SOL";19336
-"United Kingdom";GB;GBR;239;"Somerset";two-tier county;"SOM";48041
-"United Kingdom";GB;GBR;239;"South Ayrshire";council area (Scotland);"SAY";47962
-"United Kingdom";GB;GBR;239;"South Gloucestershire";unitary authority;"SGC";48040
-"United Kingdom";GB;GBR;239;"South Lanarkshire";council area (Scotland);"SLK";47961
-"United Kingdom";GB;GBR;239;"South Tyneside";metropolitan district;"STY";19341
-"United Kingdom";GB;GBR;239;"Southampton";unitary authority;"STH";48038
-"United Kingdom";GB;GBR;239;"Southend-on-Sea";unitary authority;"SOS";48037
-"United Kingdom";GB;GBR;239;"Southwark";borough;"SWK";19344
-"United Kingdom";GB;GBR;239;"St. Helens";metropolitan district;"SHN";19345
-"United Kingdom";GB;GBR;239;"Staffordshire";two-tier county;"STS";48036
-"United Kingdom";GB;GBR;239;"Stirling";council area (Scotland);"STG";47960
-"United Kingdom";GB;GBR;239;"Stockport";metropolitan district;"SKP";19348
-"United Kingdom";GB;GBR;239;"Stockton-on-Tees";unitary authority;"STT";48035
-"United Kingdom";GB;GBR;239;"Stoke-on-Trent";unitary authority;"STE";48034
-"United Kingdom";GB;GBR;239;"Strabane";district council area (Northern Ireland);"STB";47990
-"United Kingdom";GB;GBR;239;"Suffolk";two-tier county;"SFK";48033
-"United Kingdom";GB;GBR;239;"Sunderland";metropolitan district;"SND";19353
-"United Kingdom";GB;GBR;239;"Surrey";two-tier county;"SRY";48032
-"United Kingdom";GB;GBR;239;"Sutton";borough;"STN";19355
-"United Kingdom";GB;GBR;239;"Swansea [Abertawe GB-ATA]";unitary authority (Wales);"SWA";47939
-"United Kingdom";GB;GBR;239;"Swindon";unitary authority;"SWD";48031
-"United Kingdom";GB;GBR;239;"Tameside";metropolitan district;"TAM";19358
-"United Kingdom";GB;GBR;239;"Telford and Wrekin";unitary authority;"TFW";48030
-"United Kingdom";GB;GBR;239;"Thurrock";unitary authority;"THR";48029
-"United Kingdom";GB;GBR;239;"Torbay";unitary authority;"TOB";48028
-"United Kingdom";GB;GBR;239;"Torfaen [Tor-faen]";unitary authority (Wales);"TOF";47938
-"United Kingdom";GB;GBR;239;"Tower Hamlets";borough;"TWH";19363
-"United Kingdom";GB;GBR;239;"Trafford";metropolitan district;"TRF";19364
-"United Kingdom";GB;GBR;239;"The [Bro Morgannwg GB-BMG] Vale of Glamorgan";unitary authority (Wales);"VGL";47937
-"United Kingdom";GB;GBR;239;"Wakefield";metropolitan district;"WKF";19366
-"United Kingdom";GB;GBR;239;"Walsall";metropolitan district;"WLL";19367
-"United Kingdom";GB;GBR;239;"Waltham Forest";borough;"WFT";19368
-"United Kingdom";GB;GBR;239;"Wandsworth";borough;"WND";19369
-"United Kingdom";GB;GBR;239;"Warrington";unitary authority;"WRT";48026
-"United Kingdom";GB;GBR;239;"Warwickshire";two-tier county;"WAR";48025
-"United Kingdom";GB;GBR;239;"West Berkshire";unitary authority;"WBK";48024
-"United Kingdom";GB;GBR;239;"West Dunbartonshire";council area (Scotland);"WDU";47959
-"United Kingdom";GB;GBR;239;"West Lothian";council area (Scotland);"WLN";47958
-"United Kingdom";GB;GBR;239;"West Sussex";two-tier county;"WSX";48022
-"United Kingdom";GB;GBR;239;"Westminster";borough;"WSM";19376
-"United Kingdom";GB;GBR;239;"Wigan";metropolitan district;"WGN";19377
-"United Kingdom";GB;GBR;239;"Wiltshire";unitary authority;"WIL";48020
-"United Kingdom";GB;GBR;239;"Windsor and Maidenhead";unitary authority;"WNM";48019
-"United Kingdom";GB;GBR;239;"Wirral";metropolitan district;"WRL";19380
-"United Kingdom";GB;GBR;239;"Wokingham";unitary authority;"WOK";48018
-"United Kingdom";GB;GBR;239;"Wolverhampton";metropolitan district;"WLV";19382
-"United Kingdom";GB;GBR;239;"Worcestershire";two-tier county;"WOR";48017
-"United Kingdom";GB;GBR;239;"Wrexham [Wrecsam GB-WRC]";unitary authority (Wales);"WRX";47936
-"United Kingdom";GB;GBR;239;"York";unitary authority;"YOR";48016
-"United States";US;USA;240;"Alabama";state;"AL";18655
-"United States";US;USA;240;"Alaska";state;"AK";18683
-"United States";US;USA;240;"American Samoa (see also separate entry under AS)";outlying area;"AS";19386
-"United States";US;USA;240;"Arizona";state;"AZ";18656
-"United States";US;USA;240;"Arkansas";state;"AR";18684
-"United States";US;USA;240;"California";state;"CA";18657
-"United States";US;USA;240;"Colorado";state;"CO";18685
-"United States";US;USA;240;"Connecticut";state;"CT";18658
-"United States";US;USA;240;"Delaware";state;"DE";18686
-"United States";US;USA;240;"District of Columbia";district;"DC";18659
-"United States";US;USA;240;"Florida";state;"FL";18687
-"United States";US;USA;240;"Georgia";state;"GA";18660
-"United States";US;USA;240;"Guam (see also separate entry under GU)";outlying area;"GU";19388
-"United States";US;USA;240;"Hawaii";state;"HI";18688
-"United States";US;USA;240;"Idaho";state;"ID";18661
-"United States";US;USA;240;"Illinois";state;"IL";18674
-"United States";US;USA;240;"Indiana";state;"IN";18662
-"United States";US;USA;240;"Iowa";state;"IA";18663
-"United States";US;USA;240;"Kansas";state;"KS";18675
-"United States";US;USA;240;"Kentucky";state;"KY";18664
-"United States";US;USA;240;"Louisiana";state;"LA";18676
-"United States";US;USA;240;"Maine";state;"ME";18665
-"United States";US;USA;240;"Maryland";state;"MD";18677
-"United States";US;USA;240;"Massachusetts";state;"MA";18666
-"United States";US;USA;240;"Michigan";state;"MI";18678
-"United States";US;USA;240;"Minnesota";state;"MN";18646
-"United States";US;USA;240;"Mississippi";state;"MS";18679
-"United States";US;USA;240;"Missouri";state;"MO";18647
-"United States";US;USA;240;"Montana";state;"MT";18648
-"United States";US;USA;240;"Nebraska";state;"NE";18680
-"United States";US;USA;240;"Nevada";state;"NV";18649
-"United States";US;USA;240;"New Hampshire";state;"NH";18681
-"United States";US;USA;240;"New Jersey";state;"NJ";18650
-"United States";US;USA;240;"New Mexico";state;"NM";18682
-"United States";US;USA;240;"New York";state;"NY";18651
-"United States";US;USA;240;"North Carolina";state;"NC";18645
-"United States";US;USA;240;"North Dakota";state;"ND";18652
-"United States";US;USA;240;"Northern Mariana Islands (see also separate entry under MP)";outlying area;"MP";19390
-"United States";US;USA;240;"Ohio";state;"OH";18689
-"United States";US;USA;240;"Oklahoma";state;"OK";18653
-"United States";US;USA;240;"Oregon";state;"OR";18654
-"United States";US;USA;240;"Pennsylvania";state;"PA";18644
-"United States";US;USA;240;"Puerto Rico (see also separate entry under PR)";outlying area;"PR";19591
-"United States";US;USA;240;"Rhode Island";state;"RI";18667
-"United States";US;USA;240;"South Carolina";state;"SC";18690
-"United States";US;USA;240;"South Dakota";state;"SD";18668
-"United States";US;USA;240;"Tennessee";state;"TN";18643
-"United States";US;USA;240;"Texas";state;"TX";18669
-"United States";US;USA;240;"United States Minor Outlying Islands (see also separate entry under UM)";outlying area;"UM";19597
-"United States";US;USA;240;"Utah";state;"UT";18642
-"United States";US;USA;240;"Vermont";state;"VT";18670
-"United States";US;USA;240;"U.S. (see also separate entry under VI) Virgin Islands";outlying area;"VI";19593
-"United States";US;USA;240;"Virginia";state;"VA";18641
-"United States";US;USA;240;"Washington";state;"WA";18671
-"United States";US;USA;240;"West Virginia";state;"WV";18640
-"United States";US;USA;240;"Wisconsin";state;"WI";18672
-"United States";US;USA;240;"Wyoming";state;"WY";18673
-"United States Minor Outlying Islands";UM;UMI;241;"Baker Island";Territory;"81";18637
-"United States Minor Outlying Islands";UM;UMI;241;"Howland Island";Territory;"84";18636
-"United States Minor Outlying Islands";UM;UMI;241;"Jarvis Island";Territory;"86";18638
-"United States Minor Outlying Islands";UM;UMI;241;"Johnston Atoll";Territory;"67";18635
-"United States Minor Outlying Islands";UM;UMI;241;"Kingman Reef";Territory;"89";18639
-"United States Minor Outlying Islands";UM;UMI;241;"Midway Islands";Territory;"71";18634
-"United States Minor Outlying Islands";UM;UMI;241;"Navassa Island";Territory;"76";18633
-"United States Minor Outlying Islands";UM;UMI;241;"Palmyra Atoll";Territory;"95";18632
-"United States Minor Outlying Islands";UM;UMI;241;"Wake Island";Territory;"79";18631
-"Uruguay";UY;URY;242;"Artigas";Department;"AR";18696
-"Uruguay";UY;URY;242;"Durazno";Department;"DU";18699
-"Uruguay";UY;URY;242;"Flores";Department;"FS";18695
-"Uruguay";UY;URY;242;"Florida";Department;"FD";18700
-"Uruguay";UY;URY;242;"Lavalleja";Department;"LA";18709
-"Uruguay";UY;URY;242;"Maldonado";Department;"MA";18701
-"Uruguay";UY;URY;242;"Montevideo";Department;"MO";18702
-"Uruguay";UY;URY;242;"Paysandú";Department;"PA";18694
-"Uruguay";UY;URY;242;"Rivera";Department;"RV";18693
-"Uruguay";UY;URY;242;"Rocha";Department;"RO";18704
-"Uruguay";UY;URY;242;"Río Negro";Department;"RN";18703
-"Uruguay";UY;URY;242;"Salto";Department;"SA";18705
-"Uruguay";UY;URY;242;"San José";Department;"SJ";18692
-"Uruguay";UY;URY;242;"Soriano";Department;"SO";18706
-"Uruguay";UY;URY;242;"Tacuarembó";Department;"TA";18691
-"Uruguay";UY;URY;242;"Treinta y Tres";Department;"TT";18707
-"Uruguay";UY;URY;242;"";Department;"X1~";18697
-"Uruguay";UY;URY;242;"";Department;"X2~";18708
-"Uruguay";UY;URY;242;"";Department;"X3~";18698
-"Uzbekistan";UZ;UZB;243;"Andijon";region;"AN";18715
-"Uzbekistan";UZ;UZB;243;"Buxoro";region;"BU";18717
-"Uzbekistan";UZ;UZB;243;"Farg‘ona";region;"FA";18714
-"Uzbekistan";UZ;UZB;243;"Jizzax";region;"JI";18723
-"Uzbekistan";UZ;UZB;243;"Namangan";region;"NG";18719
-"Uzbekistan";UZ;UZB;243;"Navoiy";region;"NW";18712
-"Uzbekistan";UZ;UZB;243;"Qashqadaryo";region;"QA";18718
-"Uzbekistan";UZ;UZB;243;"Qoraqalpog‘iston Respublikasi";republic;"QR";18713
-"Uzbekistan";UZ;UZB;243;"Samarqand";region;"SA";18720
-"Uzbekistan";UZ;UZB;243;"Sirdaryo";region;"SI";18711
-"Uzbekistan";UZ;UZB;243;"Surxondaryo";region;"SU";18710
-"Uzbekistan";UZ;UZB;243;"Toshkent";region;"TO";18721
-"Uzbekistan";UZ;UZB;243;"Toshkent City";city;"TK";20580
-"Uzbekistan";UZ;UZB;243;"Xorazm";region;"XO";18724
-"Vanuatu";VU;VUT;244;"Malampa";Province;"MAP";18726
-"Vanuatu";VU;VUT;244;"Pénama";Province;"PAM";18728
-"Vanuatu";VU;VUT;244;"Sanma";Province;"SAM";18730
-"Vanuatu";VU;VUT;244;"Shéfa";Province;"SEE";18727
-"Vanuatu";VU;VUT;244;"Taféa";Province;"TAE";18725
-"Vanuatu";VU;VUT;244;"Torba";Province;"TOB";18729
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Amazonas";state;"Z";18735
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Anzoátegui";state;"B";18745
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Apure";state;"C";18746
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Aragua";state;"D";18736
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Barinas";state;"E";18747
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Bolívar";state;"F";18737
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Carabobo";state;"G";18748
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Cojedes";state;"H";18749
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Delta Amacuro";state;"Y";18738
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Dependencias Federales";federal dependency;"W";18750
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Distrito Federal";federal district;"A";18739
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Falcón";state;"I";18751
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Guárico";state;"J";18740
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Lara";state;"K";18741
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Miranda";state;"M";18743
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Monagas";state;"N";18744
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Mérida";state;"L";18742
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Nueva Esparta";state;"O";18734
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Portuguesa";state;"P";18752
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Sucre";state;"R";18733
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Trujillo";state;"T";20682
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Táchira";state;"S";20681
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Vargas";state;"X";20683
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Yaracuy";state;"U";20680
-"Bolivarian Republic of Venezuela";VE;VEN;245;"Zulia";state;"V";20684
-"Viet Nam";VN;VNM;247;"An Giang";Province;"44";18753
-"Viet Nam";VN;VNM;247;"Ba Ria-Vung Tau";Province;"43";18756
-"Viet Nam";VN;VNM;247;"Bac Can";Province;"53";18755
-"Viet Nam";VN;VNM;247;"Bac Giang";Province;"54";18754
-"Viet Nam";VN;VNM;247;"Bac Lieu";Province;"55";18732
-"Viet Nam";VN;VNM;247;"Bac Ninh";Province;"56";20625
-"Viet Nam";VN;VNM;247;"Ben Tre";Province;"50";20622
-"Viet Nam";VN;VNM;247;"Binh Dinh";Province;"31";20607
-"Viet Nam";VN;VNM;247;"Binh Duong";Province;"57";20626
-"Viet Nam";VN;VNM;247;"Binh Phuoc";Province;"58";20627
-"Viet Nam";VN;VNM;247;"Binh Thuan";Province;"40";20615
-"Viet Nam";VN;VNM;247;"Ca Mau";Province;"59";20628
-"Viet Nam";VN;VNM;247;"Can Tho";municipality;"CT";48708
-"Viet Nam";VN;VNM;247;"Can Tho";Province;"48";20620
-"Viet Nam";VN;VNM;247;"Cao Bang";Province;"04";20587
-"Viet Nam";VN;VNM;247;"Da Nang";municipality;"DN";48892
-"Viet Nam";VN;VNM;247;"thanh pho Da Nang";Province;"60";20629
-"Viet Nam";VN;VNM;247;"Dac Lac";Province;"33";20609
-"Viet Nam";VN;VNM;247;"Dak Nong";Province;"72";20640
-"Viet Nam";VN;VNM;247;"Dien Bien";Province;"71";20639
-"Viet Nam";VN;VNM;247;"Dong Nai";Province;"39";20614
-"Viet Nam";VN;VNM;247;"Dong Thap";Province;"45";20617
-"Viet Nam";VN;VNM;247;"Gia Lai";Province;"30";20606
-"Viet Nam";VN;VNM;247;"Ha Giang";Province;"03";20586
-"Viet Nam";VN;VNM;247;"Ha Nam";Province;"63";20632
-"Viet Nam";VN;VNM;247;"Ha Noi";municipality;"HN";48893
-"Viet Nam";VN;VNM;247;"thu do Ha Noi";Province;"64";20633
-"Viet Nam";VN;VNM;247;"Ha Tay";Province;"15";20594
-"Viet Nam";VN;VNM;247;"Ha Tinh";Province;"23";20599
-"Viet Nam";VN;VNM;247;"Hai Duong";Province;"61";20630
-"Viet Nam";VN;VNM;247;"Hai Phong";municipality;"HP";48894
-"Viet Nam";VN;VNM;247;"thanh pho Hai Phong";Province;"62";20631
-"Viet Nam";VN;VNM;247;"Hau Giang";Province;"73";20641
-"Viet Nam";VN;VNM;247;"Ho Chi Minh [Sai Gon]";municipality;"SG";48895
-"Viet Nam";VN;VNM;247;"thanh pho [Sai Gon] Ho Chi Minh";Province;"65";20634
-"Viet Nam";VN;VNM;247;"Hoa Binh";Province;"14";20593
-"Viet Nam";VN;VNM;247;"Hung Yen";Province;"66";20635
-"Viet Nam";VN;VNM;247;"Khanh Hoa";Province;"34";20610
-"Viet Nam";VN;VNM;247;"Kien Giang";Province;"47";20619
-"Viet Nam";VN;VNM;247;"Kon Tum";Province;"28";20604
-"Viet Nam";VN;VNM;247;"Lai Chau";Province;"01";20584
-"Viet Nam";VN;VNM;247;"Lam Dong";Province;"35";20611
-"Viet Nam";VN;VNM;247;"Lang Son";Province;"09";20591
-"Viet Nam";VN;VNM;247;"Lao Cai";Province;"02";20585
-"Viet Nam";VN;VNM;247;"Long An";Province;"41";20616
-"Viet Nam";VN;VNM;247;"Nam Dinh";Province;"67";20636
-"Viet Nam";VN;VNM;247;"Nghe An";Province;"22";20598
-"Viet Nam";VN;VNM;247;"Ninh Binh";Province;"18";20595
-"Viet Nam";VN;VNM;247;"Ninh Thuan";Province;"36";20612
-"Viet Nam";VN;VNM;247;"Phu Tho";Province;"68";20637
-"Viet Nam";VN;VNM;247;"Phu Yen";Province;"32";20608
-"Viet Nam";VN;VNM;247;"Quang Binh";Province;"24";20600
-"Viet Nam";VN;VNM;247;"Quang Nam";Province;"27";20603
-"Viet Nam";VN;VNM;247;"Quang Ngai";Province;"29";20605
-"Viet Nam";VN;VNM;247;"Quang Ninh";Province;"13";20592
-"Viet Nam";VN;VNM;247;"Quang Tri";Province;"25";20601
-"Viet Nam";VN;VNM;247;"Soc Trang";Province;"52";20624
-"Viet Nam";VN;VNM;247;"Son La";Province;"05";20588
-"Viet Nam";VN;VNM;247;"Tay Ninh";Province;"37";20613
-"Viet Nam";VN;VNM;247;"Thai Binh";Province;"20";20596
-"Viet Nam";VN;VNM;247;"Thai Nguyen";Province;"69";18763
-"Viet Nam";VN;VNM;247;"Thanh Hoa";Province;"21";20597
-"Viet Nam";VN;VNM;247;"Thua Thien-Hue";Province;"26";20602
-"Viet Nam";VN;VNM;247;"Tien Giang";Province;"46";20618
-"Viet Nam";VN;VNM;247;"Tra Vinh";Province;"51";20623
-"Viet Nam";VN;VNM;247;"Tuyen Quang";Province;"07";20590
-"Viet Nam";VN;VNM;247;"Vinh Long";Province;"49";20621
-"Viet Nam";VN;VNM;247;"Vinh Phuc";Province;"70";20638
-"Viet Nam";VN;VNM;247;"Yen Bai";Province;"06";20589
-"Western Sahara";EH;ESH;251;"Boujdour";Province;"BOD";18775
-"Western Sahara";EH;ESH;251;"Es Semara";Province;"ESM";18777
-"Western Sahara";EH;ESH;251;"Laayoune";Province;"LAA";18773
-"Western Sahara";EH;ESH;251;"Oued el Dahab";Province;"OUD";18774
-"Yemen";YE;YEM;252;"'Amran";Governorate;"AM";20660
-"Yemen";YE;YEM;252;"Abyan";Governorate;"AB";18787
-"Yemen";YE;YEM;252;"Ad Dāli‘";Governorate;"DA";20662
-"Yemen";YE;YEM;252;"Al ?udaydah";Governorate;"HU";18790
-"Yemen";YE;YEM;252;"Al Bay?a'";Governorate;"BA";18784
-"Yemen";YE;YEM;252;"Al Jawf";Governorate;"JA";18792
-"Yemen";YE;YEM;252;"Al Mahrah";Governorate;"MR";18793
-"Yemen";YE;YEM;252;"Al Mahwit";Governorate;"MW";18781
-"Yemen";YE;YEM;252;"Dhamar";Governorate;"DH";18789
-"Yemen";YE;YEM;252;"Hadramawt";Governorate;"HD";18785
-"Yemen";YE;YEM;252;"Hajjah";Governorate;"HJ";18786
-"Yemen";YE;YEM;252;"Ibb";Governorate;"IB";18791
-"Yemen";YE;YEM;252;"La?ij";Governorate;"LA";18782
-"Yemen";YE;YEM;252;"Ma'rib";Governorate;"MA";18794
-"Yemen";YE;YEM;252;"Raymah";Governorate;"RA";42618
-"Yemen";YE;YEM;252;"Sa`dah";Governorate;"SD";18795
-"Yemen";YE;YEM;252;"Sanʿā";Governorate;"SN";18779
-"Yemen";YE;YEM;252;"Shabwah";Governorate;"SH";18780
-"Yemen";YE;YEM;252;"Taʿizz";Governorate;"TA";18778
-"Yemen";YE;YEM;252;"Şan‘ā";municipality;"SA";48214
-"Yemen";YE;YEM;252;"ʿAdan";Governorate;"AD";18783
-"Zambia";ZM;ZMB;255;"Central";Province;"02";20690
-"Zambia";ZM;ZMB;255;"Copperbelt";Province;"08";18800
-"Zambia";ZM;ZMB;255;"Eastern";Province;"03";21381
-"Zambia";ZM;ZMB;255;"Luapula";Province;"04";18803
-"Zambia";ZM;ZMB;255;"Lusaka";Province;"09";18801
-"Zambia";ZM;ZMB;255;"North-Western";Province;"06";18804
-"Zambia";ZM;ZMB;255;"Northern";Province;"05";18798
-"Zambia";ZM;ZMB;255;"Southern";Province;"07";18802
-"Zambia";ZM;ZMB;255;"Western";Province;"01";18796
-"Zimbabwe";ZW;ZWE;256;"Bulawayo";City;"BU";21380
-"Zimbabwe";ZW;ZWE;256;"Harare";City;"HA";21379
-"Zimbabwe";ZW;ZWE;256;"Manicaland";Province;"MA";21280
-"Zimbabwe";ZW;ZWE;256;"Mashonaland Central";Province;"MC";21282
-"Zimbabwe";ZW;ZWE;256;"Mashonaland East";Province;"ME";21283
-"Zimbabwe";ZW;ZWE;256;"Mashonaland West";Province;"MW";21284
-"Zimbabwe";ZW;ZWE;256;"Masvingo";Province;"MV";21287
-"Zimbabwe";ZW;ZWE;256;"Matabeleland North";Province;"MN";21285
-"Zimbabwe";ZW;ZWE;256;"Matabeleland South";Province;"MS";21286
-"Zimbabwe";ZW;ZWE;256;"Midlands";Province;"MI";21281
+"COUNTRY NAME";"COUNTRY SHORT CODE";"COUNTRY LONG CODE";"COUNTRY NUMBER CODE";"REGION NAME";"REGION NAME (ASCII)";"REGION TYPE";"REGIONAL CODE";"REGIONAL NUMBER CODE"
+Afghanistan;AF;AFG;2;Badakhshān;Badakhshan;province;BDS;12267
+Afghanistan;AF;AFG;2;Baghlān;Baghlan;province;BGL;12268
+Afghanistan;AF;AFG;2;Balkh;Balkh;province;BAL;12273
+Afghanistan;AF;AFG;2;Bādghīs;Badghis;province;BDG;12272
+Afghanistan;AF;AFG;2;Bāmyān;Bamyan;province;BAM;12269
+Afghanistan;AF;AFG;2;Dāykundī;Daykundi;province;DAY;20221
+Afghanistan;AF;AFG;2;Farāh;Farah;province;FRA;12274
+Afghanistan;AF;AFG;2;Fāryāb;Faryab;province;FYB;12270
+Afghanistan;AF;AFG;2;Ghaznī;Ghazni;province;GHA;12271
+Afghanistan;AF;AFG;2;Ghōr;Ghor;province;GHO;12275
+Afghanistan;AF;AFG;2;Helmand;Helmand;province;HEL;12277
+Afghanistan;AF;AFG;2;Herāt;Herat;province;HER;12262
+Afghanistan;AF;AFG;2;Jowzjān;Jowzjan;province;JOW;12283
+Afghanistan;AF;AFG;2;Kandahār;Kandahar;province;KAN;12263
+Afghanistan;AF;AFG;2;Khōst;Khost;province;KHO;12276
+Afghanistan;AF;AFG;2;Kunar;Kunar;province;KNR;12284
+Afghanistan;AF;AFG;2;Kunduz;Kunduz;province;KDZ;12256
+Afghanistan;AF;AFG;2;Kābul;Kabul;province;KAB;12278
+Afghanistan;AF;AFG;2;Kāpīsā;Kapisa;province;KAP;12261
+Afghanistan;AF;AFG;2;Laghmān;Laghman;province;LAG;12279
+Afghanistan;AF;AFG;2;Lōgar;Logar;province;LOW;12260
+Afghanistan;AF;AFG;2;Nangarhār;Nangarhar;province;NAN;12280
+Afghanistan;AF;AFG;2;Nīmrōz;Nimroz;province;NIM;12285
+Afghanistan;AF;AFG;2;Nūristān;Nuristan;province;NUR;12281
+Afghanistan;AF;AFG;2;Paktia;Paktia;province;PIA;12282
+Afghanistan;AF;AFG;2;Paktika;Paktika;province;PKA;12259
+Afghanistan;AF;AFG;2;Panjshayr;Panjshayr;province;PAN;20222
+Afghanistan;AF;AFG;2;Parwān;Parwan;province;PAR;12257
+Afghanistan;AF;AFG;2;Samangan;Samangan;province;SAM;12264
+Afghanistan;AF;AFG;2;"Sar-e Pul";"Sar-e Pul";province;SAR;12258
+Afghanistan;AF;AFG;2;Takhar;Takhar;province;TAK;12265
+Afghanistan;AF;AFG;2;Uruzgān;Uruzgan;province;URU;12255
+Afghanistan;AF;AFG;2;Uruzgān;Uruzgan;province;ORU;48898
+Afghanistan;AF;AFG;2;Wardak;Wardak;province;WAR;12266
+Afghanistan;AF;AFG;2;Zābul;Zabul;province;ZAB;12254
+Albania;AL;ALB;4;Berat;Berat;district;BR;12316
+Albania;AL;ALB;4;Berat;Berat;county;01;48288
+Albania;AL;ALB;4;Bulqizë;Bulqize;district;BU;12309
+Albania;AL;ALB;4;Delvinë;Delvine;district;DL;12310
+Albania;AL;ALB;4;Devoll;Devoll;district;DV;12317
+Albania;AL;ALB;4;Dibër;Diber;district;DI;12311
+Albania;AL;ALB;4;Dibër;Diber;county;09;48289
+Albania;AL;ALB;4;Durrës;Durres;county;02;48290
+Albania;AL;ALB;4;Durrës;Durres;district;DR;12312
+Albania;AL;ALB;4;Elbasan;Elbasan;district;EL;12315
+Albania;AL;ALB;4;Elbasan;Elbasan;county;03;48291
+Albania;AL;ALB;4;Fier;Fier;county;04;48292
+Albania;AL;ALB;4;Fier;Fier;district;FR;12313
+Albania;AL;ALB;4;Gjirokastër;Gjirokaster;district;GJ;12314
+Albania;AL;ALB;4;Gjirokastër;Gjirokaster;county;05;48293
+Albania;AL;ALB;4;Gramsh;Gramsh;district;GR;12318
+Albania;AL;ALB;4;Has;Has;district;HA;12300
+Albania;AL;ALB;4;Kavajë;Kavaje;district;KA;12301
+Albania;AL;ALB;4;Kolonjë;Kolonje;district;ER;12290
+Albania;AL;ALB;4;Korçë;Korce;district;KO;12302
+Albania;AL;ALB;4;Korçë;Korce;county;06;48294
+Albania;AL;ALB;4;Krujë;Kruje;district;KR;12303
+Albania;AL;ALB;4;Kukës;Kukes;district;KU;12304
+Albania;AL;ALB;4;Kukës;Kukes;county;07;48295
+Albania;AL;ALB;4;Kurbin;Kurbin;district;KB;12305
+Albania;AL;ALB;4;Kuçovë;Kucove;district;KC;12319
+Albania;AL;ALB;4;Lezhë;Lezhe;district;LE;12320
+Albania;AL;ALB;4;Lezhë;Lezhe;county;08;48296
+Albania;AL;ALB;4;Librazhd;Librazhd;district;LB;12306
+Albania;AL;ALB;4;Lushnjë;Lushnje;district;LU;12307
+Albania;AL;ALB;4;Mallakastër;Mallakaster;district;MK;12321
+Albania;AL;ALB;4;"Malësi e Madhe";"Malesi e Madhe";district;MM;12308
+Albania;AL;ALB;4;Mat;Mat;district;MT;12291
+Albania;AL;ALB;4;Mirditë;Mirdite;district;MR;12289
+Albania;AL;ALB;4;Peqin;Peqin;district;PQ;12292
+Albania;AL;ALB;4;Pogradec;Pogradec;district;PG;12288
+Albania;AL;ALB;4;Pukë;Puke;district;PU;12294
+Albania;AL;ALB;4;Përmet;Permet;district;PR;12293
+Albania;AL;ALB;4;Sarandë;Sarande;district;SR;12295
+Albania;AL;ALB;4;Shkodër;Shkoder;district;SH;12287
+Albania;AL;ALB;4;Shkodër;Shkoder;county;10;48297
+Albania;AL;ALB;4;Skrapar;Skrapar;district;SK;12296
+Albania;AL;ALB;4;Tepelenë;Tepelene;district;TE;12297
+Albania;AL;ALB;4;Tiranë;Tirane;district;TR;12286
+Albania;AL;ALB;4;Tiranë;Tirane;county;11;48298
+Albania;AL;ALB;4;Tropojë;Tropoje;district;TP;12298
+Albania;AL;ALB;4;Vlorë;Vlore;county;12;48299
+Albania;AL;ALB;4;Vlorë;Vlore;district;VL;12299
+Algeria;DZ;DZA;5;Adrar;Adrar;province;01;12363
+Algeria;DZ;DZA;5;Alger;Alger;province;16;12344
+Algeria;DZ;DZA;5;Annaba;Annaba;province;23;12332
+Algeria;DZ;DZA;5;"Aïn Defla";"Ain Defla";province;44;12351
+Algeria;DZ;DZA;5;"Aïn Témouchent";"Ain Temouchent";province;46;12333
+Algeria;DZ;DZA;5;Batna;Batna;province;05;12334
+Algeria;DZ;DZA;5;Biskra;Biskra;province;07;12354
+Algeria;DZ;DZA;5;Blida;Blida;province;09;12336
+Algeria;DZ;DZA;5;"Bordj Bou Arréridj";"Bordj Bou Arreridj";province;34;12342
+Algeria;DZ;DZA;5;Bouira;Bouira;province;10;12341
+Algeria;DZ;DZA;5;Boumerdès;Boumerdes;province;35;12337
+Algeria;DZ;DZA;5;Béchar;Bechar;province;08;12352
+Algeria;DZ;DZA;5;Béjaïa;Bejaia;province;06;12335
+Algeria;DZ;DZA;5;Chlef;Chlef;province;02;12367
+Algeria;DZ;DZA;5;Constantine;Constantine;province;25;12348
+Algeria;DZ;DZA;5;Djelfa;Djelfa;province;17;12345
+Algeria;DZ;DZA;5;"El Bayadh";"El Bayadh";province;32;12353
+Algeria;DZ;DZA;5;"El Oued";"El Oued";province;39;12323
+Algeria;DZ;DZA;5;"El Tarf";"El Tarf";province;36;12357
+Algeria;DZ;DZA;5;Ghardaïa;Ghardaia;province;47;12343
+Algeria;DZ;DZA;5;Guelma;Guelma;province;24;12366
+Algeria;DZ;DZA;5;Illizi;Illizi;province;33;12340
+Algeria;DZ;DZA;5;Jijel;Jijel;province;18;12330
+Algeria;DZ;DZA;5;Khenchela;Khenchela;province;40;12339
+Algeria;DZ;DZA;5;Laghouat;Laghouat;province;03;12350
+Algeria;DZ;DZA;5;Mascara;Mascara;province;29;12365
+Algeria;DZ;DZA;5;Mila;Mila;province;43;12329
+Algeria;DZ;DZA;5;Mostaganem;Mostaganem;province;27;12347
+Algeria;DZ;DZA;5;Msila;Msila;province;28;12364
+Algeria;DZ;DZA;5;Médéa;Medea;province;26;12346
+Algeria;DZ;DZA;5;Naama;Naama;province;45;12328
+Algeria;DZ;DZA;5;Oran;Oran;province;31;12362
+Algeria;DZ;DZA;5;Ouargla;Ouargla;province;30;12322
+Algeria;DZ;DZA;5;"Oum el Bouaghi";"Oum el Bouaghi";province;04;12361
+Algeria;DZ;DZA;5;Relizane;Relizane;province;48;12338
+Algeria;DZ;DZA;5;Saïda;Saida;province;20;12327
+Algeria;DZ;DZA;5;"Sidi Bel Abbès";"Sidi Bel Abbes";province;22;12326
+Algeria;DZ;DZA;5;Skikda;Skikda;province;21;12349
+Algeria;DZ;DZA;5;"Souk Ahras";"Souk Ahras";province;41;12356
+Algeria;DZ;DZA;5;Sétif;Setif;province;19;12355
+Algeria;DZ;DZA;5;Tamanghasset;Tamanghasset;province;11;12368
+Algeria;DZ;DZA;5;Tiaret;Tiaret;province;14;12360
+Algeria;DZ;DZA;5;Tindouf;Tindouf;province;37;12359
+Algeria;DZ;DZA;5;Tipaza;Tipaza;province;42;12369
+Algeria;DZ;DZA;5;Tissemsilt;Tissemsilt;province;38;12325
+Algeria;DZ;DZA;5;"Tizi Ouzou";"Tizi Ouzou";province;15;12324
+Algeria;DZ;DZA;5;Tlemcen;Tlemcen;province;13;12370
+Algeria;DZ;DZA;5;Tébessa;Tebessa;province;12;12358
+Andorra;AD;AND;7;"Andorra la Vella";"Andorra la Vella";parish;07;12382
+Andorra;AD;AND;7;Canillo;Canillo;parish;02;12381
+Andorra;AD;AND;7;Encamp;Encamp;parish;03;12383
+Andorra;AD;AND;7;Escaldes-Engordany;Escaldes-Engordany;parish;08;12380
+Andorra;AD;AND;7;"La Massana";"La Massana";parish;04;12384
+Andorra;AD;AND;7;Ordino;Ordino;parish;05;12379
+Andorra;AD;AND;7;"Sant Julià de Lòria";"Sant Julia de Loria";parish;06;12378
+Angola;AO;AGO;8;Bengo;Bengo;province;BGO;12390
+Angola;AO;AGO;8;Benguela;Benguela;province;BGU;12391
+Angola;AO;AGO;8;Bié;Bie;province;BIE;12395
+Angola;AO;AGO;8;Cabinda;Cabinda;province;CAB;12392
+Angola;AO;AGO;8;Cuando-Cubango;Cuando-Cubango;province;CCU;12394
+Angola;AO;AGO;8;"Cuanza Norte";"Cuanza Norte";province;CNO;12388
+Angola;AO;AGO;8;"Cuanza Sul";"Cuanza Sul";province;CUS;12397
+Angola;AO;AGO;8;Cunene;Cunene;province;CNN;12389
+Angola;AO;AGO;8;Huambo;Huambo;province;HUA;12393
+Angola;AO;AGO;8;Huíla;Huila;province;HUI;12396
+Angola;AO;AGO;8;Luanda;Luanda;province;LUA;12387
+Angola;AO;AGO;8;"Lunda Norte";"Lunda Norte";province;LNO;12398
+Angola;AO;AGO;8;"Lunda Sul";"Lunda Sul";province;LSU;12386
+Angola;AO;AGO;8;Malange;Malange;province;MAL;12399
+Angola;AO;AGO;8;Moxico;Moxico;province;MOX;12401
+Angola;AO;AGO;8;Namibe;Namibe;province;NAM;12402
+Angola;AO;AGO;8;Uíge;Uige;province;UIG;12400
+Angola;AO;AGO;8;Zaire;Zaire;province;ZAI;12385
+"Antigua and Barbuda";AG;ATG;11;Barbuda;Barbuda;dependency;10;12426
+"Antigua and Barbuda";AG;ATG;11;Redonda;Redonda;dependency;11;12425
+"Antigua and Barbuda";AG;ATG;11;Redonda;Redonda;dependency;X2~;48127
+"Antigua and Barbuda";AG;ATG;11;"Saint George";"Saint George";parish;03;12427
+"Antigua and Barbuda";AG;ATG;11;"Saint John’s";"Saint John's";parish;04;12431
+"Antigua and Barbuda";AG;ATG;11;"Saint Mary";"Saint Mary";parish;05;12428
+"Antigua and Barbuda";AG;ATG;11;"Saint Paul";"Saint Paul";parish;06;12429
+"Antigua and Barbuda";AG;ATG;11;"Saint Peter";"Saint Peter";parish;07;12432
+"Antigua and Barbuda";AG;ATG;11;"Saint Philip";"Saint Philip";parish;08;12430
+Argentina;AR;ARG;12;"Buenos Aires";"Buenos Aires";province;B;12439
+Argentina;AR;ARG;12;Catamarca;Catamarca;province;K;12438
+Argentina;AR;ARG;12;Chaco;Chaco;province;H;12440
+Argentina;AR;ARG;12;Chubut;Chubut;province;U;12454
+Argentina;AR;ARG;12;"Ciudad Autónoma de Buenos Aires";"Ciudad Autonoma de Buenos Aires";"federal district";C;12437
+Argentina;AR;ARG;12;Corrientes;Corrientes;province;W;12442
+Argentina;AR;ARG;12;Córdoba;Cordoba;province;X;12441
+Argentina;AR;ARG;12;"Entre Ríos";"Entre Rios";province;E;12443
+Argentina;AR;ARG;12;Formosa;Formosa;province;P;12455
+Argentina;AR;ARG;12;Jujuy;Jujuy;province;Y;12444
+Argentina;AR;ARG;12;"La Pampa";"La Pampa";province;L;12445
+Argentina;AR;ARG;12;"La Rioja";"La Rioja";province;F;12436
+Argentina;AR;ARG;12;Mendoza;Mendoza;province;M;12446
+Argentina;AR;ARG;12;Misiones;Misiones;province;N;12456
+Argentina;AR;ARG;12;Neuquén;Neuquen;province;Q;12447
+Argentina;AR;ARG;12;"Río Negro";"Rio Negro";province;R;12448
+Argentina;AR;ARG;12;Salta;Salta;province;A;12435
+Argentina;AR;ARG;12;"San Juan";"San Juan";province;J;12449
+Argentina;AR;ARG;12;"San Luis";"San Luis";province;D;12450
+Argentina;AR;ARG;12;"Santa Cruz";"Santa Cruz";province;Z;12434
+Argentina;AR;ARG;12;"Santa Fe";"Santa Fe";province;S;12451
+Argentina;AR;ARG;12;"Santiago del Estero";"Santiago del Estero";province;G;12433
+Argentina;AR;ARG;12;"Tierra del Fuego";"Tierra del Fuego";province;V;12452
+Argentina;AR;ARG;12;Tucumán;Tucuman;province;T;12453
+Armenia;AM;ARM;13;Aragac?otn;Aragacotn;province;AG;12466
+Armenia;AM;ARM;13;Ararat;Ararat;province;AR;12461
+Armenia;AM;ARM;13;Armavir;Armavir;province;AV;12467
+Armenia;AM;ARM;13;Erevan;Erevan;city;ER;12464
+Armenia;AM;ARM;13;Gegark'unik';Gegark'unik';province;GR;12460
+Armenia;AM;ARM;13;Kotayk';Kotayk';province;KT;12462
+Armenia;AM;ARM;13;Lo?y;Loy;province;LO;12465
+Armenia;AM;ARM;13;Syunik';Syunik';province;SU;12463
+Armenia;AM;ARM;13;Tavuš;Tavus;province;TV;12457
+Armenia;AM;ARM;13;"Vayoc Jor";"Vayoc Jor";province;VD;12458
+Armenia;AM;ARM;13;Širak;Sirak;province;SH;12459
+Australia;AU;AUS;15;"Australian Capital Territory";"Australian Capital Territory";territory;ACT;12471
+Australia;AU;AUS;15;"New South Wales";"New South Wales";state;NSW;12477
+Australia;AU;AUS;15;"Northern Territory";"Northern Territory";territory;NT;12475
+Australia;AU;AUS;15;Queensland;Queensland;state;QLD;12476
+Australia;AU;AUS;15;"South Australia";"South Australia";state;SA;12472
+Australia;AU;AUS;15;Tasmania;Tasmania;state;TAS;12474
+Australia;AU;AUS;15;Victoria;Victoria;state;VIC;12473
+Australia;AU;AUS;15;"Western Australia";"Western Australia";state;WA;12470
+Austria;AT;AUT;16;Burgenland;Burgenland;state;1;12480
+Austria;AT;AUT;16;Kärnten;Karnten;state;2;12481
+Austria;AT;AUT;16;Niederösterreich;Niederosterreich;state;3;12485
+Austria;AT;AUT;16;Oberösterreich;Oberosterreich;state;4;12482
+Austria;AT;AUT;16;Salzburg;Salzburg;state;5;12479
+Austria;AT;AUT;16;Steiermark;Steiermark;state;6;12483
+Austria;AT;AUT;16;Tirol;Tirol;state;7;12486
+Austria;AT;AUT;16;Vorarlberg;Vorarlberg;state;8;12484
+Austria;AT;AUT;16;Wien;Wien;state;9;12478
+Azerbaijan;AZ;AZE;17;Abseron;Abseron;district;ABS;12521
+Azerbaijan;AZ;AZE;17;Agcabädi;Agcabadi;district;AGC;12522
+Azerbaijan;AZ;AZE;17;Agdam;Agdam;district;AGM;12550
+Azerbaijan;AZ;AZE;17;Agdas;Agdas;district;AGS;12523
+Azerbaijan;AZ;AZE;17;Agstafa;Agstafa;district;AGA;12493
+Azerbaijan;AZ;AZE;17;Agsu;Agsu;district;AGU;12524
+Azerbaijan;AZ;AZE;17;Astara;Astara;district;AST;12525
+Azerbaijan;AZ;AZE;17;Babäk;Babak;district;BAB;12494
+Azerbaijan;AZ;AZE;17;Baki;Baki;municipality;BA;12526
+Azerbaijan;AZ;AZE;17;Balakän;Balakan;district;BAL;12527
+Azerbaijan;AZ;AZE;17;Beyläqan;Beylaqan;district;BEY;12528
+Azerbaijan;AZ;AZE;17;Biläsuvar;Bilasuvar;district;BIL;12529
+Azerbaijan;AZ;AZE;17;Bärdä;Barda;district;BAR;12495
+Azerbaijan;AZ;AZE;17;Culfa;Culfa;district;CUL;12531
+Azerbaijan;AZ;AZE;17;Cäbrayil;Cabrayil;district;CAB;12496
+Azerbaijan;AZ;AZE;17;Cälilabab;Calilabab;district;CAL;12530
+Azerbaijan;AZ;AZE;17;Daskäsän;Daskasan;district;DAS;12497
+Azerbaijan;AZ;AZE;17;Däväçi;Davaci;district;DAV;12532
+Azerbaijan;AZ;AZE;17;Füzuli;Fuzuli;district;FUZ;12533
+Azerbaijan;AZ;AZE;17;Goranboy;Goranboy;district;GOR;12512
+Azerbaijan;AZ;AZE;17;Gädäbäy;Gadabay;district;GAD;12534
+Azerbaijan;AZ;AZE;17;Göygöl;Goygol;district;GYG;48902
+Azerbaijan;AZ;AZE;17;Göyçay;Goycay;district;GOY;12513
+Azerbaijan;AZ;AZE;17;Gəncə;Gence;municipality;GA;12499
+Azerbaijan;AZ;AZE;17;Haciqabul;Haciqabul;district;HAC;12500
+Azerbaijan;AZ;AZE;17;Imisli;Imisli;district;IMI;12514
+Azerbaijan;AZ;AZE;17;Ismayilli;Ismayilli;district;ISM;12501
+Azerbaijan;AZ;AZE;17;Kälbäcär;Kalbacar;district;KAL;12515
+Azerbaijan;AZ;AZE;17;Kürdämir;Kurdamir;district;KUR;12516
+Azerbaijan;AZ;AZE;17;Kǝngǝrli;Kengerli;district;KAN;48903
+Azerbaijan;AZ;AZE;17;Laçin;Lacin;district;LAC;12551
+Azerbaijan;AZ;AZE;17;Lerik;Lerik;district;LER;12518
+Azerbaijan;AZ;AZE;17;Länkäran;Lankaran;district;LAN;12517
+Azerbaijan;AZ;AZE;17;Lənkəran;Lenkeran;municipality;LA;20104
+Azerbaijan;AZ;AZE;17;Masalli;Masalli;district;MAS;12552
+Azerbaijan;AZ;AZE;17;Mingəçevir;Mingecevir;municipality;MI;12519
+Azerbaijan;AZ;AZE;17;Naftalan;Naftalan;municipality;NA;12520
+Azerbaijan;AZ;AZE;17;Naxçivan;Naxcivan;"autonomous republic";NX;12553
+Azerbaijan;AZ;AZE;17;Naxçıvan;Naxcivan;municipality;NV;48899
+Azerbaijan;AZ;AZE;17;Neftçala;Neftcala;district;NEF;12535
+Azerbaijan;AZ;AZE;17;Oguz;Oguz;district;OGU;12554
+Azerbaijan;AZ;AZE;17;Ordubad;Ordubad;district;ORD;12536
+Azerbaijan;AZ;AZE;17;Qax;Qax;district;QAX;12537
+Azerbaijan;AZ;AZE;17;Qazax;Qazax;district;QAZ;12555
+Azerbaijan;AZ;AZE;17;Qobustan;Qobustan;district;QOB;12539
+Azerbaijan;AZ;AZE;17;Quba;Quba;district;QBA;12556
+Azerbaijan;AZ;AZE;17;Qubadli;Qubadli;district;QBI;12540
+Azerbaijan;AZ;AZE;17;Qusar;Qusar;district;QUS;12541
+Azerbaijan;AZ;AZE;17;Qäbälä;Qabala;district;QAB;12538
+Azerbaijan;AZ;AZE;17;Saatli;Saatli;district;SAT;12557
+Azerbaijan;AZ;AZE;17;Sabirabad;Sabirabad;district;SAB;12542
+Azerbaijan;AZ;AZE;17;Sahbuz;Sahbuz;district;SAH;12502
+Azerbaijan;AZ;AZE;17;Salyan;Salyan;district;SAL;12558
+Azerbaijan;AZ;AZE;17;Samaxi;Samaxi;district;SMI;12503
+Azerbaijan;AZ;AZE;17;Samux;Samux;district;SMX;12492
+Azerbaijan;AZ;AZE;17;Siyäzän;Siyazan;district;SIY;12507
+Azerbaijan;AZ;AZE;17;Sumqayıt;Sumqayit;municipality;SM;12491
+Azerbaijan;AZ;AZE;17;Susa;Susa;district;SUS;12508
+Azerbaijan;AZ;AZE;17;"Susa City";"Susa City";municipality;SS;20106
+Azerbaijan;AZ;AZE;17;Sädäräk;Sadarak;district;SAD;12504
+Azerbaijan;AZ;AZE;17;Säki;Saki;district;SAK;12505
+Azerbaijan;AZ;AZE;17;Sämkir;Samkir;district;SKR;12559
+Azerbaijan;AZ;AZE;17;Särur;Sarur;district;SAR;12506
+Azerbaijan;AZ;AZE;17;Tovuz;Tovuz;district;TOV;12560
+Azerbaijan;AZ;AZE;17;Tärtär;Tartar;district;TAR;12509
+Azerbaijan;AZ;AZE;17;Ucar;Ucar;district;UCA;12510
+Azerbaijan;AZ;AZE;17;Xankəndi;Xankendi;municipality;XA;12490
+Azerbaijan;AZ;AZE;17;Xanlar;Xanlar;district;XAN;12544
+Azerbaijan;AZ;AZE;17;Xaçmaz;Xacmaz;district;XAC;12543
+Azerbaijan;AZ;AZE;17;Xizi;Xizi;district;XIZ;12545
+Azerbaijan;AZ;AZE;17;Xocali;Xocali;district;XCI;12489
+Azerbaijan;AZ;AZE;17;Xocavänd;Xocavand;district;XVD;12546
+Azerbaijan;AZ;AZE;17;Yardimli;Yardimli;district;YAR;12488
+Azerbaijan;AZ;AZE;17;Yevlax;Yevlax;district;YEV;12547
+Azerbaijan;AZ;AZE;17;"Yevlax City";"Yevlax City";municipality;YE;20107
+Azerbaijan;AZ;AZE;17;Zaqatala;Zaqatala;district;ZAQ;12548
+Azerbaijan;AZ;AZE;17;Zängilan;Zangilan;district;ZAN;12487
+Azerbaijan;AZ;AZE;17;Zärdab;Zardab;district;ZAR;12549
+Azerbaijan;AZ;AZE;17;"Äli Bayramli";"Ali Bayramli";municipality;AB;12498
+Azerbaijan;AZ;AZE;17;Şabran;Sabran;district;SBN;48901
+Azerbaijan;AZ;AZE;17;Şirvan;Sirvan;municipality;SR;48900
+Azerbaijan;AZ;AZE;17;Şəki;Seki;municipality;SA;20105
+Bahamas;BS;BHS;18;"Acklins  Islands";"Acklins  Islands";district;AK;12567
+Bahamas;BS;BHS;18;"Acklins and Crooked Islands";"Acklins and Crooked Islands";district;AC;48139
+Bahamas;BS;BHS;18;"Berry Islands";"Berry Islands";district;BY;48140
+Bahamas;BS;BHS;18;"Bimini and Cat Cay";"Bimini and Cat Cay";district;BI;12574
+Bahamas;BS;BHS;18;"Black Point";"Black Point";district;BP;48141
+Bahamas;BS;BHS;18;"Cat Island";"Cat Island";district;CI;12575
+Bahamas;BS;BHS;18;"Central Abaco";"Central Abaco";district;CO;48142
+Bahamas;BS;BHS;18;"Central Andros";"Central Andros";district;CS;48143
+Bahamas;BS;BHS;18;"Central Eleuthera";"Central Eleuthera";district;CE;48144
+Bahamas;BS;BHS;18;"City of Freeport";"City of Freeport";district;FP;12566
+Bahamas;BS;BHS;18;"Crooked Island and Long Cay";"Crooked Island and Long Cay";district;CK;48146
+Bahamas;BS;BHS;18;"East Grand Bahama";"East Grand Bahama";district;EG;48147
+Bahamas;BS;BHS;18;Exuma;Exuma;district;EX;12578
+Bahamas;BS;BHS;18;"Governor's Harbour";"Governor's Harbour";district;GH;12577
+Bahamas;BS;BHS;18;"Grand Cay";"Grand Cay";district;GC;12572
+Bahamas;BS;BHS;18;"Green Turtle Cay";"Green Turtle Cay";district;GT;12571
+Bahamas;BS;BHS;18;"Harbour Island";"Harbour Island";district;HI;12579
+Bahamas;BS;BHS;18;"High Rock";"High Rock";district;HR;20112
+Bahamas;BS;BHS;18;"Hope Town";"Hope Town";district;HT;48148
+Bahamas;BS;BHS;18;Inagua;Inagua;district;IN;12565
+Bahamas;BS;BHS;18;"Kemps Bay";"Kemps Bay";district;KB;20113
+Bahamas;BS;BHS;18;"Long Island";"Long Island";district;LI;12580
+Bahamas;BS;BHS;18;"Mangrove Cay";"Mangrove Cay";district;MC;48149
+Bahamas;BS;BHS;18;"Marsh Harbour";"Marsh Harbour";district;MH;20114
+Bahamas;BS;BHS;18;Mayaguana;Mayaguana;district;MG;12564
+Bahamas;BS;BHS;18;"Moore’s Island";"Moore's Island";district;MI;48150
+Bahamas;BS;BHS;18;"New Providence";"New Providence";district;NP;12563
+Bahamas;BS;BHS;18;"Nicholls Town and Berry Islands";"Nicholls Town and Berry Islands";district;NB;12573
+Bahamas;BS;BHS;18;"North Abaco";"North Abaco";district;NO;48151
+Bahamas;BS;BHS;18;"North Andros";"North Andros";district;NS;48152
+Bahamas;BS;BHS;18;"North Eleuthera";"North Eleuthera";district;NE;48153
+Bahamas;BS;BHS;18;"Ragged Island";"Ragged Island";district;RI;12568
+Bahamas;BS;BHS;18;"Rock Sound";"Rock Sound";district;RS;20115
+Bahamas;BS;BHS;18;"Rum Cay";"Rum Cay";district;RC;48154
+Bahamas;BS;BHS;18;"San Salvador";"San Salvador";district;SS;48155
+Bahamas;BS;BHS;18;"San Salvador and Rum Cay";"San Salvador and Rum Cay";district;SR;12569
+Bahamas;BS;BHS;18;"Sandy Point";"Sandy Point";district;SP;20116
+Bahamas;BS;BHS;18;"South Abaco";"South Abaco";district;SO;48156
+Bahamas;BS;BHS;18;"South Andros";"South Andros";district;SA;48157
+Bahamas;BS;BHS;18;"South Eleuthera";"South Eleuthera";district;SE;48158
+Bahamas;BS;BHS;18;"Spanish Wells";"Spanish Wells";district;SW;48159
+Bahamas;BS;BHS;18;"West Grand Bahama";"West Grand Bahama";district;WG;48160
+Bahrain;BH;BHR;21;"Al Janubiyah";"Al Janubiyah";governorate;14;12592
+Bahrain;BH;BHR;21;"Al Manamah (Al ‘Asimah)";"Al Manamah (Al 'Asimah)";governorate;13;12589
+Bahrain;BH;BHR;21;"Al Muharraq";"Al Muharraq";governorate;15;12583
+Bahrain;BH;BHR;21;"Al Wustá";"Al Wusta";governorate;16;12581
+Bahrain;BH;BHR;21;"Ash Shamaliyah";"Ash Shamaliyah";governorate;17;12582
+Bangladesh;BD;BGD;22;Bagerhat;Bagerhat;district;05;12600
+Bangladesh;BD;BGD;22;Bandarban;Bandarban;district;01;12601
+Bangladesh;BD;BGD;22;Barguna;Barguna;district;02;12602
+Bangladesh;BD;BGD;22;Barisal;Barisal;division;A;48675
+Bangladesh;BD;BGD;22;Barisal;Barisal;district;06;12612
+Bangladesh;BD;BGD;22;Barisal;Barisal;division;1;48257
+Bangladesh;BD;BGD;22;Bhola;Bhola;district;07;12613
+Bangladesh;BD;BGD;22;Bogra;Bogra;district;03;12614
+Bangladesh;BD;BGD;22;Brahmanbaria;Brahmanbaria;district;04;12630
+Bangladesh;BD;BGD;22;Chandpur;Chandpur;district;09;12615
+Bangladesh;BD;BGD;22;Chittagong;Chittagong;division;2;48258
+Bangladesh;BD;BGD;22;Chittagong;Chittagong;division;B;48676
+Bangladesh;BD;BGD;22;Chittagong;Chittagong;district;10;12631
+Bangladesh;BD;BGD;22;Chuadanga;Chuadanga;district;12;12632
+Bangladesh;BD;BGD;22;Comilla;Comilla;district;08;12606
+Bangladesh;BD;BGD;22;"Cox's Bazar";"Cox's Bazar";district;11;12641
+Bangladesh;BD;BGD;22;Dhaka;Dhaka;district;13;12616
+Bangladesh;BD;BGD;22;Dhaka;Dhaka;division;C;48677
+Bangladesh;BD;BGD;22;Dhaka;Dhaka;division;3;48259
+Bangladesh;BD;BGD;22;Dinajpur;Dinajpur;district;14;12633
+Bangladesh;BD;BGD;22;Faridpur;Faridpur;district;15;12617
+Bangladesh;BD;BGD;22;Feni;Feni;district;16;12618
+Bangladesh;BD;BGD;22;Gaibandha;Gaibandha;district;19;12634
+Bangladesh;BD;BGD;22;Gazipur;Gazipur;district;18;12635
+Bangladesh;BD;BGD;22;Gopalganj;Gopalganj;district;17;12619
+Bangladesh;BD;BGD;22;Habiganj;Habiganj;district;20;12636
+Bangladesh;BD;BGD;22;Jaipurhat;Jaipurhat;district;24;12620
+Bangladesh;BD;BGD;22;Jamalpur;Jamalpur;district;21;12637
+Bangladesh;BD;BGD;22;Jessore;Jessore;district;22;12603
+Bangladesh;BD;BGD;22;Jhalakati;Jhalakati;district;25;12638
+Bangladesh;BD;BGD;22;Jhenaidah;Jhenaidah;district;23;12604
+Bangladesh;BD;BGD;22;Khagrachari;Khagrachari;district;29;12639
+Bangladesh;BD;BGD;22;Khulna;Khulna;division;4;48260
+Bangladesh;BD;BGD;22;Khulna;Khulna;division;D;48678
+Bangladesh;BD;BGD;22;Khulna;Khulna;district;27;12640
+Bangladesh;BD;BGD;22;Kishoreganj;Kishoreganj;district;26;12605
+Bangladesh;BD;BGD;22;Kurigram;Kurigram;district;28;12642
+Bangladesh;BD;BGD;22;Kushtia;Kushtia;district;30;12607
+Bangladesh;BD;BGD;22;Lakshmipur;Lakshmipur;district;31;12643
+Bangladesh;BD;BGD;22;Lalmonirhat;Lalmonirhat;district;32;12608
+Bangladesh;BD;BGD;22;Madaripur;Madaripur;district;36;12644
+Bangladesh;BD;BGD;22;Magura;Magura;district;37;12609
+Bangladesh;BD;BGD;22;Manikganj;Manikganj;district;33;12610
+Bangladesh;BD;BGD;22;Meherpur;Meherpur;district;39;12611
+Bangladesh;BD;BGD;22;Moulvibazar;Moulvibazar;district;38;12622
+Bangladesh;BD;BGD;22;Munshiganj;Munshiganj;district;35;12623
+Bangladesh;BD;BGD;22;Mymensingh;Mymensingh;district;34;12621
+Bangladesh;BD;BGD;22;Naogaon;Naogaon;district;48;12626
+Bangladesh;BD;BGD;22;Narail;Narail;district;43;12624
+Bangladesh;BD;BGD;22;Narayanganj;Narayanganj;district;40;12599
+Bangladesh;BD;BGD;22;Narsingdi;Narsingdi;district;42;12625
+Bangladesh;BD;BGD;22;Natore;Natore;district;44;12653
+Bangladesh;BD;BGD;22;Nawabganj;Nawabganj;district;45;12598
+Bangladesh;BD;BGD;22;Netrakona;Netrakona;district;41;12627
+Bangladesh;BD;BGD;22;Nilphamari;Nilphamari;district;46;12654
+Bangladesh;BD;BGD;22;Noakhali;Noakhali;district;47;12628
+Bangladesh;BD;BGD;22;Pabna;Pabna;district;49;12629
+Bangladesh;BD;BGD;22;Panchagarh;Panchagarh;district;52;12597
+Bangladesh;BD;BGD;22;Patuakhali;Patuakhali;district;51;12645
+Bangladesh;BD;BGD;22;Pirojpur;Pirojpur;district;50;12655
+Bangladesh;BD;BGD;22;Rajbari;Rajbari;district;53;12646
+Bangladesh;BD;BGD;22;Rajshahi;Rajshahi;district;54;12596
+Bangladesh;BD;BGD;22;Rajshahi;Rajshahi;division;5;48261
+Bangladesh;BD;BGD;22;Rajshahi;Rajshahi;division;E;48679
+Bangladesh;BD;BGD;22;"Rangamati   Parbattya Chattagram";"Rangamati   Parbattya Chattagram";district;56;12647
+Bangladesh;BD;BGD;22;Rangpur;Rangpur;district;55;12648
+Bangladesh;BD;BGD;22;Rangpur;Rangpur;division;F;48681
+Bangladesh;BD;BGD;22;Satkhira;Satkhira;district;58;12656
+Bangladesh;BD;BGD;22;Shariatpur;Shariatpur;district;62;12649
+Bangladesh;BD;BGD;22;Sherpur;Sherpur;district;57;12595
+Bangladesh;BD;BGD;22;Sirajganj;Sirajganj;district;59;12594
+Bangladesh;BD;BGD;22;Sunamganj;Sunamganj;district;61;12651
+Bangladesh;BD;BGD;22;Sylhet;Sylhet;division;6;48262
+Bangladesh;BD;BGD;22;Sylhet;Sylhet;district;60;12650
+Bangladesh;BD;BGD;22;Sylhet;Sylhet;division;G;48680
+Bangladesh;BD;BGD;22;Tangail;Tangail;district;63;12593
+Bangladesh;BD;BGD;22;Thakurgaon;Thakurgaon;district;64;12652
+Barbados;BB;BRB;23;"Christ Church";"Christ Church";parish;01;12661
+Barbados;BB;BRB;23;"Saint Andrew";"Saint Andrew";parish;02;12663
+Barbados;BB;BRB;23;"Saint George";"Saint George";parish;03;12662
+Barbados;BB;BRB;23;"Saint James";"Saint James";parish;04;12660
+Barbados;BB;BRB;23;"Saint John";"Saint John";parish;05;12664
+Barbados;BB;BRB;23;"Saint Joseph";"Saint Joseph";parish;06;12659
+Barbados;BB;BRB;23;"Saint Lucy";"Saint Lucy";parish;07;12665
+Barbados;BB;BRB;23;"Saint Michael";"Saint Michael";parish;08;12658
+Barbados;BB;BRB;23;"Saint Peter";"Saint Peter";parish;09;12666
+Barbados;BB;BRB;23;"Saint Philip";"Saint Philip";parish;10;12667
+Barbados;BB;BRB;23;"Saint Thomas";"Saint Thomas";parish;11;12657
+Belarus;BY;BLR;24;"Brestskaya voblasts";"Brestskaya voblasts";region;BR;12669
+Belarus;BY;BLR;24;"Homyel'skaya voblasts";"Homyel'skaya voblasts";region;HO;12670
+Belarus;BY;BLR;24;"Horad Minsk";"Horad Minsk";city;HM;12674
+Belarus;BY;BLR;24;"Horad Minsk";"Horad Minsk";municipality;X1~;48130
+Belarus;BY;BLR;24;"Hrodzenskaya voblasts";"Hrodzenskaya voblasts";region;HR;12672
+Belarus;BY;BLR;24;"Mahilyowskaya voblasts";"Mahilyowskaya voblasts";region;MA;12671
+Belarus;BY;BLR;24;"Minskaya voblasts";"Minskaya voblasts";region;MI;12673
+Belarus;BY;BLR;24;"Vitsyebskaya voblasts";"Vitsyebskaya voblasts";region;VI;12668
+Belgium;BE;BEL;25;Antwerpen;Antwerpen;province;VAN;12683
+Belgium;BE;BEL;25;"Brabant Wallon";"Brabant Wallon";province;WBR;12679
+Belgium;BE;BEL;25;Brussels;Brussels;"capital region";BRU;12682
+Belgium;BE;BEL;25;"Flemish Region";"Flemish Region";region;VLG;48264
+Belgium;BE;BEL;25;Hainaut;Hainaut;province;WHT;12678
+Belgium;BE;BEL;25;Limburg;Limburg;province;VLI;12680
+Belgium;BE;BEL;25;Liège;Liege;province;WLG;12684
+Belgium;BE;BEL;25;Luxembourg;Luxembourg;province;WLX;12676
+Belgium;BE;BEL;25;Namur;Namur;province;WNA;12685
+Belgium;BE;BEL;25;Oost-Vlaanderen;Oost-Vlaanderen;province;VOV;12677
+Belgium;BE;BEL;25;"Vlaams Brabant";"Vlaams Brabant";province;VBR;12675
+Belgium;BE;BEL;25;Wallonia;Wallonia;region;WAL;48265
+Belgium;BE;BEL;25;West-Vlaanderen;West-Vlaanderen;province;VWV;12681
+Belize;BZ;BLZ;26;Belize;Belize;district;BZ;12687
+Belize;BZ;BLZ;26;Cayo;Cayo;district;CY;12691
+Belize;BZ;BLZ;26;Corozal;Corozal;district;CZL;12688
+Belize;BZ;BLZ;26;"Orange Walk";"Orange Walk";district;OW;12689
+Belize;BZ;BLZ;26;"Stann Creek";"Stann Creek";district;SC;12686
+Belize;BZ;BLZ;26;Toledo;Toledo;district;TOL;12690
+Benin;BJ;BEN;27;Alibori;Alibori;department;AL;12696
+Benin;BJ;BEN;27;Atakora;Atakora;department;AK;12702
+Benin;BJ;BEN;27;Atlantique;Atlantique;department;AQ;12697
+Benin;BJ;BEN;27;Borgou;Borgou;department;BO;12698
+Benin;BJ;BEN;27;Collines;Collines;department;CO;12704
+Benin;BJ;BEN;27;Donga;Donga;department;DO;12705
+Benin;BJ;BEN;27;Kouffo;Kouffo;department;KO;12699
+Benin;BJ;BEN;27;Littoral;Littoral;department;LI;12694
+Benin;BJ;BEN;27;Mono;Mono;department;MO;12700
+Benin;BJ;BEN;27;Ouémé;Oueme;department;OU;12701
+Benin;BJ;BEN;27;Plateau;Plateau;department;PL;12693
+Benin;BJ;BEN;27;Zou;Zou;department;ZO;12692
+Bermuda;BM;BMU;28;Devonshire;Devonshire;parish;DEV;12708
+Bermuda;BM;BMU;28;Hamilton;Hamilton;parish;HAM;12707
+Bermuda;BM;BMU;28;"Hamilton municipality";"Hamilton municipality";municipality;HA;12709
+Bermuda;BM;BMU;28;Paget;Paget;parish;PAG;12710
+Bermuda;BM;BMU;28;Pembroke;Pembroke;parish;PEM;12711
+Bermuda;BM;BMU;28;"Saint George";"Saint George";parish;SGE;12712
+Bermuda;BM;BMU;28;"Saint George municipality";"Saint George municipality";municipality;SG;12716
+Bermuda;BM;BMU;28;Sandys;Sandys;parish;SAN;12713
+Bermuda;BM;BMU;28;Smiths;Smiths;parish;SMI;12706
+Bermuda;BM;BMU;28;Southampton;Southampton;parish;SOU;12714
+Bermuda;BM;BMU;28;Warwick;Warwick;parish;WAR;12715
+Bhutan;BT;BTN;29;Bumthang;Bumthang;district;33;12724
+Bhutan;BT;BTN;29;Chhukha;Chhukha;district;12;12735
+Bhutan;BT;BTN;29;Dagana;Dagana;district;22;12723
+Bhutan;BT;BTN;29;Gasa;Gasa;district;GA;12733
+Bhutan;BT;BTN;29;Ha;Ha;district;13;12736
+Bhutan;BT;BTN;29;Lhuentse;Lhuentse;district;44;12727
+Bhutan;BT;BTN;29;Monggar;Monggar;district;42;12722
+Bhutan;BT;BTN;29;Paro;Paro;district;11;12729
+Bhutan;BT;BTN;29;Pemagatshel;Pemagatshel;district;43;12728
+Bhutan;BT;BTN;29;Punakha;Punakha;district;23;12719
+Bhutan;BT;BTN;29;"Samdrup Jongkha";"Samdrup Jongkha";district;45;12730
+Bhutan;BT;BTN;29;Samtse;Samtse;district;14;12718
+Bhutan;BT;BTN;29;Sarpang;Sarpang;district;31;12726
+Bhutan;BT;BTN;29;Thimphu;Thimphu;district;15;12731
+Bhutan;BT;BTN;29;"Trashi Yangtse";"Trashi Yangtse";district;TY;12734
+Bhutan;BT;BTN;29;Trashigang;Trashigang;district;41;12721
+Bhutan;BT;BTN;29;Trongsa;Trongsa;district;32;12717
+Bhutan;BT;BTN;29;Tsirang;Tsirang;district;21;12725
+Bhutan;BT;BTN;29;"Wangdue Phodrang";"Wangdue Phodrang";district;24;12732
+Bhutan;BT;BTN;29;Zhemgang;Zhemgang;district;34;12720
+"Plurinational State Of Bolivia";BO;BOL;30;Chuquisaca;Chuquisaca;department;H;12739
+"Plurinational State Of Bolivia";BO;BOL;30;Cochabamba;Cochabamba;department;C;12741
+"Plurinational State Of Bolivia";BO;BOL;30;"El Beni";"El Beni";department;B;12740
+"Plurinational State Of Bolivia";BO;BOL;30;"La Paz";"La Paz";department;L;12742
+"Plurinational State Of Bolivia";BO;BOL;30;Oruro;Oruro;department;O;12738
+"Plurinational State Of Bolivia";BO;BOL;30;Pando;Pando;department;N;12743
+"Plurinational State Of Bolivia";BO;BOL;30;Potosí;Potosi;department;P;12737
+"Plurinational State Of Bolivia";BO;BOL;30;"Santa Cruz";"Santa Cruz";department;S;12744
+"Plurinational State Of Bolivia";BO;BOL;30;Tarija;Tarija;department;T;12745
+"Sint Eustatius and Saba Bonaire";BQ;BES;700;Bonaire;Bonaire;municipality;BO;48682
+"Sint Eustatius and Saba Bonaire";BQ;BES;700;Saba;Saba;municipality;SA;48683
+"Sint Eustatius and Saba Bonaire";BQ;BES;700;"Sint Eustatius";"Sint Eustatius";municipality;SE;48684
+"Bosnia and Herzegovina";BA;BIH;31;"Bosansko-podrinjski kanton";"Bosansko-podrinjski kanton";canton;05;48161
+"Bosnia and Herzegovina";BA;BIH;31;"Brčko distrikt";"Brcko distrikt";district;BRC;42644
+"Bosnia and Herzegovina";BA;BIH;31;"Federacija Bosna i Hercegovina";"Federacija Bosna i Hercegovina";entity;BIH;12746
+"Bosnia and Herzegovina";BA;BIH;31;"Hercegova?ko-neretvanski kanton";"Hercegovako-neretvanski kanton";canton;07;48162
+"Bosnia and Herzegovina";BA;BIH;31;"Kanton br. 10 (Livanjski kanton)";"Kanton br. 10 (Livanjski kanton)";canton;10;48163
+"Bosnia and Herzegovina";BA;BIH;31;"Kanton Sarajevo";"Kanton Sarajevo";canton;09;48164
+"Bosnia and Herzegovina";BA;BIH;31;"Posavski kanton";"Posavski kanton";canton;02;48165
+"Bosnia and Herzegovina";BA;BIH;31;"Republika Srpska";"Republika Srpska";entity;SRP;12747
+"Bosnia and Herzegovina";BA;BIH;31;"Srednjobosanski kanton";"Srednjobosanski kanton";canton;06;48166
+"Bosnia and Herzegovina";BA;BIH;31;"Tuzlanski kanton";"Tuzlanski kanton";canton;03;48167
+"Bosnia and Herzegovina";BA;BIH;31;"Unsko-sanski kanton";"Unsko-sanski kanton";canton;01;48168
+"Bosnia and Herzegovina";BA;BIH;31;"Zapadnohercegova?ki kanton";"Zapadnohercegovaki kanton";canton;08;48169
+"Bosnia and Herzegovina";BA;BIH;31;"Zeni?ko-dobojski kanton";"Zeniko-dobojski kanton";canton;04;48170
+Botswana;BW;BWA;32;Central;Central;district;CE;19401
+Botswana;BW;BWA;32;Ghanzi;Ghanzi;district;GH;12759
+Botswana;BW;BWA;32;Kgalagadi;Kgalagadi;district;KG;19402
+Botswana;BW;BWA;32;Kgatleng;Kgatleng;district;KL;12770
+Botswana;BW;BWA;32;Kweneng;Kweneng;district;KW;12762
+Botswana;BW;BWA;32;North-East;North-East;district;NE;12749
+Botswana;BW;BWA;32;North-West;North-West;district;NW;19403
+Botswana;BW;BWA;32;South-East;South-East;district;SE;12751
+Botswana;BW;BWA;32;Southern;Southern;district;SO;19404
+Brazil;BR;BRA;34;Acre;Acre;state;AC;12793
+Brazil;BR;BRA;34;Alagoas;Alagoas;state;AL;12784
+Brazil;BR;BRA;34;Amapá;Amapa;state;AP;12775
+Brazil;BR;BRA;34;Amazonas;Amazonas;state;AM;12794
+Brazil;BR;BRA;34;Bahia;Bahia;state;BA;12776
+Brazil;BR;BRA;34;Ceará;Ceara;state;CE;12795
+Brazil;BR;BRA;34;"Distrito Federal";"Distrito Federal";"federal district";DF;12777
+Brazil;BR;BRA;34;"Espírito Santo";"Espirito Santo";state;ES;12778
+Brazil;BR;BRA;34;Goiás;Goias;state;GO;12796
+Brazil;BR;BRA;34;Maranhão;Maranhao;state;MA;12779
+Brazil;BR;BRA;34;"Mato Grosso";"Mato Grosso";state;MT;12780
+Brazil;BR;BRA;34;"Mato Grosso do Sul";"Mato Grosso do Sul";state;MS;12774
+Brazil;BR;BRA;34;"Minas Gerais";"Minas Gerais";state;MG;12781
+Brazil;BR;BRA;34;Paraná;Parana;state;PR;12783
+Brazil;BR;BRA;34;Paraíba;Paraiba;state;PB;12782
+Brazil;BR;BRA;34;Pará;Para;state;PA;12797
+Brazil;BR;BRA;34;Pernambuco;Pernambuco;state;PE;12773
+Brazil;BR;BRA;34;Piauí;Piaui;state;PI;12785
+Brazil;BR;BRA;34;"Rio de Janeiro";"Rio de Janeiro";state;RJ;12786
+Brazil;BR;BRA;34;"Rio Grande do Norte";"Rio Grande do Norte";state;RN;12798
+Brazil;BR;BRA;34;"Rio Grande do Sul";"Rio Grande do Sul";state;RS;12787
+Brazil;BR;BRA;34;Rondônia;Rondonia;state;RO;12772
+Brazil;BR;BRA;34;Roraima;Roraima;state;RR;12788
+Brazil;BR;BRA;34;"Santa Catarina";"Santa Catarina";state;SC;12789
+Brazil;BR;BRA;34;Sergipe;Sergipe;state;SE;12790
+Brazil;BR;BRA;34;"São Paulo";"Sao Paulo";state;SP;12771
+Brazil;BR;BRA;34;Tocantins;Tocantins;state;TO;12791
+"Brunei Darussalam";BN;BRN;36;Belait;Belait;district;BE;12805
+"Brunei Darussalam";BN;BRN;36;Brunei-Muara;Brunei-Muara;district;BM;12807
+"Brunei Darussalam";BN;BRN;36;Temburong;Temburong;district;TE;12806
+"Brunei Darussalam";BN;BRN;36;Tutong;Tutong;district;TU;12804
+Bulgaria;BG;BGR;37;Blagoevgrad;Blagoevgrad;region;01;12829
+Bulgaria;BG;BGR;37;Burgas;Burgas;region;02;12813
+Bulgaria;BG;BGR;37;Dobrich;Dobrich;region;08;12830
+Bulgaria;BG;BGR;37;Gabrovo;Gabrovo;region;07;12823
+Bulgaria;BG;BGR;37;Haskovo;Haskovo;region;26;12824
+Bulgaria;BG;BGR;37;Kardzhali;Kardzhali;region;09;12825
+Bulgaria;BG;BGR;37;Kjustendil;Kjustendil;region;10;12831
+Bulgaria;BG;BGR;37;Lovech;Lovech;region;11;12826
+Bulgaria;BG;BGR;37;Montana;Montana;region;12;12811
+Bulgaria;BG;BGR;37;Pazardzhik;Pazardzhik;region;13;12827
+Bulgaria;BG;BGR;37;Pernik;Pernik;region;14;12832
+Bulgaria;BG;BGR;37;Pleven;Pleven;region;15;12828
+Bulgaria;BG;BGR;37;Plovdiv;Plovdiv;region;16;12814
+Bulgaria;BG;BGR;37;Razgrad;Razgrad;region;17;12810
+Bulgaria;BG;BGR;37;Ruse;Ruse;region;18;12815
+Bulgaria;BG;BGR;37;Silistra;Silistra;region;19;12833
+Bulgaria;BG;BGR;37;Sliven;Sliven;region;20;12816
+Bulgaria;BG;BGR;37;Smolyan;Smolyan;region;21;12809
+Bulgaria;BG;BGR;37;Sofia;Sofia;region;23;12834
+Bulgaria;BG;BGR;37;Sofia-Grad;Sofia-Grad;region;22;12817
+Bulgaria;BG;BGR;37;"Stara Zagora";"Stara Zagora";region;24;12818
+Bulgaria;BG;BGR;37;Targovishte;Targovishte;region;25;12835
+Bulgaria;BG;BGR;37;Varna;Varna;region;03;12820
+Bulgaria;BG;BGR;37;"Veliko Tarnovo";"Veliko Tarnovo";region;04;12808
+Bulgaria;BG;BGR;37;Vidin;Vidin;region;05;12821
+Bulgaria;BG;BGR;37;Vratsa;Vratsa;region;06;12822
+Bulgaria;BG;BGR;37;Yambol;Yambol;region;28;12812
+Bulgaria;BG;BGR;37;Šumen;Sumen;region;27;12819
+"Burkina Faso";BF;BFA;38;Balé;Bale;province;BAL;12846
+"Burkina Faso";BF;BFA;38;Bam;Bam;province;BAM;12855
+"Burkina Faso";BF;BFA;38;Banwa;Banwa;province;BAN;12847
+"Burkina Faso";BF;BFA;38;Bazèga;Bazega;province;BAZ;12856
+"Burkina Faso";BF;BFA;38;"Boucle du Mouhoun";"Boucle du Mouhoun";region;01;48171
+"Burkina Faso";BF;BFA;38;Bougouriba;Bougouriba;province;BGR;12857
+"Burkina Faso";BF;BFA;38;Boulgou;Boulgou;province;BLG;12848
+"Burkina Faso";BF;BFA;38;Boulkiemdé;Boulkiemde;province;BLK;12858
+"Burkina Faso";BF;BFA;38;Cascades;Cascades;region;02;48172
+"Burkina Faso";BF;BFA;38;Centre;Centre;region;03;48173
+"Burkina Faso";BF;BFA;38;Centre-Est;Centre-Est;region;04;48174
+"Burkina Faso";BF;BFA;38;Centre-Nord;Centre-Nord;region;05;48175
+"Burkina Faso";BF;BFA;38;Centre-Ouest;Centre-Ouest;region;06;48176
+"Burkina Faso";BF;BFA;38;Centre-Sud;Centre-Sud;region;07;48177
+"Burkina Faso";BF;BFA;38;Comoé;Comoe;province;COM;12849
+"Burkina Faso";BF;BFA;38;Est;Est;region;08;48178
+"Burkina Faso";BF;BFA;38;Ganzourgou;Ganzourgou;province;GAN;12859
+"Burkina Faso";BF;BFA;38;Gnagna;Gnagna;province;GNA;12860
+"Burkina Faso";BF;BFA;38;Gourma;Gourma;province;GOU;12850
+"Burkina Faso";BF;BFA;38;Hauts-Bassins;Hauts-Bassins;region;09;48179
+"Burkina Faso";BF;BFA;38;Houet;Houet;province;HOU;12861
+"Burkina Faso";BF;BFA;38;Ioba;Ioba;province;IOB;12851
+"Burkina Faso";BF;BFA;38;Kadiogo;Kadiogo;province;KAD;12862
+"Burkina Faso";BF;BFA;38;Komondjari;Komondjari;province;KMD;12863
+"Burkina Faso";BF;BFA;38;Kompienga;Kompienga;province;KMP;12864
+"Burkina Faso";BF;BFA;38;Kossi;Kossi;province;KOS;12853
+"Burkina Faso";BF;BFA;38;Koulpélogo;Koulpelogo;province;KOP;12865
+"Burkina Faso";BF;BFA;38;Kouritenga;Kouritenga;province;KOT;12854
+"Burkina Faso";BF;BFA;38;Kourwéogo;Kourweogo;province;KOW;12866
+"Burkina Faso";BF;BFA;38;Kénédougou;Kenedougou;province;KEN;12852
+"Burkina Faso";BF;BFA;38;Loroum;Loroum;province;LOR;12837
+"Burkina Faso";BF;BFA;38;Léraba;Leraba;province;LER;12867
+"Burkina Faso";BF;BFA;38;Mouhoun;Mouhoun;province;MOU;12868
+"Burkina Faso";BF;BFA;38;Nahouri;Nahouri;province;NAO;12838
+"Burkina Faso";BF;BFA;38;Namentenga;Namentenga;province;NAM;12869
+"Burkina Faso";BF;BFA;38;Nayala;Nayala;province;NAY;12870
+"Burkina Faso";BF;BFA;38;Nord;Nord;region;10;48180
+"Burkina Faso";BF;BFA;38;Noumbiel;Noumbiel;province;NOU;12839
+"Burkina Faso";BF;BFA;38;Oubritenga;Oubritenga;province;OUB;12871
+"Burkina Faso";BF;BFA;38;Oudalan;Oudalan;province;OUD;12840
+"Burkina Faso";BF;BFA;38;Passoré;Passore;province;PAS;12872
+"Burkina Faso";BF;BFA;38;Plateau-Central;Plateau-Central;region;11;48181
+"Burkina Faso";BF;BFA;38;Poni;Poni;province;PON;12873
+"Burkina Faso";BF;BFA;38;Sahel;Sahel;region;12;48182
+"Burkina Faso";BF;BFA;38;Sanguié;Sanguie;province;SNG;12841
+"Burkina Faso";BF;BFA;38;Sanmatenga;Sanmatenga;province;SMT;12874
+"Burkina Faso";BF;BFA;38;Sissili;Sissili;province;SIS;12843
+"Burkina Faso";BF;BFA;38;Soum;Soum;province;SOM;12844
+"Burkina Faso";BF;BFA;38;Sourou;Sourou;province;SOR;12845
+"Burkina Faso";BF;BFA;38;Sud-Ouest;Sud-Ouest;region;13;48183
+"Burkina Faso";BF;BFA;38;Séno;Seno;province;SEN;12842
+"Burkina Faso";BF;BFA;38;Tapoa;Tapoa;province;TAP;12879
+"Burkina Faso";BF;BFA;38;Tui;Tui;province;TUI;12880
+"Burkina Faso";BF;BFA;38;Yagha;Yagha;province;YAG;12878
+"Burkina Faso";BF;BFA;38;Yatenga;Yatenga;province;YAT;12877
+"Burkina Faso";BF;BFA;38;Ziro;Ziro;province;ZIR;12876
+"Burkina Faso";BF;BFA;38;Zondoma;Zondoma;province;ZON;12881
+"Burkina Faso";BF;BFA;38;Zoundwéogo;Zoundweogo;province;ZOU;12882
+Burundi;BI;BDI;39;Bubanza;Bubanza;province;BB;12893
+Burundi;BI;BDI;39;Bujumbura;Bujumbura;province;BJ;12884
+Burundi;BI;BDI;39;"Bujumbura Mairie";"Bujumbura Mairie";province;BM;48128
+Burundi;BI;BDI;39;"Bujumbura Rural";"Bujumbura Rural";province;BL;48129
+Burundi;BI;BDI;39;Bururi;Bururi;province;BR;12895
+Burundi;BI;BDI;39;Cankuzo;Cankuzo;province;CA;12885
+Burundi;BI;BDI;39;Cibitoke;Cibitoke;province;CI;12896
+Burundi;BI;BDI;39;Gitega;Gitega;province;GI;12886
+Burundi;BI;BDI;39;Karuzi;Karuzi;province;KR;12887
+Burundi;BI;BDI;39;Kayanza;Kayanza;province;KY;12894
+Burundi;BI;BDI;39;Kirundo;Kirundo;province;KI;12888
+Burundi;BI;BDI;39;Makamba;Makamba;province;MA;12889
+Burundi;BI;BDI;39;Muramvya;Muramvya;province;MU;12897
+Burundi;BI;BDI;39;Muyinga;Muyinga;province;MY;12890
+Burundi;BI;BDI;39;Mwaro;Mwaro;province;MW;12898
+Burundi;BI;BDI;39;Ngozi;Ngozi;province;NG;12891
+Burundi;BI;BDI;39;Rutana;Rutana;province;RT;12892
+Burundi;BI;BDI;39;Ruyigi;Ruyigi;province;RY;12883
+Cambodia;KH;KHM;40;"Baat Dambang (Batdâmbâng)";"Baat Dambang (Batdambang)";province;2;12918
+Cambodia;KH;KHM;40;"Banteay Mean Chey (Bântéay Méanchey)";"Banteay Mean Chey (Banteay Meanchey)";province;1;12911
+Cambodia;KH;KHM;40;"Kampong Chaam (Kâmpóng Cham)";"Kampong Chaam (Kampong Cham)";province;3;12912
+Cambodia;KH;KHM;40;"Kampong Chhnang (Kâmpóng Chhnang)";"Kampong Chhnang (Kampong Chhnang)";province;4;12919
+Cambodia;KH;KHM;40;"Kampong Spueu (Kâmpóng Spœ)";"Kampong Spueu (Kampong Spue)";province;5;12920
+Cambodia;KH;KHM;40;"Kampong Thum (Kâmpóng Thum)";"Kampong Thum (Kampong Thum)";province;6;12902
+Cambodia;KH;KHM;40;"Kampot (Kâmpôt)";"Kampot (Kampot)";province;7;12903
+Cambodia;KH;KHM;40;"Kandaal (Kândal)";"Kandaal (Kandal)";province;8;12904
+Cambodia;KH;KHM;40;"Kaoh Kong (Kaôh Kong)";"Kaoh Kong (Kaoh Kong)";province;9;12905
+Cambodia;KH;KHM;40;"Kracheh (Krâchéh)";"Kracheh (Kracheh)";province;10;12906
+Cambodia;KH;KHM;40;"Krong Kaeb (Krong Kêb)";"Krong Kaeb (Krong Keb)";"autonomous municipality";23;12907
+Cambodia;KH;KHM;40;"Krong Pailin (Krong Pailin)";"Krong Pailin (Krong Pailin)";"autonomous municipality";24;12908
+Cambodia;KH;KHM;40;"Krong Preah Sihanouk (Krong Preah Sihanouk)";"Krong Preah Sihanouk (Krong Preah Sihanouk)";"autonomous municipality";18;12909
+Cambodia;KH;KHM;40;"Mondol Kiri (Môndól Kiri)";"Mondol Kiri (Mondol Kiri)";province;11;12910
+Cambodia;KH;KHM;40;"Otdar Mean Chey (Otdâr Méanchey)";"Otdar Mean Chey (Otdar Meanchey)";province;22;12901
+Cambodia;KH;KHM;40;"Phnom Penh (Phnum Pénh)";"Phnom Penh (Phnum Penh)";"autonomous municipality";12;12921
+Cambodia;KH;KHM;40;"Pousaat (Pouthisat)";"Pousaat (Pouthisat)";province;15;12900
+Cambodia;KH;KHM;40;"Preah Vihear (Preah Vihéar)";"Preah Vihear (Preah Vihear)";province;13;12913
+Cambodia;KH;KHM;40;"Prey Veaeng (Prey Vêng)";"Prey Veaeng (Prey Veng)";province;14;12914
+Cambodia;KH;KHM;40;"Rotanak Kiri (Rôtânôkiri)";"Rotanak Kiri (Rotanokiri)";province;16;12922
+Cambodia;KH;KHM;40;"Siem Reab (Siemréab)";"Siem Reab (Siemreab)";province;17;12915
+Cambodia;KH;KHM;40;"Stueng Traeng (Stœ?ng Trêng)";"Stueng Traeng (Stueng Treng)";province;19;12925
+Cambodia;KH;KHM;40;"Svaay Rieng (Svay Rieng)";"Svaay Rieng (Svay Rieng)";province;20;12916
+Cambodia;KH;KHM;40;"Taakaev (Takêv)";"Taakaev (Takev)";province;21;12924
+Cameroon;CM;CMR;41;Adamaoua;Adamaoua;region;AD;12932
+Cameroon;CM;CMR;41;Centre;Centre;region;CE;12928
+Cameroon;CM;CMR;41;East;East;region;ES;12933
+Cameroon;CM;CMR;41;"Far North";"Far North";region;EN;12934
+Cameroon;CM;CMR;41;Littoral;Littoral;region;LT;12929
+Cameroon;CM;CMR;41;North;North;region;NO;12931
+Cameroon;CM;CMR;41;North-West;North-West;region;NW;12927
+Cameroon;CM;CMR;41;South;South;region;SU;12935
+Cameroon;CM;CMR;41;South-West;South-West;region;SW;12926
+Cameroon;CM;CMR;41;West;West;region;OU;12930
+Canada;CA;CAN;42;Alberta;Alberta;province;AB;12940
+Canada;CA;CAN;42;"British Columbia";"British Columbia";province;BC;12938
+Canada;CA;CAN;42;Manitoba;Manitoba;province;MB;12941
+Canada;CA;CAN;42;"New Brunswick";"New Brunswick";province;NB;12937
+Canada;CA;CAN;42;"Newfoundland and Labrador";"Newfoundland and Labrador";province;NL;12942
+Canada;CA;CAN;42;"Northwest Territories";"Northwest Territories";territory;NT;12939
+Canada;CA;CAN;42;"Nova Scotia";"Nova Scotia";province;NS;12943
+Canada;CA;CAN;42;Nunavut;Nunavut;territory;NU;12944
+Canada;CA;CAN;42;Ontario;Ontario;province;ON;12948
+Canada;CA;CAN;42;"Prince Edward Island";"Prince Edward Island";province;PE;12945
+Canada;CA;CAN;42;Quebec;Quebec;province;QC;12946
+Canada;CA;CAN;42;Saskatchewan;Saskatchewan;province;SK;12936
+Canada;CA;CAN;42;"Yukon Territory";"Yukon Territory";territory;YT;12947
+"Cape Verde";CV;CPV;43;"Boa Vista";"Boa Vista";municipality;BV;12953
+"Cape Verde";CV;CPV;43;Brava;Brava;municipality;BR;12957
+"Cape Verde";CV;CPV;43;"Calheta de São Miguel";"Calheta de Sao Miguel";;CS;19405
+"Cape Verde";CV;CPV;43;"Ilhas de Barlavento";"Ilhas de Barlavento";"geographical region";B;48184
+"Cape Verde";CV;CPV;43;"Ilhas de Sotavento";"Ilhas de Sotavento";"geographical region";S;48185
+"Cape Verde";CV;CPV;43;Maio;Maio;municipality;MA;12954
+"Cape Verde";CV;CPV;43;Mosteiros;Mosteiros;municipality;MO;19406
+"Cape Verde";CV;CPV;43;Paul;Paul;municipality;PA;19407
+"Cape Verde";CV;CPV;43;"Porto Novo";"Porto Novo";municipality;PN;19408
+"Cape Verde";CV;CPV;43;Praia;Praia;municipality;PR;19409
+"Cape Verde";CV;CPV;43;"Ribeira Brava";"Ribeira Brava";municipality;RB;48244
+"Cape Verde";CV;CPV;43;"Ribeira Grande";"Ribeira Grande";municipality;RG;12955
+"Cape Verde";CV;CPV;43;"Ribeira Grande de Santiago";"Ribeira Grande de Santiago";municipality;RS;48245
+"Cape Verde";CV;CPV;43;Sal;Sal;municipality;SL;12956
+"Cape Verde";CV;CPV;43;"Santa Catarina";"Santa Catarina";municipality;CA;19411
+"Cape Verde";CV;CPV;43;"Santa Catarina do Fogo";"Santa Catarina do Fogo";municipality;CF;48246
+"Cape Verde";CV;CPV;43;"Santa Cruz";"Santa Cruz";municipality;CR;19412
+"Cape Verde";CV;CPV;43;"São Domingos";"Sao Domingos";municipality;SD;19413
+"Cape Verde";CV;CPV;43;"São Filipe";"Sao Filipe";municipality;SF;19414
+"Cape Verde";CV;CPV;43;"São Lourenço dos Órgãos";"Sao Lourenco dos Orgaos";municipality;SO;48904
+"Cape Verde";CV;CPV;43;"São Miguel";"Sao Miguel";municipality;SM;48247
+"Cape Verde";CV;CPV;43;"São Nicolau";"Sao Nicolau";;SN;12949
+"Cape Verde";CV;CPV;43;"São Salvador do Mundo";"Sao Salvador do Mundo";municipality;SS;48248
+"Cape Verde";CV;CPV;43;"São Vicente";"Sao Vicente";municipality;SV;12950
+"Cape Verde";CV;CPV;43;Tarrafal;Tarrafal;municipality;TA;19415
+"Cape Verde";CV;CPV;43;"Tarrafal de São Nicolau";"Tarrafal de Sao Nicolau";municipality;TS;48249
+"Cayman Islands";KY;CYM;44;"Bodden Town";"Bodden Town";district;01~;48080
+"Cayman Islands";KY;CYM;44;"Cayman Brac";"Cayman Brac";district;02~;12962
+"Cayman Islands";KY;CYM;44;"East End";"East End";district;03~;20891
+"Cayman Islands";KY;CYM;44;"George Town";"George Town";district;04~;48081
+"Cayman Islands";KY;CYM;44;"Little Cayman";"Little Cayman";district;05~;12958
+"Cayman Islands";KY;CYM;44;"North Side";"North Side";district;06~;48082
+"Cayman Islands";KY;CYM;44;"West Bay";"West Bay";district;07~;48083
+"Central African Republic";CF;CAF;45;Bamingui-Bangoran;Bamingui-Bangoran;prefecture;BB;12972
+"Central African Republic";CF;CAF;45;Bangui;Bangui;commune;BGF;12969
+"Central African Republic";CF;CAF;45;Basse-Kotto;Basse-Kotto;prefecture;BK;12973
+"Central African Republic";CF;CAF;45;Gribingui;Gribingui;"economic prefecture";KB;12965
+"Central African Republic";CF;CAF;45;Haut-Mbomou;Haut-Mbomou;prefecture;HM;12974
+"Central African Republic";CF;CAF;45;Haute-Kotto;Haute-Kotto;prefecture;HK;12968
+"Central African Republic";CF;CAF;45;"Haute-Sangha / Mambéré-Kadéï";"Haute-Sangha / Mambere-Kadei";prefecture;HS;12966
+"Central African Republic";CF;CAF;45;Kémo-Gribingui;Kemo-Gribingui;prefecture;KG;12967
+"Central African Republic";CF;CAF;45;Lobaye;Lobaye;prefecture;LB;12975
+"Central African Republic";CF;CAF;45;Mbomou;Mbomou;prefecture;MB;12976
+"Central African Republic";CF;CAF;45;Nana-Mambéré;Nana-Mambere;prefecture;NM;12977
+"Central African Republic";CF;CAF;45;Ombella-Mpoko;Ombella-Mpoko;prefecture;MP;12964
+"Central African Republic";CF;CAF;45;Ouaka;Ouaka;prefecture;UK;12979
+"Central African Republic";CF;CAF;45;Ouham;Ouham;prefecture;AC;12978
+"Central African Republic";CF;CAF;45;Ouham-Pendé;Ouham-Pende;prefecture;OP;12970
+"Central African Republic";CF;CAF;45;Sangha;Sangha;"economic prefecture";SE;12963
+"Central African Republic";CF;CAF;45;Vakaga;Vakaga;prefecture;VK;12971
+Chad;TD;TCD;46;"Al Baṭḩah";"Al Bathah";region;BA;12981
+Chad;TD;TCD;46;"Al Buḩayrah";"Al Buhayrah";region;LC;12985
+Chad;TD;TCD;46;"Baḩr al Ghazāl";"Bahr al Ghazal";region;BG;48189
+Chad;TD;TCD;46;Borkou-Ennedi-Tibesti;Borkou-Ennedi-Tibesti;region;BET;12982
+Chad;TD;TCD;46;Būrkū;Burku;region;BO;48190
+Chad;TD;TCD;46;Innīdī;Innidi;region;EN;48191
+Chad;TD;TCD;46;Kānim;Kanim;region;KA;12984
+Chad;TD;TCD;46;"Lūqūn al Gharbī";"Luqun al Gharbi";region;LO;12986
+Chad;TD;TCD;46;"Lūqūn ash Sharqī";"Luqun ash Sharqi";region;LR;12987
+Chad;TD;TCD;46;"Madīnat Injamīnā";"Madinat Injamina";region;ND;19420
+Chad;TD;TCD;46;Māndūl;Mandul;region;MA;19417
+Chad;TD;TCD;46;"Māyū Kībbī al Gharbī";"Mayu Kibbi al Gharbi";region;MO;19419
+Chad;TD;TCD;46;"Māyū Kībbī ash Sharqī";"Mayu Kibbi ash Sharqi";region;ME;19418
+Chad;TD;TCD;46;Qīrā;Qira;region;GR;12983
+Chad;TD;TCD;46;Salāmāt;Salamat;region;SA;12992
+Chad;TD;TCD;46;"Shārī al Awsaṭ";"Shari al Awsat";region;MC;12991
+Chad;TD;TCD;46;"Shārī Bāqirmī";"Shari Baqirmi";region;CB;12990
+Chad;TD;TCD;46;Sīlā;Sila;region;SI;48192
+Chad;TD;TCD;46;Tibastī;Tibasti;region;TI;48193
+Chad;TD;TCD;46;Tānjilī;Tanjili;region;TA;12980
+Chad;TD;TCD;46;Waddāy;Wadday;region;OD;12988
+Chad;TD;TCD;46;"Wādī Fīrā";"Wadi Fira";region;WF;19421
+Chad;TD;TCD;46;"Ḥajjar Lamīs";"Hajjar Lamis";region;HL;19416
+Chile;CL;CHL;47;"Aisén del General Carlos Ibáñez del Campo";"Aisen del General Carlos Ibanez del Campo";region;AI;13004
+Chile;CL;CHL;47;Antofagasta;Antofagasta;region;AN;12998
+Chile;CL;CHL;47;Araucanía;Araucania;region;AR;12997
+Chile;CL;CHL;47;"Arica y Parinacota";"Arica y Parinacota";region;AP;21383
+Chile;CL;CHL;47;Atacama;Atacama;region;AT;12999
+Chile;CL;CHL;47;Bío-Bío;Bio-Bio;region;BI;13005
+Chile;CL;CHL;47;Coquimbo;Coquimbo;region;CO;12996
+Chile;CL;CHL;47;"Libertador General Bernardo O'Higgins";"Libertador General Bernardo O'Higgins";region;LI;13000
+Chile;CL;CHL;47;"Los Lagos";"Los Lagos";region;LL;13006
+Chile;CL;CHL;47;"Los Ríos";"Los Rios";region;LR;21384
+Chile;CL;CHL;47;Magallanes;Magallanes;region;MA;13001
+Chile;CL;CHL;47;Maule;Maule;region;ML;12995
+Chile;CL;CHL;47;"Región Metropolitana de Santiago";"Region Metropolitana de Santiago";region;RM;13002
+Chile;CL;CHL;47;Tarapacá;Tarapaca;region;TA;12994
+Chile;CL;CHL;47;Valparaíso;Valparaiso;region;VS;13003
+China;CN;CHN;48;Anhui;Anhui;province;34;13012
+China;CN;CHN;48;"Aomen (zh) ***";"Aomen (zh) ";"special administrative region";92;13034
+China;CN;CHN;48;Beijing;Beijing;municipality;11;13013
+China;CN;CHN;48;Chongqing;Chongqing;municipality;50;13014
+China;CN;CHN;48;Fujian;Fujian;province;35;13035
+China;CN;CHN;48;Gansu;Gansu;province;62;13015
+China;CN;CHN;48;Guangdong;Guangdong;province;44;13016
+China;CN;CHN;48;Guangxi;Guangxi;"autonomous region";45;13036
+China;CN;CHN;48;Guizhou;Guizhou;province;52;13017
+China;CN;CHN;48;Hainan;Hainan;province;46;13018
+China;CN;CHN;48;Hebei;Hebei;province;13;13019
+China;CN;CHN;48;Heilongjiang;Heilongjiang;province;23;13028
+China;CN;CHN;48;Henan;Henan;province;41;13029
+China;CN;CHN;48;Hubei;Hubei;province;42;13020
+China;CN;CHN;48;Hunan;Hunan;province;43;13030
+China;CN;CHN;48;Jiangsu;Jiangsu;province;32;13031
+China;CN;CHN;48;Jiangxi;Jiangxi;province;36;13021
+China;CN;CHN;48;Jilin;Jilin;province;22;13022
+China;CN;CHN;48;Liaoning;Liaoning;province;21;13023
+China;CN;CHN;48;"Nei Mongol (mn)";"Nei Mongol (mn)";"autonomous region";15;13024
+China;CN;CHN;48;Ningxia;Ningxia;"autonomous region";64;13025
+China;CN;CHN;48;Qinghai;Qinghai;province;63;13026
+China;CN;CHN;48;Shaanxi;Shaanxi;province;61;13027
+China;CN;CHN;48;Shandong;Shandong;province;37;13011
+China;CN;CHN;48;Shanghai;Shanghai;municipality;31;13037
+China;CN;CHN;48;Shanxi;Shanxi;province;14;13010
+China;CN;CHN;48;Sichuan;Sichuan;province;51;13038
+China;CN;CHN;48;"Taiwan *";"Taiwan ";province;71;18995
+China;CN;CHN;48;Tianjin;Tianjin;municipality;12;13009
+China;CN;CHN;48;"Xianggang (zh) **";"Xianggang (zh) ";"special administrative region";91;13039
+China;CN;CHN;48;Xinjiang;Xinjiang;"autonomous region";65;13008
+China;CN;CHN;48;Xizang;Xizang;"autonomous region";54;13032
+China;CN;CHN;48;Yunnan;Yunnan;province;53;13033
+China;CN;CHN;48;Zhejiang;Zhejiang;province;33;13007
+Colombia;CO;COL;51;Amazonas;Amazonas;department;AMA;13045
+Colombia;CO;COL;51;Antioquia;Antioquia;department;ANT;13055
+Colombia;CO;COL;51;Arauca;Arauca;department;ARA;13046
+Colombia;CO;COL;51;Atlántico;Atlantico;department;ATL;13047
+Colombia;CO;COL;51;Bolívar;Bolivar;department;BOL;13048
+Colombia;CO;COL;51;Boyacá;Boyaca;department;BOY;13057
+Colombia;CO;COL;51;Caldas;Caldas;department;CAL;13049
+Colombia;CO;COL;51;Caquetá;Caqueta;department;CAQ;13050
+Colombia;CO;COL;51;Casanare;Casanare;department;CAS;13058
+Colombia;CO;COL;51;Cauca;Cauca;department;CAU;13051
+Colombia;CO;COL;51;Cesar;Cesar;department;CES;13059
+Colombia;CO;COL;51;Chocó;Choco;department;CHO;13052
+Colombia;CO;COL;51;Cundinamarca;Cundinamarca;department;CUN;13060
+Colombia;CO;COL;51;Córdoba;Cordoba;department;COR;13053
+Colombia;CO;COL;51;"Distrito Capital de Bogotá";"Distrito Capital de Bogota";"capital district";DC;13056
+Colombia;CO;COL;51;Guainía;Guainia;department;GUA;13054
+Colombia;CO;COL;51;Guaviare;Guaviare;department;GUV;13061
+Colombia;CO;COL;51;Huila;Huila;department;HUI;13063
+Colombia;CO;COL;51;"La Guajira";"La Guajira";department;LAG;13064
+Colombia;CO;COL;51;Magdalena;Magdalena;department;MAG;13062
+Colombia;CO;COL;51;Meta;Meta;department;MET;13065
+Colombia;CO;COL;51;Nariño;Narino;department;NAR;13044
+Colombia;CO;COL;51;"Norte de Santander";"Norte de Santander";department;NSA;13066
+Colombia;CO;COL;51;Putumayo;Putumayo;department;PUT;13067
+Colombia;CO;COL;51;Quindío;Quindio;department;QUI;13042
+Colombia;CO;COL;51;Risaralda;Risaralda;department;RIS;13068
+Colombia;CO;COL;51;"Providencia y Santa Catalina San Andrés";"Providencia y Santa Catalina San Andres";department;SAP;13043
+Colombia;CO;COL;51;Santander;Santander;department;SAN;13069
+Colombia;CO;COL;51;Sucre;Sucre;department;SUC;13041
+Colombia;CO;COL;51;Tolima;Tolima;department;TOL;13070
+Colombia;CO;COL;51;"Valle del Cauca";"Valle del Cauca";department;VAC;13071
+Colombia;CO;COL;51;Vaupés;Vaupes;department;VAU;13040
+Colombia;CO;COL;51;Vichada;Vichada;department;VID;13072
+Comoros;KM;COM;52;Andjazîdja;Andjazidja;island;G;13074
+Comoros;KM;COM;52;"Andjouân (Anjwān)";"Andjouan (Anjwan)";island;A;13073
+Comoros;KM;COM;52;"Moûhîlî (Mūhīlī)";"Mouhili (Muhili)";island;M;13075
+Congo;CG;COG;53;Bouenza;Bouenza;department;11;13078
+Congo;CG;COG;53;Brazzaville;Brazzaville;commune;BZV;13080
+Congo;CG;COG;53;Cuvette;Cuvette;department;8;13077
+Congo;CG;COG;53;Cuvette-Ouest;Cuvette-Ouest;department;15;13076
+Congo;CG;COG;53;Kouilou;Kouilou;department;5;13081
+Congo;CG;COG;53;Likouala;Likouala;department;7;13079
+Congo;CG;COG;53;Lékoumou;Lekoumou;department;2;13082
+Congo;CG;COG;53;Niari;Niari;department;9;13083
+Congo;CG;COG;53;Plateaux;Plateaux;department;14;13086
+Congo;CG;COG;53;Pool;Pool;department;12;13084
+Congo;CG;COG;53;Sangha;Sangha;department;13;13085
+"The Democratic Republic Of The Congo";CD;COD;54;Bandundu;Bandundu;province;BN;13094
+"The Democratic Republic Of The Congo";CD;COD;54;Bas-Congo;Bas-Congo;province;BC;13088
+"The Democratic Republic Of The Congo";CD;COD;54;Kasai-Occidental;Kasai-Occidental;province;KW;13092
+"The Democratic Republic Of The Congo";CD;COD;54;Kasai-Oriental;Kasai-Oriental;province;KE;13090
+"The Democratic Republic Of The Congo";CD;COD;54;Katanga;Katanga;province;KA;13097
+"The Democratic Republic Of The Congo";CD;COD;54;Kinshasa;Kinshasa;city;KN;13091
+"The Democratic Republic Of The Congo";CD;COD;54;Maniema;Maniema;province;MA;13095
+"The Democratic Republic Of The Congo";CD;COD;54;Nord-Kivu;Nord-Kivu;province;NK;13087
+"The Democratic Republic Of The Congo";CD;COD;54;Orientale;Orientale;province;OR;13089
+"The Democratic Republic Of The Congo";CD;COD;54;Sud-Kivu;Sud-Kivu;province;SK;13096
+"The Democratic Republic Of The Congo";CD;COD;54;Équateur;Equateur;province;EQ;13093
+"Costa Rica";CR;CRI;56;Alajuela;Alajuela;province;A;13119
+"Costa Rica";CR;CRI;56;Cartago;Cartago;province;C;13115
+"Costa Rica";CR;CRI;56;Guanacaste;Guanacaste;province;G;13116
+"Costa Rica";CR;CRI;56;Heredia;Heredia;province;H;13118
+"Costa Rica";CR;CRI;56;Limón;Limon;province;L;13114
+"Costa Rica";CR;CRI;56;Puntarenas;Puntarenas;province;P;13113
+"Costa Rica";CR;CRI;56;"San José";"San Jose";province;SJ;13117
+Croatia;HR;HRV;58;"Bjelovarsko-bilogorska županija";"Bjelovarsko-bilogorska zupanija";county;07;13135
+Croatia;HR;HRV;58;"Brodsko-posavska županija";"Brodsko-posavska zupanija";county;12;13130
+Croatia;HR;HRV;58;"Dubrovacko-neretvanska županija";"Dubrovacko-neretvanska zupanija";county;19;13122
+Croatia;HR;HRV;58;"Grad Zagreb";"Grad Zagreb";city;21;13123
+Croatia;HR;HRV;58;"Istarska županija";"Istarska zupanija";county;18;13121
+Croatia;HR;HRV;58;"Karlovacka županija";"Karlovacka zupanija";county;04;13124
+Croatia;HR;HRV;58;"Koprivnicko-križevacka županija";"Koprivnicko-krizevacka zupanija";county;06;13136
+Croatia;HR;HRV;58;"Krapinsko-zagorska županija";"Krapinsko-zagorska zupanija";county;02;13125
+Croatia;HR;HRV;58;"Licko-senjska županija";"Licko-senjska zupanija";county;09;13126
+Croatia;HR;HRV;58;"Medimurska županija";"Medimurska zupanija";county;20;13140
+Croatia;HR;HRV;58;"Osjecko-baranjska županija";"Osjecko-baranjska zupanija";county;14;13127
+Croatia;HR;HRV;58;"Požeško-slavonska županija";"Pozesko-slavonska zupanija";county;11;13139
+Croatia;HR;HRV;58;"Primorsko-goranska županija";"Primorsko-goranska zupanija";county;08;13128
+Croatia;HR;HRV;58;"Sisacko-moslavacka županija";"Sisacko-moslavacka zupanija";county;03;13138
+Croatia;HR;HRV;58;"Splitsko-dalmatinska županija";"Splitsko-dalmatinska zupanija";county;17;13137
+Croatia;HR;HRV;58;"Varaždinska županija";"Varazdinska zupanija";county;05;13131
+Croatia;HR;HRV;58;"Viroviticko-podravska županija";"Viroviticko-podravska zupanija";county;10;13132
+Croatia;HR;HRV;58;"Vukovarsko-srijemska županija";"Vukovarsko-srijemska zupanija";county;16;13120
+Croatia;HR;HRV;58;"Zadarska županija";"Zadarska zupanija";county;13;13133
+Croatia;HR;HRV;58;"Zagrebacka županija";"Zagrebacka zupanija";county;01;13134
+Croatia;HR;HRV;58;"Šibensko-kninska županija";"Sibensko-kninska zupanija";county;15;13129
+Cuba;CU;CUB;59;Camagüey;Camaguey;province;09;13152
+Cuba;CU;CUB;59;"Ciego de Ávila";"Ciego de Avila";province;08;13153
+Cuba;CU;CUB;59;Cienfuegos;Cienfuegos;province;06;13154
+Cuba;CU;CUB;59;"Ciudad de La Habana";"Ciudad de La Habana";province;03;13142
+Cuba;CU;CUB;59;Granma;Granma;province;12;13155
+Cuba;CU;CUB;59;Guantánamo;Guantanamo;province;14;13157
+Cuba;CU;CUB;59;Holguín;Holguin;province;11;13156
+Cuba;CU;CUB;59;"Isla de la Juventud";"Isla de la Juventud";"special municipality";99;13143
+Cuba;CU;CUB;59;"La Habana";"La Habana";province;02;13159
+Cuba;CU;CUB;59;"Las Tunas";"Las Tunas";province;10;13144
+Cuba;CU;CUB;59;Matanzas;Matanzas;province;04;13145
+Cuba;CU;CUB;59;"Pinar del Río";"Pinar del Rio";province;01;13160
+Cuba;CU;CUB;59;"Sancti Spíritus";"Sancti Spiritus";province;07;13146
+Cuba;CU;CUB;59;"Santiago de Cuba";"Santiago de Cuba";province;13;13158
+Cuba;CU;CUB;59;"Villa Clara";"Villa Clara";province;05;13147
+Cyprus;CY;CYP;60;Ammochostos;Ammochostos;district;04;20225
+Cyprus;CY;CYP;60;Keryneia;Keryneia;district;06;19428
+Cyprus;CY;CYP;60;Larnaka;Larnaka;district;03;19429
+Cyprus;CY;CYP;60;Lefkosia;Lefkosia;district;01;19430
+Cyprus;CY;CYP;60;Lemesos;Lemesos;district;02;19431
+Cyprus;CY;CYP;60;Pafos;Pafos;district;05;19433
+"Czech Republic";CZ;CZE;61;Benešov;Benesov;district;"201 ";13247
+"Czech Republic";CZ;CZE;61;Beroun;Beroun;district;"202 ";13201
+"Czech Republic";CZ;CZE;61;Blansko;Blansko;district;"621 ";13231
+"Czech Republic";CZ;CZE;61;Brno-město;Brno-mesto;district;"622 ";13192
+"Czech Republic";CZ;CZE;61;Brno-venkov;Brno-venkov;district;"623 ";13233
+"Czech Republic";CZ;CZE;61;Bruntál;Bruntal;district;"801 ";13180
+"Czech Republic";CZ;CZE;61;Břeclav;Breclav;district;"624 ";13232
+"Czech Republic";CZ;CZE;61;Cheb;Cheb;district;"411 ";13175
+"Czech Republic";CZ;CZE;61;Chomutov;Chomutov;district;"422 ";13173
+"Czech Republic";CZ;CZE;61;Chrudim;Chrudim;district;"531 ";13240
+"Czech Republic";CZ;CZE;61;Domažlice;Domazlice;district;"321 ";13242
+"Czech Republic";CZ;CZE;61;Děčín;Decin;district;"421 ";13164
+"Czech Republic";CZ;CZE;61;"Frýdek Místek";"Frydek Mistek";district;"802 ";13213
+"Czech Republic";CZ;CZE;61;"Havlíčkův Brod";"Havlickuv Brod";district;"611 ";13204
+"Czech Republic";CZ;CZE;61;Hodonín;Hodonin;district;"625 ";13174
+"Czech Republic";CZ;CZE;61;"Hradec Králové";"Hradec Kralove";district;"521 ";13237
+"Czech Republic";CZ;CZE;61;"Jablonec nad Nisou";"Jablonec nad Nisou";district;"512 ";13179
+"Czech Republic";CZ;CZE;61;Jeseník;Jesenik;district;"711 ";13216
+"Czech Republic";CZ;CZE;61;Jihlava;Jihlava;district;"612 ";13205
+"Czech Republic";CZ;CZE;61;"Jihoceský kraj";"Jihocesky kraj";region;JC;13219
+"Czech Republic";CZ;CZE;61;"Jihomoravský kraj";"Jihomoravsky kraj";region;JM;13220
+"Czech Republic";CZ;CZE;61;"Jindřichův Hradec";"Jindrichuv Hradec";district;"313 ";13228
+"Czech Republic";CZ;CZE;61;Jičín;Jicin;district;"522 ";13177
+"Czech Republic";CZ;CZE;61;"Karlovarský kraj";"Karlovarsky kraj";region;KA;13183
+"Czech Republic";CZ;CZE;61;"Karlovy Vary";"Karlovy Vary";district;"412 ";13236
+"Czech Republic";CZ;CZE;61;Karviná;Karvina;district;"803 ";13181
+"Czech Republic";CZ;CZE;61;Kladno;Kladno;district;"203 ";13200
+"Czech Republic";CZ;CZE;61;Klatovy;Klatovy;district;"322 ";13243
+"Czech Republic";CZ;CZE;61;Kolín;Kolin;district;"204 ";13202
+"Czech Republic";CZ;CZE;61;Kromĕříž;Kromeriz;district;"721 ";13207
+"Czech Republic";CZ;CZE;61;"Královéhradecký kraj";"Kralovehradecky kraj";region;KR;13221
+"Czech Republic";CZ;CZE;61;"Kutná Hora";"Kutna Hora";district;"205 ";13165
+"Czech Republic";CZ;CZE;61;Liberec;Liberec;district;"513 ";13211
+"Czech Republic";CZ;CZE;61;"Liberecký kraj";"Liberecky kraj";region;LI;13184
+"Czech Republic";CZ;CZE;61;Litoměřice;Litomerice;district;"423 ";13248
+"Czech Republic";CZ;CZE;61;Louny;Louny;district;"424 ";13252
+"Czech Republic";CZ;CZE;61;"Mladá Boleslav";"Mlada Boleslav";district;"207 ";13167
+"Czech Republic";CZ;CZE;61;"Moravskoslezský kraj";"Moravskoslezsky kraj";region;MO;13222
+"Czech Republic";CZ;CZE;61;Most;Most;district;"425 ";13251
+"Czech Republic";CZ;CZE;61;Mělník;Melnik;district;"206 ";13166
+"Czech Republic";CZ;CZE;61;"Nový Jičín";"Novy Jicin";district;"804 ";13214
+"Czech Republic";CZ;CZE;61;Nymburk;Nymburk;district;"208 ";13168
+"Czech Republic";CZ;CZE;61;Náchod;Nachod;district;"523 ";13238
+"Czech Republic";CZ;CZE;61;Olomouc;Olomouc;district;"712 ";13193
+"Czech Republic";CZ;CZE;61;"Olomoucký kraj";"Olomoucky kraj";region;OL;13185
+"Czech Republic";CZ;CZE;61;Opava;Opava;district;"805 ";13182
+"Czech Republic";CZ;CZE;61;"Ostrava město";"Ostrava mesto";district;"806 ";13215
+"Czech Republic";CZ;CZE;61;Pardubice;Pardubice;district;"532 ";13195
+"Czech Republic";CZ;CZE;61;"Pardubický kraj";"Pardubicky kraj";region;PA;13223
+"Czech Republic";CZ;CZE;61;Pelhřimov;Pelhrimov;district;"613 ";13253
+"Czech Republic";CZ;CZE;61;"Plzenský kraj";"Plzensky kraj";region;PL;13186
+"Czech Republic";CZ;CZE;61;"Plzeň jih";"Plzen jih";district;"324 ";13197
+"Czech Republic";CZ;CZE;61;"Plzeň město";"Plzen mesto";district;"323 ";13244
+"Czech Republic";CZ;CZE;61;"Plzeň sever";"Plzen sever";district;"325 ";13198
+"Czech Republic";CZ;CZE;61;Prachatice;Prachatice;district;"315 ";13190
+"Czech Republic";CZ;CZE;61;"Praha 1";"Praha 1";district;101;48300
+"Czech Republic";CZ;CZE;61;"Praha 10";"Praha 10";district;10A;48309
+"Czech Republic";CZ;CZE;61;"Praha 11";"Praha 11";district;10B;48310
+"Czech Republic";CZ;CZE;61;"Praha 12";"Praha 12";district;10C;48311
+"Czech Republic";CZ;CZE;61;"Praha 13";"Praha 13";district;10D;48312
+"Czech Republic";CZ;CZE;61;"Praha 14";"Praha 14";district;10E;48313
+"Czech Republic";CZ;CZE;61;"Praha 15";"Praha 15";district;10F;48314
+"Czech Republic";CZ;CZE;61;"Praha 2";"Praha 2";district;102;48301
+"Czech Republic";CZ;CZE;61;"Praha 3";"Praha 3";district;103;48302
+"Czech Republic";CZ;CZE;61;"Praha 4";"Praha 4";district;104;48303
+"Czech Republic";CZ;CZE;61;"Praha 5";"Praha 5";district;105;48304
+"Czech Republic";CZ;CZE;61;"Praha 6";"Praha 6";district;106;48305
+"Czech Republic";CZ;CZE;61;"Praha 7";"Praha 7";district;107;48306
+"Czech Republic";CZ;CZE;61;"Praha 8";"Praha 8";district;108;48307
+"Czech Republic";CZ;CZE;61;"Praha 9";"Praha 9";district;109;48308
+"Czech Republic";CZ;CZE;61;"Praha východ";"Praha vychod";district;"209 ";13170
+"Czech Republic";CZ;CZE;61;"Praha západ";"Praha zapad";district;"20A ";13171
+"Czech Republic";CZ;CZE;61;"hlavní mesto Praha";"hlavni mesto Praha";region;PR;13224
+"Czech Republic";CZ;CZE;61;Prostĕjov;Prostejov;district;"713 ";13194
+"Czech Republic";CZ;CZE;61;Písek;Pisek;district;"314 ";13229
+"Czech Republic";CZ;CZE;61;Přerov;Prerov;district;"714 ";13217
+"Czech Republic";CZ;CZE;61;Příbram;Pribram;district;"20B ";13169
+"Czech Republic";CZ;CZE;61;Rakovník;Rakovnik;district;"20C ";13172
+"Czech Republic";CZ;CZE;61;Rokycany;Rokycany;district;"326 ";13245
+"Czech Republic";CZ;CZE;61;"Rychnov nad Kněžnou";"Rychnov nad Kneznou";district;"524 ";13239
+"Czech Republic";CZ;CZE;61;Semily;Semily;district;"514 ";13212
+"Czech Republic";CZ;CZE;61;Sokolov;Sokolov;district;"413 ";13176
+"Czech Republic";CZ;CZE;61;Strakonice;Strakonice;district;"316 ";13230
+"Czech Republic";CZ;CZE;61;"Stredoceský kraj";"Stredocesky kraj";region;ST;13187
+"Czech Republic";CZ;CZE;61;Svitavy;Svitavy;district;"533 ";13241
+"Czech Republic";CZ;CZE;61;Tachov;Tachov;district;"327 ";13246
+"Czech Republic";CZ;CZE;61;Teplice;Teplice;district;"426 ";13203
+"Czech Republic";CZ;CZE;61;Trutnov;Trutnov;district;"525 ";13178
+"Czech Republic";CZ;CZE;61;Tábor;Tabor;district;"317 ";13191
+"Czech Republic";CZ;CZE;61;Třebíč;Trebic;district;"614 ";13206
+"Czech Republic";CZ;CZE;61;"Uherské Hradištĕ";"Uherske Hradiste";district;"722 ";13208
+"Czech Republic";CZ;CZE;61;Vsetín;Vsetin;district;"723 ";13163
+"Czech Republic";CZ;CZE;61;Vysocina;Vysocina;region;VY;13188
+"Czech Republic";CZ;CZE;61;Vyškov;Vyskov;district;"626 ";13234
+"Czech Republic";CZ;CZE;61;Zlín;Zlin;district;"724 ";13209
+"Czech Republic";CZ;CZE;61;"Zlínský kraj";"Zlinsky kraj";region;ZL;13226
+"Czech Republic";CZ;CZE;61;Znojmo;Znojmo;district;"627 ";13235
+"Czech Republic";CZ;CZE;61;"Ústecký kraj";"Ustecky kraj";region;US;13225
+"Czech Republic";CZ;CZE;61;"Ústí nad Labem";"Usti nad Labem";district;"427 ";13250
+"Czech Republic";CZ;CZE;61;"Ústí nad Orlicí";"Usti nad Orlici";district;"534 ";13196
+"Czech Republic";CZ;CZE;61;"Česká Lípa";"Ceska Lipa";district;"511 ";13210
+"Czech Republic";CZ;CZE;61;"České Budějovice";"Ceske Budejovice";district;"311 ";13227
+"Czech Republic";CZ;CZE;61;"Český Krumlov";"Cesky Krumlov";district;"312 ";13189
+"Czech Republic";CZ;CZE;61;Šumperk;Sumperk;district;"715 ";13218
+"Czech Republic";CZ;CZE;61;"Žd’ár nad Sázavou";"Zd'ar nad Sazavou";district;"615 ";13249
+"Côte D'Ivoire";CI;CIV;57;"18 Montagnes (Région des)";"18 Montagnes (Region des)";region;06;18974
+"Côte D'Ivoire";CI;CIV;57;"Agnébi (Région de l')";"Agnebi (Region de l')";region;16;18975
+"Côte D'Ivoire";CI;CIV;57;"Bafing (Région du)";"Bafing (Region du)";region;17;18976
+"Côte D'Ivoire";CI;CIV;57;"Bas-Sassandra (Région du)";"Bas-Sassandra (Region du)";region;09;18977
+"Côte D'Ivoire";CI;CIV;57;"Denguélé (Région du)";"Denguele (Region du)";region;10;18978
+"Côte D'Ivoire";CI;CIV;57;"Fromager (Région du)";"Fromager (Region du)";region;18;18979
+"Côte D'Ivoire";CI;CIV;57;"Haut-Sassandra (Région du)";"Haut-Sassandra (Region du)";region;02;18980
+"Côte D'Ivoire";CI;CIV;57;"Lacs (Région des)";"Lacs (Region des)";region;07;18981
+"Côte D'Ivoire";CI;CIV;57;"Lagunes (Région des)";"Lagunes (Region des)";region;01;18982
+"Côte D'Ivoire";CI;CIV;57;"Marahoué (Région de la)";"Marahoue (Region de la)";region;12;18983
+"Côte D'Ivoire";CI;CIV;57;"Moyen-Cavally (Région du)";"Moyen-Cavally (Region du)";region;19;18984
+"Côte D'Ivoire";CI;CIV;57;"Moyen-Comoé (Région du)";"Moyen-Comoe (Region du)";region;05;18985
+"Côte D'Ivoire";CI;CIV;57;"Nzi-Comoé (Région)";"Nzi-Comoe (Region)";region;11;18986
+"Côte D'Ivoire";CI;CIV;57;"Savanes (Région des)";"Savanes (Region des)";region;03;18987
+"Côte D'Ivoire";CI;CIV;57;"Sud-Bandama (Région du)";"Sud-Bandama (Region du)";region;15;18988
+"Côte D'Ivoire";CI;CIV;57;"Sud-Comoé (Région du)";"Sud-Comoe (Region du)";region;13;18989
+"Côte D'Ivoire";CI;CIV;57;"Vallée du Bandama (Région de la)";"Vallee du Bandama (Region de la)";region;04;18990
+"Côte D'Ivoire";CI;CIV;57;"Worodougou (Région du)";"Worodougou (Region du)";region;14;18991
+"Côte D'Ivoire";CI;CIV;57;"Zanzan (Région du)";"Zanzan (Region du)";region;08;18992
+Denmark;DK;DNK;62;Bornholm;Bornholm;county;040;13256
+Denmark;DK;DNK;62;Capital;Capital;region;84;19434
+Denmark;DK;DNK;62;"Central Jutland";"Central Jutland";region;82;19435
+Denmark;DK;DNK;62;"Frederiksberg City";"Frederiksberg City";city;147;13275
+Denmark;DK;DNK;62;Frederiksborg;Frederiksborg;county;020;13257
+Denmark;DK;DNK;62;Fyn;Fyn;county;042;13265
+Denmark;DK;DNK;62;København;Kobenhavn;county;015;13266
+Denmark;DK;DNK;62;"København City";"Kobenhavn City";city;101;13258
+Denmark;DK;DNK;62;Nordjylland;Nordjylland;county;080;13267
+Denmark;DK;DNK;62;"North Jutland";"North Jutland";region;81;19436
+Denmark;DK;DNK;62;Ribe;Ribe;county;055;13268
+Denmark;DK;DNK;62;Ringkøbing;Ringkobing;county;065;13259
+Denmark;DK;DNK;62;Roskilde;Roskilde;county;025;13269
+Denmark;DK;DNK;62;"South Denmark";"South Denmark";region;83;19438
+Denmark;DK;DNK;62;Storstrøm;Storstrom;county;035;13261
+Denmark;DK;DNK;62;Sønderjylland;Sonderjylland;county;050;13260
+Denmark;DK;DNK;62;Vejle;Vejle;county;060;13262
+Denmark;DK;DNK;62;Vestsjælland;Vestsjaelland;county;030;13263
+Denmark;DK;DNK;62;Viborg;Viborg;county;076;13264
+Denmark;DK;DNK;62;Zeeland;Zeeland;region;85;19437
+Denmark;DK;DNK;62;Århus;Arhus;county;070;13274
+Djibouti;DJ;DJI;63;"Ali Sabieh";"Ali Sabieh";region;AS;13283
+Djibouti;DJ;DJI;63;Arta;Arta;region;AR;19439
+Djibouti;DJ;DJI;63;Dikhil;Dikhil;region;DI;13282
+Djibouti;DJ;DJI;63;Djibouti;Djibouti;city;DJ;13280
+Djibouti;DJ;DJI;63;Obock;Obock;region;OB;13281
+Djibouti;DJ;DJI;63;Tadjourah;Tadjourah;region;TA;13284
+Dominica;DM;DMA;64;"Saint Andrew";"Saint Andrew";parish;02;13286
+Dominica;DM;DMA;64;"Saint David";"Saint David";parish;03;13289
+Dominica;DM;DMA;64;"Saint George";"Saint George";parish;04;13293
+Dominica;DM;DMA;64;"Saint John";"Saint John";parish;05;13292
+Dominica;DM;DMA;64;"Saint Joseph";"Saint Joseph";parish;06;13291
+Dominica;DM;DMA;64;"Saint Luke";"Saint Luke";parish;07;13294
+Dominica;DM;DMA;64;"Saint Mark";"Saint Mark";parish;08;13290
+Dominica;DM;DMA;64;"Saint Patrick";"Saint Patrick";parish;09;13285
+Dominica;DM;DMA;64;"Saint Paul";"Saint Paul";parish;10;13287
+Dominica;DM;DMA;64;"Saint Peter";"Saint Peter";parish;11;13288
+"Dominican Republic";DO;DOM;65;Azua;Azua;province;02;13506
+"Dominican Republic";DO;DOM;65;Bahoruco;Bahoruco;province;03;13489
+"Dominican Republic";DO;DOM;65;Barahona;Barahona;province;04;13477
+"Dominican Republic";DO;DOM;65;Dajabón;Dajabon;province;05;13490
+"Dominican Republic";DO;DOM;65;"Distrito Nacional (Santo Domingo)";"Distrito Nacional (Santo Domingo)";province;01;13520
+"Dominican Republic";DO;DOM;65;Duarte;Duarte;province;06;13491
+"Dominican Republic";DO;DOM;65;"El Seybo (El Seibo)";"El Seybo (El Seibo)";province;08;13492
+"Dominican Republic";DO;DOM;65;Espaillat;Espaillat;province;09;13493
+"Dominican Republic";DO;DOM;65;"Hato Mayor";"Hato Mayor";province;30;13510
+"Dominican Republic";DO;DOM;65;Independencia;Independencia;province;10;13494
+"Dominican Republic";DO;DOM;65;"La Altagracia";"La Altagracia";province;11;13511
+"Dominican Republic";DO;DOM;65;"La Estrelleta (Elías Piña)";"La Estrelleta (Elias Pina)";province;07;13509
+"Dominican Republic";DO;DOM;65;"La Romana";"La Romana";province;12;13487
+"Dominican Republic";DO;DOM;65;"La Vega";"La Vega";province;13;13512
+"Dominican Republic";DO;DOM;65;"María Trinidad Sánchez";"Maria Trinidad Sanchez";province;14;13496
+"Dominican Republic";DO;DOM;65;"Monseñor Nouel";"Monsenor Nouel";province;28;13513
+"Dominican Republic";DO;DOM;65;"Monte Cristi";"Monte Cristi";province;15;13497
+"Dominican Republic";DO;DOM;65;"Monte Plata";"Monte Plata";province;29;13514
+"Dominican Republic";DO;DOM;65;Pedernales;Pedernales;province;16;13498
+"Dominican Republic";DO;DOM;65;Peravia;Peravia;province;17;13499
+"Dominican Republic";DO;DOM;65;"Puerto Plata";"Puerto Plata";province;18;13515
+"Dominican Republic";DO;DOM;65;Salcedo;Salcedo;province;19;13500
+"Dominican Republic";DO;DOM;65;Samaná;Samana;province;20;13516
+"Dominican Republic";DO;DOM;65;"San Cristóbal";"San Cristobal";province;21;13517
+"Dominican Republic";DO;DOM;65;"San Jose de Ocoa";"San Jose de Ocoa";province;31;13502
+"Dominican Republic";DO;DOM;65;"San Juan";"San Juan";province;22;13518
+"Dominican Republic";DO;DOM;65;"San Pedro de Macorís";"San Pedro de Macoris";province;23;13503
+"Dominican Republic";DO;DOM;65;Santiago;Santiago;province;25;13519
+"Dominican Republic";DO;DOM;65;"Santiago Rodríguez";"Santiago Rodriguez";province;26;13504
+"Dominican Republic";DO;DOM;65;"Santo Domingo";"Santo Domingo";;32;13508
+"Dominican Republic";DO;DOM;65;"Sánchez Ramírez";"Sanchez Ramirez";province;24;13501
+"Dominican Republic";DO;DOM;65;Valverde;Valverde;province;27;13505
+Ecuador;EC;ECU;66;Azuay;Azuay;province;A;13570
+Ecuador;EC;ECU;66;Bolívar;Bolivar;province;B;13571
+Ecuador;EC;ECU;66;Carchi;Carchi;province;C;13572
+Ecuador;EC;ECU;66;Cañar;Canar;province;F;13578
+Ecuador;EC;ECU;66;Chimborazo;Chimborazo;province;H;13579
+Ecuador;EC;ECU;66;Cotopaxi;Cotopaxi;province;X;13573
+Ecuador;EC;ECU;66;"El Oro";"El Oro";province;O;13574
+Ecuador;EC;ECU;66;Esmeraldas;Esmeraldas;province;E;13580
+Ecuador;EC;ECU;66;Galápagos;Galapagos;province;W;13575
+Ecuador;EC;ECU;66;Guayas;Guayas;province;G;13576
+Ecuador;EC;ECU;66;Imbabura;Imbabura;province;I;13581
+Ecuador;EC;ECU;66;Loja;Loja;province;L;13577
+Ecuador;EC;ECU;66;"Los Ríos";"Los Rios";province;R;13582
+Ecuador;EC;ECU;66;Manabí;Manabi;province;M;13583
+Ecuador;EC;ECU;66;Morona-Santiago;Morona-Santiago;province;S;13584
+Ecuador;EC;ECU;66;Napo;Napo;province;N;13569
+Ecuador;EC;ECU;66;Orellana;Orellana;province;D;13585
+Ecuador;EC;ECU;66;Pastaza;Pastaza;province;Y;13568
+Ecuador;EC;ECU;66;Pichincha;Pichincha;province;P;13586
+Ecuador;EC;ECU;66;"Santa Elena";"Santa Elena";province;X1~;48131
+Ecuador;EC;ECU;66;"Santa Elena";"Santa Elena";province;SE;21342
+Ecuador;EC;ECU;66;"Santo Domingo de los Tsachilas";"Santo Domingo de los Tsachilas";province;SD;21343
+Ecuador;EC;ECU;66;"Santo Domingo de los Tsachilas";"Santo Domingo de los Tsachilas";province;X2~;48132
+Ecuador;EC;ECU;66;Sucumbíos;Sucumbios;province;U;13567
+Ecuador;EC;ECU;66;Tungurahua;Tungurahua;province;T;13587
+Ecuador;EC;ECU;66;Zamora-Chinchipe;Zamora-Chinchipe;province;Z;13566
+Egypt;EG;EGY;67;"Ad Daqahliyah";"Ad Daqahliyah";governorate;DK;13607
+Egypt;EG;EGY;67;"Al Bahr al Ahmar";"Al Bahr al Ahmar";governorate;BA;13605
+Egypt;EG;EGY;67;"Al Buhayrah";"Al Buhayrah";governorate;BH;13606
+Egypt;EG;EGY;67;"Al Fayyum";"Al Fayyum";governorate;FYM;13608
+Egypt;EG;EGY;67;"Al Gharbiyah";"Al Gharbiyah";governorate;GH;13609
+Egypt;EG;EGY;67;"Al Iskandariyah";"Al Iskandariyah";governorate;ALX;13595
+Egypt;EG;EGY;67;"Al Ismā`īlīyah";"Al Isma'iliyah";governorate;IS;13610
+Egypt;EG;EGY;67;"Al Jizah";"Al Jizah";governorate;GZ;13596
+Egypt;EG;EGY;67;"Al Minufiyah";"Al Minufiyah";governorate;MNF;13612
+Egypt;EG;EGY;67;"Al Minya";"Al Minya";governorate;MN;13591
+Egypt;EG;EGY;67;"Al Qahirah";"Al Qahirah";governorate;C;13598
+Egypt;EG;EGY;67;"Al Qalyubiyah";"Al Qalyubiyah";governorate;KB;13613
+Egypt;EG;EGY;67;"Al Wadi al Jadid";"Al Wadi al Jadid";governorate;WAD;13588
+Egypt;EG;EGY;67;al-Uqsur;al-Uqsur;governorate;LX;13589
+Egypt;EG;EGY;67;"As Suways";"As Suways";governorate;SUZ;13601
+Egypt;EG;EGY;67;"As Sādis min Uktūbar";"As Sadis min Uktubar";governorate;SU;48194
+Egypt;EG;EGY;67;"Ash Sharqiyah";"Ash Sharqiyah";governorate;SHR;13600
+Egypt;EG;EGY;67;Aswan;Aswan;governorate;ASN;13602
+Egypt;EG;EGY;67;Asyut;Asyut;governorate;AST;13604
+Egypt;EG;EGY;67;"Bani Suwayf";"Bani Suwayf";governorate;BNS;13603
+Egypt;EG;EGY;67;"Būr Sa`īd";"Bur Sa'id";governorate;PTS;13593
+Egypt;EG;EGY;67;Dumyat;Dumyat;governorate;DT;13594
+Egypt;EG;EGY;67;Ḩulwān;Hulwan;governorate;HU;48195
+Egypt;EG;EGY;67;"Janub Sina'";"Janub Sina'";governorate;JS;13611
+Egypt;EG;EGY;67;"Kafr ash Shaykh";"Kafr ash Shaykh";governorate;KFS;13592
+Egypt;EG;EGY;67;Matrūh;Matruh;governorate;MT;13597
+Egypt;EG;EGY;67;Qina;Qina;governorate;KN;13599
+Egypt;EG;EGY;67;"Shamal Sina'";"Shamal Sina'";governorate;SIN;13590
+Egypt;EG;EGY;67;Suhaj;Suhaj;governorate;SHG;13614
+"El Salvador";SV;SLV;68;Ahuachapán;Ahuachapan;department;AH;13619
+"El Salvador";SV;SLV;68;Cabañas;Cabanas;department;CA;13620
+"El Salvador";SV;SLV;68;Chalatenango;Chalatenango;department;CH;13618
+"El Salvador";SV;SLV;68;Cuscatlán;Cuscatlan;department;CU;13621
+"El Salvador";SV;SLV;68;"La Libertad";"La Libertad";department;LI;13627
+"El Salvador";SV;SLV;68;"La Paz";"La Paz";department;PA;13622
+"El Salvador";SV;SLV;68;"La Unión";"La Union";department;UN;13623
+"El Salvador";SV;SLV;68;Morazán;Morazan;department;MO;13617
+"El Salvador";SV;SLV;68;"San Miguel";"San Miguel";department;SM;13624
+"El Salvador";SV;SLV;68;"San Salvador";"San Salvador";department;SS;13628
+"El Salvador";SV;SLV;68;"San Vicente";"San Vicente";department;SV;13616
+"El Salvador";SV;SLV;68;"Santa Ana";"Santa Ana";department;SA;13625
+"El Salvador";SV;SLV;68;Sonsonate;Sonsonate;department;SO;13626
+"El Salvador";SV;SLV;68;Usulután;Usulutan;department;US;13615
+"Equatorial Guinea";GQ;GNQ;69;Annobón;Annobon;province;AN;13635
+"Equatorial Guinea";GQ;GNQ;69;"Bioko Norte";"Bioko Norte";province;BN;13632
+"Equatorial Guinea";GQ;GNQ;69;"Bioko Sur";"Bioko Sur";province;BS;13634
+"Equatorial Guinea";GQ;GNQ;69;"Centro Sur";"Centro Sur";province;CS;13633
+"Equatorial Guinea";GQ;GNQ;69;Kie-Ntem;Kie-Ntem;province;KN;13630
+"Equatorial Guinea";GQ;GNQ;69;Litoral;Litoral;province;LI;13631
+"Equatorial Guinea";GQ;GNQ;69;"Región Continental";"Region Continental";region;C;19440
+"Equatorial Guinea";GQ;GNQ;69;"Región Insular";"Region Insular";region;I;19441
+"Equatorial Guinea";GQ;GNQ;69;Wele-Nzás;Wele-Nzas;province;WN;13629
+Eritrea;ER;ERI;70;Anseba;Anseba;region;AN;13638
+Eritrea;ER;ERI;70;Debub;Debub;region;DU;13641
+Eritrea;ER;ERI;70;"Debubawi K’eyyĭḥ Baḥri";"Debubawi K'eyyih Bahri";region;DK;13639
+Eritrea;ER;ERI;70;Gash-Barka;Gash-Barka;region;GB;13637
+Eritrea;ER;ERI;70;Ma’ĭkel;Ma'ikel;region;MA;13640
+Eritrea;ER;ERI;70;"Semienawi K’eyyĭḥ Baḥri";"Semienawi K'eyyih Bahri";region;SK;13636
+Estonia;EE;EST;71;Harjumaa;Harjumaa;county;37;13653
+Estonia;EE;EST;71;Hiiumaa;Hiiumaa;county;39;13654
+Estonia;EE;EST;71;Ida-Virumaa;Ida-Virumaa;county;44;13646
+Estonia;EE;EST;71;Järvamaa;Jarvamaa;county;51;13652
+Estonia;EE;EST;71;Jõgevamaa;Jogevamaa;county;49;13647
+Estonia;EE;EST;71;Lääne-Virumaa;Laane-Virumaa;county;59;13655
+Estonia;EE;EST;71;Läänemaa;Laanemaa;county;57;13648
+Estonia;EE;EST;71;Pärnumaa;Parnumaa;county;67;13649
+Estonia;EE;EST;71;Põlvamaa;Polvamaa;county;65;13650
+Estonia;EE;EST;71;Raplamaa;Raplamaa;county;70;13643
+Estonia;EE;EST;71;Saaremaa;Saaremaa;county;74;13645
+Estonia;EE;EST;71;Tartumaa;Tartumaa;county;78;13656
+Estonia;EE;EST;71;Valgamaa;Valgamaa;county;82;13651
+Estonia;EE;EST;71;Viljandimaa;Viljandimaa;county;84;13644
+Estonia;EE;EST;71;Võrumaa;Vorumaa;county;86;13642
+Ethiopia;ET;ETH;73;"Adis Abeba";"Adis Abeba";administration;AA;13661
+Ethiopia;ET;ETH;73;Afar;Afar;state;AF;13662
+Ethiopia;ET;ETH;73;Amara;Amara;state;AM;13658
+Ethiopia;ET;ETH;73;"Binshangul Gumuz";"Binshangul Gumuz";state;BE;13663
+Ethiopia;ET;ETH;73;"Dire Dawa";"Dire Dawa";administration;DD;13667
+Ethiopia;ET;ETH;73;"Gambela Hizboch";"Gambela Hizboch";state;GA;13666
+Ethiopia;ET;ETH;73;"Hareri Hizb";"Hareri Hizb";state;HA;13665
+Ethiopia;ET;ETH;73;Oromiya;Oromiya;state;OR;13668
+Ethiopia;ET;ETH;73;Sumale;Sumale;state;SO;13664
+Ethiopia;ET;ETH;73;Tigray;Tigray;state;TI;13659
+Ethiopia;ET;ETH;73;"YeDebub Biheroch Bihereseboch na Hizboch";"YeDebub Biheroch Bihereseboch na Hizboch";state;SN;13657
+Fiji;FJ;FJI;76;Central;Central;division;C;13683
+Fiji;FJ;FJI;76;Eastern;Eastern;division;E;13682
+Fiji;FJ;FJI;76;Northern;Northern;division;N;13684
+Fiji;FJ;FJI;76;Rotuma;Rotuma;dependency;R;18998
+Fiji;FJ;FJI;76;Western;Western;division;W;13681
+Finland;FI;FIN;77;"Ahvenanmaan lääni";"Ahvenanmaan laani";;AL;13703
+Finland;FI;FIN;77;"Ahvenanmaan maakunta";"Ahvenanmaan maakunta";region;01;48686
+Finland;FI;FIN;77;Etelä-Karjala;Etela-Karjala;region;02;48687
+Finland;FI;FIN;77;Etelä-Pohjanmaa;Etela-Pohjanmaa;region;03;48688
+Finland;FI;FIN;77;Etelä-Savo;Etela-Savo;region;04;48689
+Finland;FI;FIN;77;"Etelä-Suomen lääni";"Etela-Suomen laani";;ES;20230
+Finland;FI;FIN;77;"Itä-Suomen lääni";"Ita-Suomen laani";;IS;13706
+Finland;FI;FIN;77;Kainuu;Kainuu;region;05;48690
+Finland;FI;FIN;77;Kanta-Häme;Kanta-Hame;region;06;48691
+Finland;FI;FIN;77;Keski-Pohjanmaa;Keski-Pohjanmaa;region;07;48692
+Finland;FI;FIN;77;Keski-Suomi;Keski-Suomi;region;08;48693
+Finland;FI;FIN;77;Kymenlaakso;Kymenlaakso;region;09;48694
+Finland;FI;FIN;77;"Lapin lääni";"Lapin laani";;LL;13690
+Finland;FI;FIN;77;Lappi;Lappi;region;10;48695
+Finland;FI;FIN;77;"Länsi-Suomen lääni";"Lansi-Suomen laani";;LS;20233
+Finland;FI;FIN;77;"Oulun lääni";"Oulun laani";;OL;20234
+Finland;FI;FIN;77;Pirkanmaa;Pirkanmaa;region;11;48696
+Finland;FI;FIN;77;Pohjanmaa;Pohjanmaa;region;12;48697
+Finland;FI;FIN;77;Pohjois-Karjala;Pohjois-Karjala;region;13;48698
+Finland;FI;FIN;77;Pohjois-Pohjanmaa;Pohjois-Pohjanmaa;region;14;48699
+Finland;FI;FIN;77;Pohjois-Savo;Pohjois-Savo;region;15;48700
+Finland;FI;FIN;77;Päijät-Häme;Paijat-Hame;region;16;48701
+Finland;FI;FIN;77;Satakunta;Satakunta;region;17;48702
+Finland;FI;FIN;77;Uusimaa;Uusimaa;region;18;48703
+Finland;FI;FIN;77;Varsinais-Suomi;Varsinais-Suomi;region;19;48704
+France;FR;FRA;78;Ain;Ain;"metropolitan department";01;13736
+France;FR;FRA;78;Aisne;Aisne;"metropolitan department";02;13737
+France;FR;FRA;78;Allier;Allier;"metropolitan department";03;13717
+France;FR;FRA;78;Alpes-de-Haute-Provence;Alpes-de-Haute-Provence;"metropolitan department";04;13738
+France;FR;FRA;78;Alpes-Maritimes;Alpes-Maritimes;"metropolitan department";06;13718
+France;FR;FRA;78;Alsace;Alsace;"metropolitan region";"A ";48315
+France;FR;FRA;78;Aquitaine;Aquitaine;"metropolitan region";"B ";48316
+France;FR;FRA;78;Ardennes;Ardennes;"metropolitan department";08;13719
+France;FR;FRA;78;Ardèche;Ardeche;"metropolitan department";07;13739
+France;FR;FRA;78;Ariège;Ariege;"metropolitan department";09;13740
+France;FR;FRA;78;Aube;Aube;"metropolitan department";10;13741
+France;FR;FRA;78;Aude;Aude;"metropolitan department";11;13720
+France;FR;FRA;78;Auvergne;Auvergne;"metropolitan region";"C ";48317
+France;FR;FRA;78;Aveyron;Aveyron;"metropolitan department";12;13742
+France;FR;FRA;78;Bas-Rhin;Bas-Rhin;"metropolitan department";67;13721
+France;FR;FRA;78;Basse-Normandie;Basse-Normandie;"metropolitan region";"P ";48318
+France;FR;FRA;78;Bouches-du-Rhône;Bouches-du-Rhone;"metropolitan department";13;13743
+France;FR;FRA;78;Bourgogne;Bourgogne;"metropolitan region";"D ";48319
+France;FR;FRA;78;Bretagne;Bretagne;"metropolitan region";"E ";48320
+France;FR;FRA;78;Calvados;Calvados;"metropolitan department";14;13722
+France;FR;FRA;78;Cantal;Cantal;"metropolitan department";15;13744
+France;FR;FRA;78;Centre;Centre;"metropolitan region";"F ";48321
+France;FR;FRA;78;Champagne-Ardenne;Champagne-Ardenne;"metropolitan region";"G ";48322
+France;FR;FRA;78;Charente;Charente;"metropolitan department";16;13723
+France;FR;FRA;78;Charente-Maritime;Charente-Maritime;"metropolitan department";17;13745
+France;FR;FRA;78;Cher;Cher;"metropolitan department";18;13746
+France;FR;FRA;78;Clipperton;Clipperton;dependency;CP;21344
+France;FR;FRA;78;Corrèze;Correze;"metropolitan department";19;13791
+France;FR;FRA;78;Corse;Corse;"metropolitan region";"H ";48323
+France;FR;FRA;78;Corse-du-Sud;Corse-du-Sud;"metropolitan department";2A;13747
+France;FR;FRA;78;Creuse;Creuse;"metropolitan department";23;13794
+France;FR;FRA;78;Côte-d'Or;Cote-d'Or;"metropolitan department";21;13792
+France;FR;FRA;78;Côtes-d'Armor;Cotes-d'Armor;"metropolitan department";22;13793
+France;FR;FRA;78;Deux-Sèvres;Deux-Sevres;"metropolitan department";79;13795
+France;FR;FRA;78;Dordogne;Dordogne;"metropolitan department";24;13796
+France;FR;FRA;78;Doubs;Doubs;"metropolitan department";25;13797
+France;FR;FRA;78;Drôme;Drome;"metropolitan department";26;13816
+France;FR;FRA;78;Essonne;Essonne;"metropolitan department";91;13817
+France;FR;FRA;78;Eure;Eure;"metropolitan department";27;13818
+France;FR;FRA;78;Eure-et-Loir;Eure-et-Loir;"metropolitan department";28;13819
+France;FR;FRA;78;Finistère;Finistere;"metropolitan department";29;13820
+France;FR;FRA;78;Franche-Comté;Franche-Comte;"metropolitan region";"I ";48324
+France;FR;FRA;78;Gard;Gard;"metropolitan department";30;13821
+France;FR;FRA;78;Gers;Gers;"metropolitan department";32;13822
+France;FR;FRA;78;Gironde;Gironde;"metropolitan department";33;13823
+France;FR;FRA;78;"Guadeloupe (see also separate entry under GP)";"Guadeloupe (see also separate entry under GP)";"overseas region";"GP ";48337
+France;FR;FRA;78;"Guyane (française) (see also separate entry under GF)";"Guyane (francaise) (see also separate entry under GF)";"overseas region";"GF ";48338
+France;FR;FRA;78;Haut-Rhin;Haut-Rhin;"metropolitan department";68;13753
+France;FR;FRA;78;Haute-Corse;Haute-Corse;"metropolitan department";2B;13748
+France;FR;FRA;78;Haute-Garonne;Haute-Garonne;"metropolitan department";31;13824
+France;FR;FRA;78;Haute-Loire;Haute-Loire;"metropolitan department";43;13749
+France;FR;FRA;78;Haute-Marne;Haute-Marne;"metropolitan department";52;13807
+France;FR;FRA;78;Haute-Normandie;Haute-Normandie;"metropolitan region";"Q ";48325
+France;FR;FRA;78;Haute-Savoie;Haute-Savoie;"metropolitan department";74;13751
+France;FR;FRA;78;Haute-Saône;Haute-Saone;"metropolitan department";70;13808
+France;FR;FRA;78;Haute-Vienne;Haute-Vienne;"metropolitan department";87;13809
+France;FR;FRA;78;Hautes-Alpes;Hautes-Alpes;"metropolitan department";05;13750
+France;FR;FRA;78;Hautes-Pyrénées;Hautes-Pyrenees;"metropolitan department";65;13752
+France;FR;FRA;78;Hauts-de-Seine;Hauts-de-Seine;"metropolitan department";92;13810
+France;FR;FRA;78;Hérault;Herault;"metropolitan department";34;13754
+France;FR;FRA;78;Ille-et-Vilaine;Ille-et-Vilaine;"metropolitan department";35;13811
+France;FR;FRA;78;Indre;Indre;"metropolitan department";36;13755
+France;FR;FRA;78;Indre-et-Loire;Indre-et-Loire;"metropolitan department";37;13756
+France;FR;FRA;78;Isère;Isere;"metropolitan department";38;13812
+France;FR;FRA;78;Jura;Jura;"metropolitan department";39;13757
+France;FR;FRA;78;"La Réunion (see also separate entry under RE)";"La Reunion (see also separate entry under RE)";"overseas region";"RE ";48340
+France;FR;FRA;78;Landes;Landes;"metropolitan department";40;13813
+France;FR;FRA;78;Languedoc-Roussillon;Languedoc-Roussillon;"metropolitan region";"K ";48327
+France;FR;FRA;78;Limousin;Limousin;"metropolitan region";"L ";48328
+France;FR;FRA;78;Loir-et-Cher;Loir-et-Cher;"metropolitan department";41;13760
+France;FR;FRA;78;Loire;Loire;"metropolitan department";42;13758
+France;FR;FRA;78;Loire-Atlantique;Loire-Atlantique;"metropolitan department";44;13814
+France;FR;FRA;78;Loiret;Loiret;"metropolitan department";45;13759
+France;FR;FRA;78;Lorraine;Lorraine;"metropolitan region";"M ";48329
+France;FR;FRA;78;Lot;Lot;"metropolitan department";46;13815
+France;FR;FRA;78;Lot-et-Garonne;Lot-et-Garonne;"metropolitan department";47;13761
+France;FR;FRA;78;Lozère;Lozere;"metropolitan department";48;13798
+France;FR;FRA;78;Maine-et-Loire;Maine-et-Loire;"metropolitan department";49;13762
+France;FR;FRA;78;Manche;Manche;"metropolitan department";50;13799
+France;FR;FRA;78;Marne;Marne;"metropolitan department";51;13763
+France;FR;FRA;78;"Martinique (see also separate entry under MQ)";"Martinique (see also separate entry under MQ)";"overseas region";"MQ ";48339
+France;FR;FRA;78;Mayenne;Mayenne;"metropolitan department";53;13764
+France;FR;FRA;78;"Mayotte (see also separate entry under YT)";"Mayotte (see also separate entry under YT)";"territorial collectivity";YT;18999
+France;FR;FRA;78;Meurthe-et-Moselle;Meurthe-et-Moselle;"metropolitan department";54;13800
+France;FR;FRA;78;Meuse;Meuse;"metropolitan department";55;13765
+France;FR;FRA;78;Midi-Pyrénées;Midi-Pyrenees;"metropolitan region";"N ";48330
+France;FR;FRA;78;Morbihan;Morbihan;"metropolitan department";56;13801
+France;FR;FRA;78;Moselle;Moselle;"metropolitan department";57;13766
+France;FR;FRA;78;Nièvre;Nievre;"metropolitan department";58;13802
+France;FR;FRA;78;Nord;Nord;"metropolitan department";59;13767
+France;FR;FRA;78;Nord-Pas-de-Calais;Nord-Pas-de-Calais;"metropolitan region";"O ";48331
+France;FR;FRA;78;"Nouvelle-Calédonie (see also separate entry under NC)";"Nouvelle-Caledonie (see also separate entry under NC)";"overseas territory";NC;19000
+France;FR;FRA;78;Oise;Oise;"metropolitan department";60;13768
+France;FR;FRA;78;Orne;Orne;"metropolitan department";61;13803
+France;FR;FRA;78;Paris;Paris;"metropolitan department";75;13769
+France;FR;FRA;78;Pas-de-Calais;Pas-de-Calais;"metropolitan department";62;13804
+France;FR;FRA;78;Pays-de-la-Loire;Pays-de-la-Loire;"metropolitan region";"R ";48332
+France;FR;FRA;78;Picardie;Picardie;"metropolitan region";"S ";48333
+France;FR;FRA;78;Poitou-Charentes;Poitou-Charentes;"metropolitan region";"T ";48334
+France;FR;FRA;78;"Polynésie française (see also separate entry under PF)";"Polynesie francaise (see also separate entry under PF)";"overseas territory";PF;19001
+France;FR;FRA;78;Provence-Alpes-Côte-d'Azur;Provence-Alpes-Cote-d'Azur;"metropolitan region";"U ";48335
+France;FR;FRA;78;Puy-de-Dôme;Puy-de-Dome;"metropolitan department";63;13770
+France;FR;FRA;78;Pyrénées-Atlantiques;Pyrenees-Atlantiques;"metropolitan department";64;13805
+France;FR;FRA;78;Pyrénées-Orientales;Pyrenees-Orientales;"metropolitan department";66;13771
+France;FR;FRA;78;Rhône;Rhone;"metropolitan department";69;13772
+France;FR;FRA;78;Rhône-Alpes;Rhone-Alpes;"metropolitan region";"V ";48336
+France;FR;FRA;78;"Saint-Barthélemy (see also separate entry under BL)";"Saint-Barthelemy (see also separate entry under BL)";"overseas territorial collectivity";BL;21345
+France;FR;FRA;78;"Saint-Martin (see also separate entry under MF)";"Saint-Martin (see also separate entry under MF)";"overseas territorial collectivity";MF;21346
+France;FR;FRA;78;"Saint-Pierre-et-Miquelon (see also separate entry under PM)";"Saint-Pierre-et-Miquelon (see also separate entry under PM)";"territorial collectivity";PM;19002
+France;FR;FRA;78;Sarthe;Sarthe;"metropolitan department";72;13773
+France;FR;FRA;78;Savoie;Savoie;"metropolitan department";73;13714
+France;FR;FRA;78;Saône-et-Loire;Saone-et-Loire;"metropolitan department";71;13806
+France;FR;FRA;78;Seine-et-Marne;Seine-et-Marne;"metropolitan department";77;13774
+France;FR;FRA;78;Seine-Maritime;Seine-Maritime;"metropolitan department";76;13710
+France;FR;FRA;78;Seine-Saint-Denis;Seine-Saint-Denis;"metropolitan department";93;13775
+France;FR;FRA;78;Somme;Somme;"metropolitan department";80;13711
+France;FR;FRA;78;Tarn;Tarn;"metropolitan department";81;13776
+France;FR;FRA;78;Tarn-et-Garonne;Tarn-et-Garonne;"metropolitan department";82;13712
+France;FR;FRA;78;"Terres Australes Françaises (see also separate entry under TF)";"Terres Australes Francaises (see also separate entry under TF)";"overseas territory";TF;19003
+France;FR;FRA;78;"Territoire de Belfort";"Territoire de Belfort";"metropolitan department";90;13777
+France;FR;FRA;78;Val-d'Oise;Val-d'Oise;"metropolitan department";95;13709
+France;FR;FRA;78;Val-de-Marne;Val-de-Marne;"metropolitan department";94;13778
+France;FR;FRA;78;Var;Var;"metropolitan department";83;13779
+France;FR;FRA;78;Vaucluse;Vaucluse;"metropolitan department";84;13713
+France;FR;FRA;78;Vendée;Vendee;"metropolitan department";85;13780
+France;FR;FRA;78;Vienne;Vienne;"metropolitan department";86;13781
+France;FR;FRA;78;Vosges;Vosges;"metropolitan department";88;13708
+France;FR;FRA;78;"Wallis et Futuna (see also separate entry under WF)";"Wallis et Futuna (see also separate entry under WF)";"overseas territory";WF;19004
+France;FR;FRA;78;Yonne;Yonne;"metropolitan department";89;13782
+France;FR;FRA;78;Yvelines;Yvelines;"metropolitan department";78;13707
+France;FR;FRA;78;Île-de-France;Ile-de-France;"metropolitan region";"J ";48326
+"French Southern Territories";TF;ATF;82;"Crozet Islands";"Crozet Islands";district;X2~;13836
+"French Southern Territories";TF;ATF;82;"Ile Saint-Paul et Ile Amsterdam";"Ile Saint-Paul et Ile Amsterdam";district;X1~;13834
+"French Southern Territories";TF;ATF;82;"Iles Eparses";"Iles Eparses";district;X4~;21356
+"French Southern Territories";TF;ATF;82;Kerguelen;Kerguelen;district;X3~;13837
+Gabon;GA;GAB;83;Estuaire;Estuaire;province;1;13839
+Gabon;GA;GAB;83;Haut-Ogooué;Haut-Ogooue;province;2;13845
+Gabon;GA;GAB;83;Moyen-Ogooué;Moyen-Ogooue;province;3;13841
+Gabon;GA;GAB;83;Ngounié;Ngounie;province;4;13844
+Gabon;GA;GAB;83;Nyanga;Nyanga;province;5;13846
+Gabon;GA;GAB;83;Ogooué-Ivindo;Ogooue-Ivindo;province;6;13842
+Gabon;GA;GAB;83;Ogooué-Lolo;Ogooue-Lolo;province;7;13843
+Gabon;GA;GAB;83;Ogooué-Maritime;Ogooue-Maritime;province;8;13840
+Gabon;GA;GAB;83;Woleu-Ntem;Woleu-Ntem;province;9;13838
+Gambia;GM;GMB;84;Banjul;Banjul;city;B;13880
+Gambia;GM;GMB;84;"Lower River";"Lower River";division;L;13887
+Gambia;GM;GMB;84;"MacCarthy Island";"MacCarthy Island";division;M;13877
+Gambia;GM;GMB;84;"North Bank";"North Bank";division;N;13885
+Gambia;GM;GMB;84;"Upper River";"Upper River";division;U;13881
+Gambia;GM;GMB;84;Western;Western;division;W;13882
+Georgia;GE;GEO;1;Abkhazia;Abkhazia;"autonomous republic";AB;13902
+Georgia;GE;GEO;1;Ajaria;Ajaria;"autonomous republic";AJ;13896
+Georgia;GE;GEO;1;Guria;Guria;region;GU;13897
+Georgia;GE;GEO;1;Imereti;Imereti;region;IM;13901
+Georgia;GE;GEO;1;Kakheti;Kakheti;region;KA;13898
+Georgia;GE;GEO;1;"Kvemo Kartli";"Kvemo Kartli";region;KK;13900
+Georgia;GE;GEO;1;Mtskheta-Mtianeti;Mtskheta-Mtianeti;region;MM;13905
+Georgia;GE;GEO;1;"Racha-Lechkhumi (and) Kvemo Svaneti";"Racha-Lechkhumi (and) Kvemo Svaneti";region;RL;13899
+Georgia;GE;GEO;1;"Samegrelo-Zemo Svaneti";"Samegrelo-Zemo Svaneti";region;SZ;13906
+Georgia;GE;GEO;1;Samtskhe-Javakheti;Samtskhe-Javakheti;region;SJ;13903
+Georgia;GE;GEO;1;"Shida Kartli";"Shida Kartli";region;SK;13904
+Georgia;GE;GEO;1;Tbilisi;Tbilisi;city;TB;13895
+Germany;DE;DEU;85;Baden-Württemberg;Baden-Wurttemberg;state;BW;14337
+Germany;DE;DEU;85;Bayern;Bayern;state;BY;14044
+Germany;DE;DEU;85;Berlin;Berlin;state;BE;14338
+Germany;DE;DEU;85;Brandenburg;Brandenburg;state;BB;14045
+Germany;DE;DEU;85;Bremen;Bremen;state;HB;14339
+Germany;DE;DEU;85;Hamburg;Hamburg;state;HH;14046
+Germany;DE;DEU;85;Hessen;Hessen;state;HE;14340
+Germany;DE;DEU;85;Mecklenburg-Vorpommern;Mecklenburg-Vorpommern;state;MV;14047
+Germany;DE;DEU;85;Niedersachsen;Niedersachsen;state;NI;14341
+Germany;DE;DEU;85;Nordrhein-Westfalen;Nordrhein-Westfalen;state;NW;14048
+Germany;DE;DEU;85;Rheinland-Pfalz;Rheinland-Pfalz;state;RP;14342
+Germany;DE;DEU;85;Saarland;Saarland;state;SL;14049
+Germany;DE;DEU;85;Sachsen;Sachsen;state;SN;14343
+Germany;DE;DEU;85;Sachsen-Anhalt;Sachsen-Anhalt;state;ST;14050
+Germany;DE;DEU;85;Schleswig-Holstein;Schleswig-Holstein;state;SH;14344
+Germany;DE;DEU;85;Thüringen;Thuringen;state;TH;14051
+Ghana;GH;GHA;86;Ashanti;Ashanti;region;AH;14403
+Ghana;GH;GHA;86;Brong-Ahafo;Brong-Ahafo;region;BA;14400
+Ghana;GH;GHA;86;Central;Central;region;CP;14404
+Ghana;GH;GHA;86;Eastern;Eastern;region;EP;14405
+Ghana;GH;GHA;86;"Greater Accra";"Greater Accra";region;AA;14399
+Ghana;GH;GHA;86;Northern;Northern;region;NP;14402
+Ghana;GH;GHA;86;"Upper East";"Upper East";region;UE;14406
+Ghana;GH;GHA;86;"Upper West";"Upper West";region;UW;14397
+Ghana;GH;GHA;86;Volta;Volta;region;TV;14401
+Ghana;GH;GHA;86;Western;Western;region;WP;14398
+Greece;GR;GRC;88;Achaïa;Achaia;department;13;14414
+Greece;GR;GRC;88;"Agio Oros";"Agio Oros";"self-governed part";69;14417
+Greece;GR;GRC;88;"Aitolia kai Akarnania";"Aitolia kai Akarnania";department;01;14423
+Greece;GR;GRC;88;"Anatoliki Makedonia kai Thraki";"Anatoliki Makedonia kai Thraki";"administrative region";A;48444
+Greece;GR;GRC;88;Argolida;Argolida;department;11;14415
+Greece;GR;GRC;88;Arkadia;Arkadia;department;12;14424
+Greece;GR;GRC;88;Arta;Arta;department;31;14425
+Greece;GR;GRC;88;Attiki;Attiki;"administrative region";I;48445
+Greece;GR;GRC;88;Attiki;Attiki;department;A1;14416
+Greece;GR;GRC;88;Chalkidiki;Chalkidiki;department;64;14421
+Greece;GR;GRC;88;Chania;Chania;department;94;14432
+Greece;GR;GRC;88;Chios;Chios;department;85;14422
+Greece;GR;GRC;88;Dodekanisos;Dodekanisos;department;81;14426
+Greece;GR;GRC;88;Drama;Drama;department;52;14427
+Greece;GR;GRC;88;"Dytiki Ellada";"Dytiki Ellada";"administrative region";G;48446
+Greece;GR;GRC;88;"Dytiki Makedonia";"Dytiki Makedonia";"administrative region";C;48447
+Greece;GR;GRC;88;Evros;Evros;department;71;14428
+Greece;GR;GRC;88;Evrytania;Evrytania;department;05;14418
+Greece;GR;GRC;88;Evvoia;Evvoia;department;04;14419
+Greece;GR;GRC;88;Florina;Florina;department;63;14429
+Greece;GR;GRC;88;Fokida;Fokida;department;07;14430
+Greece;GR;GRC;88;Fthiotida;Fthiotida;department;06;14420
+Greece;GR;GRC;88;Grevena;Grevena;department;51;14431
+Greece;GR;GRC;88;Ileia;Ileia;department;14;14433
+Greece;GR;GRC;88;Imathia;Imathia;department;53;14450
+Greece;GR;GRC;88;Ioannina;Ioannina;department;33;14451
+Greece;GR;GRC;88;"Ionia Nisia";"Ionia Nisia";"administrative region";F;48448
+Greece;GR;GRC;88;Ipeiros;Ipeiros;"administrative region";D;48449
+Greece;GR;GRC;88;Irakleio;Irakleio;department;91;14434
+Greece;GR;GRC;88;Karditsa;Karditsa;department;41;14435
+Greece;GR;GRC;88;Kastoria;Kastoria;department;56;14452
+Greece;GR;GRC;88;Kavala;Kavala;department;55;14436
+Greece;GR;GRC;88;Kefallonia;Kefallonia;department;23;14453
+Greece;GR;GRC;88;"Kentriki Makedonia";"Kentriki Makedonia";"administrative region";B;48450
+Greece;GR;GRC;88;Kerkyra;Kerkyra;department;22;14454
+Greece;GR;GRC;88;Kilkis;Kilkis;department;57;14455
+Greece;GR;GRC;88;Korinthia;Korinthia;department;15;14438
+Greece;GR;GRC;88;Kozani;Kozani;department;58;14456
+Greece;GR;GRC;88;Kriti;Kriti;"administrative region";M;48451
+Greece;GR;GRC;88;Kyklades;Kyklades;department;82;14437
+Greece;GR;GRC;88;Lakonia;Lakonia;department;16;14439
+Greece;GR;GRC;88;Larisa;Larisa;department;42;14457
+Greece;GR;GRC;88;Lasithi;Lasithi;department;92;14440
+Greece;GR;GRC;88;Lefkada;Lefkada;department;24;14441
+Greece;GR;GRC;88;Lesvos;Lesvos;department;83;14413
+Greece;GR;GRC;88;Magnisia;Magnisia;department;43;14458
+Greece;GR;GRC;88;Messinia;Messinia;department;17;14442
+Greece;GR;GRC;88;"Notio Aigaio";"Notio Aigaio";"administrative region";L;48452
+Greece;GR;GRC;88;Pella;Pella;department;59;14443
+Greece;GR;GRC;88;Peloponnisos;Peloponnisos;"administrative region";J;48453
+Greece;GR;GRC;88;Pieria;Pieria;department;61;14412
+Greece;GR;GRC;88;Preveza;Preveza;department;34;14444
+Greece;GR;GRC;88;Rethymno;Rethymno;department;93;14459
+Greece;GR;GRC;88;Rodopi;Rodopi;department;73;14445
+Greece;GR;GRC;88;Samos;Samos;department;84;14411
+Greece;GR;GRC;88;Serres;Serres;department;62;14446
+Greece;GR;GRC;88;"Sterea Ellada";"Sterea Ellada";"administrative region";H;48454
+Greece;GR;GRC;88;Thesprotia;Thesprotia;department;32;14410
+Greece;GR;GRC;88;Thessalia;Thessalia;"administrative region";E;48455
+Greece;GR;GRC;88;Thessaloniki;Thessaloniki;department;54;14447
+Greece;GR;GRC;88;Trikala;Trikala;department;44;14409
+Greece;GR;GRC;88;Voiotia;Voiotia;department;03;14448
+Greece;GR;GRC;88;"Voreio Aigaio";"Voreio Aigaio";"administrative region";K;48456
+Greece;GR;GRC;88;Xanthi;Xanthi;department;72;14408
+Greece;GR;GRC;88;Zakynthos;Zakynthos;department;21;14449
+Greenland;GL;GRL;89;"Kommune Kujalleq (kl)";"Kommune Kujalleq (kl)";municipality;KU;48225
+Greenland;GL;GRL;89;"Kommuneqarfik Sermersooq (kl)";"Kommuneqarfik Sermersooq (kl)";municipality;SM;48226
+Greenland;GL;GRL;89;"Qaasuitsup Kommunia (kl)";"Qaasuitsup Kommunia (kl)";municipality;QA;48227
+Greenland;GL;GRL;89;"Qeqqata Kommunia (kl)";"Qeqqata Kommunia (kl)";municipality;QE;48228
+Grenada;GD;GRD;90;"Saint Andrew";"Saint Andrew";parish;01;14484
+Grenada;GD;GRD;90;"Saint David";"Saint David";parish;02;14486
+Grenada;GD;GRD;90;"Saint George";"Saint George";parish;03;14485
+Grenada;GD;GRD;90;"Saint John";"Saint John";parish;04;14483
+Grenada;GD;GRD;90;"Saint Mark";"Saint Mark";parish;05;14480
+Grenada;GD;GRD;90;"Saint Patrick";"Saint Patrick";parish;06;14482
+Grenada;GD;GRD;90;"Southern Grenadine Islands";"Southern Grenadine Islands";dependency;10;14481
+Guatemala;GT;GTM;93;"Alta Verapaz";"Alta Verapaz";department;AV;14531
+Guatemala;GT;GTM;93;"Baja Verapaz";"Baja Verapaz";department;BV;14526
+Guatemala;GT;GTM;93;Chimaltenango;Chimaltenango;department;CM;14532
+Guatemala;GT;GTM;93;Chiquimula;Chiquimula;department;CQ;14527
+Guatemala;GT;GTM;93;"El Progreso";"El Progreso";department;PR;14533
+Guatemala;GT;GTM;93;Escuintla;Escuintla;department;ES;14528
+Guatemala;GT;GTM;93;Guatemala;Guatemala;department;GU;14529
+Guatemala;GT;GTM;93;Huehuetenango;Huehuetenango;department;HU;14534
+Guatemala;GT;GTM;93;Izabal;Izabal;department;IZ;14535
+Guatemala;GT;GTM;93;Jalapa;Jalapa;department;JA;14536
+Guatemala;GT;GTM;93;Jutiapa;Jutiapa;department;JU;14537
+Guatemala;GT;GTM;93;Petén;Peten;department;PE;14538
+Guatemala;GT;GTM;93;Quetzaltenango;Quetzaltenango;department;QZ;14525
+Guatemala;GT;GTM;93;Quiché;Quiche;department;QC;14539
+Guatemala;GT;GTM;93;Retalhuleu;Retalhuleu;department;RE;14524
+Guatemala;GT;GTM;93;Sacatepéquez;Sacatepequez;department;SA;14540
+Guatemala;GT;GTM;93;"San Marcos";"San Marcos";department;SM;14523
+Guatemala;GT;GTM;93;"Santa Rosa";"Santa Rosa";department;SR;14541
+Guatemala;GT;GTM;93;Sololá;Solola;department;SO;14522
+Guatemala;GT;GTM;93;Suchitepéquez;Suchitepequez;department;SU;14542
+Guatemala;GT;GTM;93;Totonicapán;Totonicapan;department;TO;14521
+Guatemala;GT;GTM;93;Zacapa;Zacapa;department;ZA;14530
+Guinea;GN;GIN;95;Beyla;Beyla;prefecture;BE;14565
+Guinea;GN;GIN;95;Boffa;Boffa;prefecture;BF;14566
+Guinea;GN;GIN;95;Boké;Boke;governorate;B;48437
+Guinea;GN;GIN;95;Boké;Boke;prefecture;BK;14567
+Guinea;GN;GIN;95;Conakry;Conakry;"special zone";C;14568
+Guinea;GN;GIN;95;Coyah;Coyah;prefecture;CO;14569
+Guinea;GN;GIN;95;Dabola;Dabola;prefecture;DB;14575
+Guinea;GN;GIN;95;Dalaba;Dalaba;prefecture;DL;14570
+Guinea;GN;GIN;95;Dinguiraye;Dinguiraye;prefecture;DI;14576
+Guinea;GN;GIN;95;Dubréka;Dubreka;prefecture;DU;14573
+Guinea;GN;GIN;95;Faranah;Faranah;prefecture;FA;14577
+Guinea;GN;GIN;95;faranah;faranah;governorate;F;48438
+Guinea;GN;GIN;95;Forécariah;Forecariah;prefecture;FO;14571
+Guinea;GN;GIN;95;Fria;Fria;prefecture;FR;14578
+Guinea;GN;GIN;95;Gaoual;Gaoual;prefecture;GA;14572
+Guinea;GN;GIN;95;Guékédou;Guekedou;prefecture;GU;14579
+Guinea;GN;GIN;95;Kankan;Kankan;governorate;K;48439
+Guinea;GN;GIN;95;Kankan;Kankan;prefecture;KA;14580
+Guinea;GN;GIN;95;Kindia;Kindia;prefecture;KD;14581
+Guinea;GN;GIN;95;Kindia;Kindia;governorate;D;48440
+Guinea;GN;GIN;95;Kissidougou;Kissidougou;prefecture;KS;14592
+Guinea;GN;GIN;95;Koubia;Koubia;prefecture;KB;14582
+Guinea;GN;GIN;95;Koundara;Koundara;prefecture;KN;14583
+Guinea;GN;GIN;95;Kouroussa;Kouroussa;prefecture;KO;14560
+Guinea;GN;GIN;95;Kérouané;Kerouane;prefecture;KE;14561
+Guinea;GN;GIN;95;Labé;Labe;governorate;L;48441
+Guinea;GN;GIN;95;Labé;Labe;prefecture;LA;14584
+Guinea;GN;GIN;95;Lola;Lola;prefecture;LO;14585
+Guinea;GN;GIN;95;Lélouma;Lelouma;prefecture;LE;14593
+Guinea;GN;GIN;95;Macenta;Macenta;prefecture;MC;14586
+Guinea;GN;GIN;95;Mali;Mali;prefecture;ML;14559
+Guinea;GN;GIN;95;Mamou;Mamou;prefecture;MM;14587
+Guinea;GN;GIN;95;Mamou;Mamou;governorate;M;48442
+Guinea;GN;GIN;95;Mandiana;Mandiana;prefecture;MD;14558
+Guinea;GN;GIN;95;Nzérékoré;Nzerekore;governorate;N;48443
+Guinea;GN;GIN;95;Nzérékoré;Nzerekore;prefecture;NZ;14588
+Guinea;GN;GIN;95;Pita;Pita;prefecture;PI;14557
+Guinea;GN;GIN;95;Siguiri;Siguiri;prefecture;SI;14589
+Guinea;GN;GIN;95;Tougué;Tougue;prefecture;TO;14556
+Guinea;GN;GIN;95;Télimélé;Telimele;prefecture;TE;14590
+Guinea;GN;GIN;95;Yomou;Yomou;prefecture;YO;14591
+Guinea-Bissau;GW;GNB;96;Bafatá;Bafata;region;BA;14595
+Guinea-Bissau;GW;GNB;96;Biombo;Biombo;region;BM;14598
+Guinea-Bissau;GW;GNB;96;Bissau;Bissau;"autonomous sector";BS;14597
+Guinea-Bissau;GW;GNB;96;Bolama;Bolama;region;BL;14601
+Guinea-Bissau;GW;GNB;96;Cacheu;Cacheu;region;CA;14599
+Guinea-Bissau;GW;GNB;96;Gabú;Gabu;region;GA;14602
+Guinea-Bissau;GW;GNB;96;Leste;Leste;province;L;48457
+Guinea-Bissau;GW;GNB;96;Norte;Norte;province;N;48458
+Guinea-Bissau;GW;GNB;96;Oio;Oio;region;OI;14596
+Guinea-Bissau;GW;GNB;96;Quinara;Quinara;region;QU;14594
+Guinea-Bissau;GW;GNB;96;Sul;Sul;province;S;48459
+Guinea-Bissau;GW;GNB;96;Tombali;Tombali;region;TO;14600
+Guyana;GY;GUY;97;Barima-Waini;Barima-Waini;region;BA;14605
+Guyana;GY;GUY;97;Cuyuni-Mazaruni;Cuyuni-Mazaruni;region;CU;14612
+Guyana;GY;GUY;97;Demerara-Mahaica;Demerara-Mahaica;region;DE;14606
+Guyana;GY;GUY;97;"East Berbice-Corentyne";"East Berbice-Corentyne";region;EB;14611
+Guyana;GY;GUY;97;"Essequibo Islands-West Demerara";"Essequibo Islands-West Demerara";region;ES;14607
+Guyana;GY;GUY;97;Mahaica-Berbice;Mahaica-Berbice;region;MA;14608
+Guyana;GY;GUY;97;Pomeroon-Supenaam;Pomeroon-Supenaam;region;PM;14604
+Guyana;GY;GUY;97;Potaro-Siparuni;Potaro-Siparuni;region;PT;14609
+Guyana;GY;GUY;97;"Upper Demerara-Berbice";"Upper Demerara-Berbice";region;UD;14603
+Guyana;GY;GUY;97;"Upper Takutu-Upper Essequibo";"Upper Takutu-Upper Essequibo";region;UT;14610
+Haiti;HT;HTI;98;Artibonite;Artibonite;department;AR;14621
+Haiti;HT;HTI;98;Centre;Centre;department;CE;14617
+Haiti;HT;HTI;98;Grande-Anse;Grande-Anse;department;GA;14620
+Haiti;HT;HTI;98;Nippes;Nippes;department;NI;48705
+Haiti;HT;HTI;98;Nord;Nord;department;ND;14616
+Haiti;HT;HTI;98;Nord-Est;Nord-Est;department;NE;14618
+Haiti;HT;HTI;98;Nord-Ouest;Nord-Ouest;department;NO;14614
+Haiti;HT;HTI;98;Ouest;Ouest;department;OU;14615
+Haiti;HT;HTI;98;Sud;Sud;department;SD;14613
+Haiti;HT;HTI;98;Sud-Est;Sud-Est;department;SE;14619
+Honduras;HN;HND;101;Atlántida;Atlantida;department;AT;14635
+Honduras;HN;HND;101;Choluteca;Choluteca;department;CH;14624
+Honduras;HN;HND;101;Colón;Colon;department;CL;14625
+Honduras;HN;HND;101;Comayagua;Comayagua;department;CM;14636
+Honduras;HN;HND;101;Copán;Copan;department;CP;14626
+Honduras;HN;HND;101;Cortés;Cortes;department;CR;14637
+Honduras;HN;HND;101;"El Paraíso";"El Paraiso";department;EP;14638
+Honduras;HN;HND;101;"Francisco Morazán";"Francisco Morazan";department;FM;14628
+Honduras;HN;HND;101;"Gracias a Dios";"Gracias a Dios";department;GD;14629
+Honduras;HN;HND;101;Intibucá;Intibuca;department;IN;14623
+Honduras;HN;HND;101;"Islas de la Bahía";"Islas de la Bahia";department;IB;14630
+Honduras;HN;HND;101;"La Paz";"La Paz";department;LP;14639
+Honduras;HN;HND;101;Lempira;Lempira;department;LE;14631
+Honduras;HN;HND;101;Ocotepeque;Ocotepeque;department;OC;14640
+Honduras;HN;HND;101;Olancho;Olancho;department;OL;14632
+Honduras;HN;HND;101;"Santa Bárbara";"Santa Barbara";department;SB;14633
+Honduras;HN;HND;101;Valle;Valle;department;VA;14622
+Honduras;HN;HND;101;Yoro;Yoro;department;YO;14634
+Hungary;HU;HUN;103;Baranya;Baranya;county;BA;14646
+Hungary;HU;HUN;103;Borsod-Abaúj-Zemplén;Borsod-Abauj-Zemplen;county;BZ;14660
+Hungary;HU;HUN;103;Budapest;Budapest;"capital city";BU;14649
+Hungary;HU;HUN;103;Bács-Kiskun;Bacs-Kiskun;county;BK;14647
+Hungary;HU;HUN;103;Békés;Bekes;county;BE;14648
+Hungary;HU;HUN;103;Békéscsaba;Bekescsaba;"city of county right";BC;19442
+Hungary;HU;HUN;103;Csongrád;Csongrad;county;CS;14650
+Hungary;HU;HUN;103;Debrecen;Debrecen;"city of county right";DE;19443
+Hungary;HU;HUN;103;Dunaújváros;Dunaujvaros;"city of county right";DU;19444
+Hungary;HU;HUN;103;Eger;Eger;"city of county right";EG;19445
+Hungary;HU;HUN;103;Erd;Erd;county;ER;21352
+Hungary;HU;HUN;103;Erd;Erd;county;X1~;48133
+Hungary;HU;HUN;103;Fejér;Fejer;county;FE;14645
+Hungary;HU;HUN;103;Gyor;Gyor;"city of county right";GY;19446
+Hungary;HU;HUN;103;Gyor-Moson-Sopron;Gyor-Moson-Sopron;county;GS;14651
+Hungary;HU;HUN;103;Hajdú-Bihar;Hajdu-Bihar;county;HB;14661
+Hungary;HU;HUN;103;Heves;Heves;county;HE;14652
+Hungary;HU;HUN;103;Hódmezovásárhely;Hodmezovasarhely;"city of county right";HV;19447
+Hungary;HU;HUN;103;Jász-Nagykun-Szolnok;Jasz-Nagykun-Szolnok;county;JN;14653
+Hungary;HU;HUN;103;Kaposvár;Kaposvar;"city of county right";KV;19448
+Hungary;HU;HUN;103;Kecskemét;Kecskemet;"city of county right";KM;19449
+Hungary;HU;HUN;103;Komárom-Esztergom;Komarom-Esztergom;county;KE;14644
+Hungary;HU;HUN;103;Miskolc;Miskolc;"city of county right";MI;19450
+Hungary;HU;HUN;103;Nagykanizsa;Nagykanizsa;"city of county right";NK;19451
+Hungary;HU;HUN;103;Nyíregyháza;Nyiregyhaza;"city of county right";NY;19452
+Hungary;HU;HUN;103;Nógrád;Nograd;county;NO;14654
+Hungary;HU;HUN;103;Pest;Pest;county;PE;14643
+Hungary;HU;HUN;103;Pécs;Pecs;"city of county right";PS;19453
+Hungary;HU;HUN;103;Salgótarján;Salgotarjan;"city of county right";ST;19454
+Hungary;HU;HUN;103;Somogy;Somogy;county;SO;14655
+Hungary;HU;HUN;103;Sopron;Sopron;"city of county right";SN;19455
+Hungary;HU;HUN;103;Szabolcs-Szatmár-Bereg;Szabolcs-Szatmar-Bereg;county;SZ;14656
+Hungary;HU;HUN;103;Szeged;Szeged;"city of county right";SD;19456
+Hungary;HU;HUN;103;Szekszárd;Szekszard;"city of county right";SS;19458
+Hungary;HU;HUN;103;Szolnok;Szolnok;"city of county right";SK;19459
+Hungary;HU;HUN;103;Szombathely;Szombathely;"city of county right";SH;19460
+Hungary;HU;HUN;103;Székesfehérvár;Szekesfehervar;"city of county right";SF;19457
+Hungary;HU;HUN;103;Tatabánya;Tatabanya;"city of county right";TB;19461
+Hungary;HU;HUN;103;Tolna;Tolna;county;TO;14642
+Hungary;HU;HUN;103;Vas;Vas;county;VA;14657
+Hungary;HU;HUN;103;Veszprém;Veszprem;county;VE;14658
+Hungary;HU;HUN;103;"Veszprém City";"Veszprem City";"city of county right";VM;19462
+Hungary;HU;HUN;103;Zala;Zala;county;ZA;14641
+Hungary;HU;HUN;103;Zalaegerszeg;Zalaegerszeg;"city of county right";ZE;19463
+Iceland;IS;ISL;104;Austurland;Austurland;region;7;14670
+Iceland;IS;ISL;104;"Höfuðborgarsvæði utan Reykjavíkur";"Hofudborgarsvaedi utan Reykjavikur";region;1;14666
+Iceland;IS;ISL;104;"Norðurland eystra";"Nordurland eystra";region;6;14669
+Iceland;IS;ISL;104;"Norðurland vestra";"Nordurland vestra";region;5;14664
+Iceland;IS;ISL;104;Reykjavík;Reykjavik;city;0;19009
+Iceland;IS;ISL;104;Suðurland;Sudurland;region;8;14668
+Iceland;IS;ISL;104;Suðurnes;Sudurnes;region;2;14667
+Iceland;IS;ISL;104;Vestfirðir;Vestfirdir;region;4;14663
+Iceland;IS;ISL;104;Vesturland;Vesturland;region;3;14662
+India;IN;IND;105;"Andaman and Nicobar Islands";"Andaman and Nicobar Islands";"union territory";AN;14673
+India;IN;IND;105;"Andhra Pradesh";"Andhra Pradesh";state;AP;14695
+India;IN;IND;105;"Arunachal Pradesh";"Arunachal Pradesh";state;AR;14674
+India;IN;IND;105;Assam;Assam;state;AS;14675
+India;IN;IND;105;Bihar;Bihar;state;BR;14676
+India;IN;IND;105;Chandigarh;Chandigarh;"union territory";CH;14697
+India;IN;IND;105;Chhattisgarh;Chhattisgarh;state;CT;14677
+India;IN;IND;105;"Dadra and Nagar Haveli";"Dadra and Nagar Haveli";"union territory";DN;14678
+India;IN;IND;105;"Daman and Diu";"Daman and Diu";"union territory";DD;14698
+India;IN;IND;105;Delhi;Delhi;"union territory";DL;14679
+India;IN;IND;105;Goa;Goa;state;GA;14699
+India;IN;IND;105;Gujarat;Gujarat;state;GJ;14680
+India;IN;IND;105;Haryana;Haryana;state;HR;14681
+India;IN;IND;105;"Himachal Pradesh";"Himachal Pradesh";state;HP;14672
+India;IN;IND;105;"Jammu and Kashmir";"Jammu and Kashmir";state;JK;14682
+India;IN;IND;105;Jharkhand;Jharkhand;state;JH;14700
+India;IN;IND;105;Karnataka;Karnataka;state;KA;14683
+India;IN;IND;105;Kerala;Kerala;state;KL;14684
+India;IN;IND;105;Lakshadweep;Lakshadweep;"union territory";LD;14704
+India;IN;IND;105;"Madhya Pradesh";"Madhya Pradesh";state;MP;14685
+India;IN;IND;105;Maharashtra;Maharashtra;state;MH;14686
+India;IN;IND;105;Manipur;Manipur;state;MN;14703
+India;IN;IND;105;Meghalaya;Meghalaya;state;ML;14687
+India;IN;IND;105;Mizoram;Mizoram;state;MZ;14702
+India;IN;IND;105;Nagaland;Nagaland;state;NL;14688
+India;IN;IND;105;Orissa;Orissa;state;OR;14689
+India;IN;IND;105;Pondicherry;Pondicherry;"union territory";PY;14705
+India;IN;IND;105;Punjab;Punjab;state;PB;14690
+India;IN;IND;105;Rajasthan;Rajasthan;state;RJ;14691
+India;IN;IND;105;Sikkim;Sikkim;state;SK;14701
+India;IN;IND;105;"Tamil Nadu";"Tamil Nadu";state;TN;14692
+India;IN;IND;105;Tripura;Tripura;state;TR;14693
+India;IN;IND;105;"Uttar Pradesh";"Uttar Pradesh";state;UP;14694
+India;IN;IND;105;Uttaranchal;Uttaranchal;state;UL;14671
+India;IN;IND;105;"West Bengal";"West Bengal";state;WB;14696
+Indonesia;ID;IDN;106;Aceh;Aceh;"autonomous province";AC;14720
+Indonesia;ID;IDN;106;Bali;Bali;province;BA;14719
+Indonesia;ID;IDN;106;"Bangka Belitung";"Bangka Belitung";province;BB;14721
+Indonesia;ID;IDN;106;Banten;Banten;province;BT;14723
+Indonesia;ID;IDN;106;Bengkulu;Bengkulu;province;BE;14722
+Indonesia;ID;IDN;106;Gorontalo;Gorontalo;province;GO;14711
+Indonesia;ID;IDN;106;"Jakarta Raya";"Jakarta Raya";"special district";JK;14724
+Indonesia;ID;IDN;106;Jambi;Jambi;province;JA;14712
+Indonesia;ID;IDN;106;Jawa;Jawa;"geographic unit";JW;48462
+Indonesia;ID;IDN;106;"Jawa Barat";"Jawa Barat";province;JB;14725
+Indonesia;ID;IDN;106;"Jawa Tengah";"Jawa Tengah";province;JT;14713
+Indonesia;ID;IDN;106;"Jawa Timur";"Jawa Timur";province;JI;14726
+Indonesia;ID;IDN;106;Kalimantan;Kalimantan;"geographic unit";KA;48463
+Indonesia;ID;IDN;106;"Kalimantan Barat";"Kalimantan Barat";province;KB;14714
+Indonesia;ID;IDN;106;"Kalimantan Selatan";"Kalimantan Selatan";province;KS;14715
+Indonesia;ID;IDN;106;"Kalimantan Tengah";"Kalimantan Tengah";province;KT;14727
+Indonesia;ID;IDN;106;"Kalimantan Timur";"Kalimantan Timur";province;KI;14728
+Indonesia;ID;IDN;106;"Kepulauan Riau";"Kepulauan Riau";province;KR;14733
+Indonesia;ID;IDN;106;Lampung;Lampung;province;LA;14729
+Indonesia;ID;IDN;106;Maluku;Maluku;"geographic unit";ML;48905
+Indonesia;ID;IDN;106;Maluku;Maluku;province;MA;14730
+Indonesia;ID;IDN;106;"Maluku Utara";"Maluku Utara";province;MU;14710
+Indonesia;ID;IDN;106;"Nusa Tenggara";"Nusa Tenggara";"geographic unit";NU;48465
+Indonesia;ID;IDN;106;"Nusa Tenggara Barat";"Nusa Tenggara Barat";province;NB;14731
+Indonesia;ID;IDN;106;"Nusa Tenggara Timur";"Nusa Tenggara Timur";province;NT;14709
+Indonesia;ID;IDN;106;Papua;Papua;province;PA;14732
+Indonesia;ID;IDN;106;Papua;Papua;"geographic unit";IJ;48466
+Indonesia;ID;IDN;106;"Papua Barat";"Papua Barat";;X1~;48084
+Indonesia;ID;IDN;106;"Papua Barat";"Papua Barat";province;PB;19010
+Indonesia;ID;IDN;106;Riau;Riau;province;RI;14708
+Indonesia;ID;IDN;106;Sulawesi;Sulawesi;"geographic unit";SL;48467
+Indonesia;ID;IDN;106;"Sulawesi Barat";"Sulawesi Barat";province;SR;19011
+Indonesia;ID;IDN;106;"Sulawesi Selatan";"Sulawesi Selatan";province;SN;14707
+Indonesia;ID;IDN;106;"Sulawesi Tengah";"Sulawesi Tengah";province;ST;14734
+Indonesia;ID;IDN;106;"Sulawesi Tenggara";"Sulawesi Tenggara";province;SG;14736
+Indonesia;ID;IDN;106;"Sulawesi Utara";"Sulawesi Utara";province;SA;14716
+Indonesia;ID;IDN;106;Sumatera;Sumatera;"geographic unit";SM;48468
+Indonesia;ID;IDN;106;"Sumatera Barat";"Sumatera Barat";province;SB;14735
+Indonesia;ID;IDN;106;"Sumatera Selatan";"Sumatera Selatan";province;SS;14717
+Indonesia;ID;IDN;106;"Sumatera Utara";"Sumatera Utara";province;SU;14706
+Indonesia;ID;IDN;106;Yogyakarta;Yogyakarta;"special region";YO;14718
+"Islamic Republic Of Iran";IR;IRN;107;Ardabil;Ardabil;province;03;14748
+"Islamic Republic Of Iran";IR;IRN;107;"Az¯arbayjan-e Gharbi";"Az-arbayjan-e Gharbi";province;02;14756
+"Islamic Republic Of Iran";IR;IRN;107;"Az¯arbayjan-e Sharqi";"Az-arbayjan-e Sharqi";province;01;14749
+"Islamic Republic Of Iran";IR;IRN;107;Bushehr;Bushehr;province;06;14757
+"Islamic Republic Of Iran";IR;IRN;107;"Chahar Mah¸all va Bakhtiari";"Chahar Mah,all va Bakhtiari";province;08;14750
+"Islamic Republic Of Iran";IR;IRN;107;Esfahan;Esfahan;province;04;14758
+"Islamic Republic Of Iran";IR;IRN;107;Fars;Fars;province;14;14751
+"Islamic Republic Of Iran";IR;IRN;107;Gilan;Gilan;province;19;14759
+"Islamic Republic Of Iran";IR;IRN;107;Golestan;Golestan;province;27;14760
+"Islamic Republic Of Iran";IR;IRN;107;Hamadan;Hamadan;province;24;14752
+"Islamic Republic Of Iran";IR;IRN;107;Hormozgan;Hormozgan;province;23;14761
+"Islamic Republic Of Iran";IR;IRN;107;Ilam;Ilam;province;05;14753
+"Islamic Republic Of Iran";IR;IRN;107;Kerman;Kerman;province;15;14762
+"Islamic Republic Of Iran";IR;IRN;107;Kermanshah;Kermanshah;province;17;14739
+"Islamic Republic Of Iran";IR;IRN;107;Khorasan;Khorasan;;09;14740
+"Islamic Republic Of Iran";IR;IRN;107;"Khorasan-e Janubi";"Khorasan-e Janubi";province;29;19012
+"Islamic Republic Of Iran";IR;IRN;107;"Khorasan-e Razavi";"Khorasan-e Razavi";province;30;19013
+"Islamic Republic Of Iran";IR;IRN;107;"Khorasan-e Shemali";"Khorasan-e Shemali";province;31;19014
+"Islamic Republic Of Iran";IR;IRN;107;Khuzestan;Khuzestan;province;10;14741
+"Islamic Republic Of Iran";IR;IRN;107;"Kohkiluyeh va Buyer Ahmad";"Kohkiluyeh va Buyer Ahmad";province;18;14742
+"Islamic Republic Of Iran";IR;IRN;107;Kordestan;Kordestan;province;16;14743
+"Islamic Republic Of Iran";IR;IRN;107;Lorestan;Lorestan;province;20;14744
+"Islamic Republic Of Iran";IR;IRN;107;Markazi;Markazi;province;22;14745
+"Islamic Republic Of Iran";IR;IRN;107;Mazandaran;Mazandaran;province;21;14746
+"Islamic Republic Of Iran";IR;IRN;107;Qazvin;Qazvin;province;28;14747
+"Islamic Republic Of Iran";IR;IRN;107;Qom;Qom;province;26;14738
+"Islamic Republic Of Iran";IR;IRN;107;Semnan;Semnan;province;12;14754
+"Islamic Republic Of Iran";IR;IRN;107;"Sistan va Baluchestan";"Sistan va Baluchestan";province;13;14764
+"Islamic Republic Of Iran";IR;IRN;107;Tehran;Tehran;province;07;14755
+"Islamic Republic Of Iran";IR;IRN;107;Yazd;Yazd;province;25;14763
+"Islamic Republic Of Iran";IR;IRN;107;Zanjan;Zanjan;province;11;14737
+Iraq;IQ;IRQ;108;"Al Anbar";"Al Anbar";province;AN;14771
+Iraq;IQ;IRQ;108;"Al Basrah";"Al Basrah";province;BA;14773
+Iraq;IQ;IRQ;108;"Al Muthanná";"Al Muthanna";province;MU;14777
+Iraq;IQ;IRQ;108;"Al Qadisiyah";"Al Qadisiyah";province;QA;14766
+Iraq;IQ;IRQ;108;"An Najaf";"An Najaf";province;NA;14768
+Iraq;IQ;IRQ;108;Arbil;Arbil;province;AR;14769
+Iraq;IQ;IRQ;108;"As Sulaymaniyah";"As Sulaymaniyah";province;SU;14779
+Iraq;IQ;IRQ;108;"At Ta'mim";"At Ta'mim";province;TS;14765
+Iraq;IQ;IRQ;108;Babil;Babil;province;BB;14772
+Iraq;IQ;IRQ;108;Baghdad;Baghdad;province;BG;14770
+Iraq;IQ;IRQ;108;Dahuk;Dahuk;province;DA;14774
+Iraq;IQ;IRQ;108;"Dhi Qar";"Dhi Qar";province;DQ;14781
+Iraq;IQ;IRQ;108;Diyalá;Diyala;province;DI;14775
+Iraq;IQ;IRQ;108;Karbala';Karbala';province;KA;14776
+Iraq;IQ;IRQ;108;Maysan;Maysan;province;MA;14782
+Iraq;IQ;IRQ;108;Ninawá;Ninawa;province;NI;14778
+Iraq;IQ;IRQ;108;"Salah ad Din";"Salah ad Din";province;SD;14767
+Iraq;IQ;IRQ;108;Wasit;Wasit;province;WA;14780
+Ireland;IE;IRL;109;Carlow;Carlow;county;CW;14798
+Ireland;IE;IRL;109;Cavan;Cavan;county;CN;14795
+Ireland;IE;IRL;109;Clare;Clare;county;CE;14799
+Ireland;IE;IRL;109;Connaught;Connaught;province;C;48469
+Ireland;IE;IRL;109;Cork;Cork;county;CO;48897
+Ireland;IE;IRL;109;Cork;Cork;county;C;14800
+Ireland;IE;IRL;109;Donegal;Donegal;county;DL;14796
+Ireland;IE;IRL;109;Dublin;Dublin;county;D;14801
+Ireland;IE;IRL;109;Galway;Galway;county;G;14797
+Ireland;IE;IRL;109;Kerry;Kerry;county;KY;14802
+Ireland;IE;IRL;109;Kildare;Kildare;county;KE;14788
+Ireland;IE;IRL;109;Kilkenny;Kilkenny;county;KK;14803
+Ireland;IE;IRL;109;Laois;Laois;county;LS;14807
+Ireland;IE;IRL;109;Leinster;Leinster;province;L;48470
+Ireland;IE;IRL;109;Leitrim;Leitrim;county;LM;14804
+Ireland;IE;IRL;109;Limerick;Limerick;county;LK;14805
+Ireland;IE;IRL;109;Longford;Longford;county;LD;14787
+Ireland;IE;IRL;109;Louth;Louth;county;LH;14806
+Ireland;IE;IRL;109;Mayo;Mayo;county;MO;14808
+Ireland;IE;IRL;109;Meath;Meath;county;MH;14789
+Ireland;IE;IRL;109;Monaghan;Monaghan;county;MN;14786
+Ireland;IE;IRL;109;Munster;Munster;province;M;48471
+Ireland;IE;IRL;109;Offaly;Offaly;county;OY;14790
+Ireland;IE;IRL;109;Roscommon;Roscommon;county;RN;14809
+Ireland;IE;IRL;109;Sligo;Sligo;county;SO;14791
+Ireland;IE;IRL;109;Tipperary;Tipperary;county;TA;14792
+Ireland;IE;IRL;109;Ulster;Ulster;province;U;48472
+Ireland;IE;IRL;109;Waterford;Waterford;county;WD;14784
+Ireland;IE;IRL;109;Westmeath;Westmeath;county;WH;14793
+Ireland;IE;IRL;109;Wexford;Wexford;county;WX;14783
+Ireland;IE;IRL;109;Wicklow;Wicklow;county;WW;14794
+Israel;IL;ISR;111;HaDarom;HaDarom;district;D;14847
+Israel;IL;ISR;111;Haifa;Haifa;district;HA;14878
+Israel;IL;ISR;111;HaMerkaz;HaMerkaz;district;M;14877
+Israel;IL;ISR;111;HaZafon;HaZafon;district;Z;14848
+Israel;IL;ISR;111;Tel-Aviv;Tel-Aviv;district;TA;14850
+Israel;IL;ISR;111;Yerushalayim;Yerushalayim;district;JM;14879
+Italy;IT;ITA;112;Abruzzo;Abruzzo;region;65;14895
+Italy;IT;ITA;112;Agrigento;Agrigento;province;AG;19465
+Italy;IT;ITA;112;Alessandria;Alessandria;province;AL;19466
+Italy;IT;ITA;112;Ancona;Ancona;province;AN;19467
+Italy;IT;ITA;112;Aosta;Aosta;province;AO;19468
+Italy;IT;ITA;112;Arezzo;Arezzo;province;AR;19469
+Italy;IT;ITA;112;"Ascoli Piceno";"Ascoli Piceno";province;AP;19470
+Italy;IT;ITA;112;Asti;Asti;province;AT;19471
+Italy;IT;ITA;112;Avellino;Avellino;province;AV;19472
+Italy;IT;ITA;112;Bari;Bari;province;BA;19473
+Italy;IT;ITA;112;Barletta-Andria-Trani;Barletta-Andria-Trani;province;BT;48088
+Italy;IT;ITA;112;Basilicata;Basilicata;region;77;14897
+Italy;IT;ITA;112;Belluno;Belluno;province;BL;19474
+Italy;IT;ITA;112;Benevento;Benevento;province;BN;19475
+Italy;IT;ITA;112;Bergamo;Bergamo;province;BG;19476
+Italy;IT;ITA;112;Biella;Biella;province;BI;19477
+Italy;IT;ITA;112;Bologna;Bologna;province;BO;19478
+Italy;IT;ITA;112;Bolzano;Bolzano;province;BZ;19479
+Italy;IT;ITA;112;Brescia;Brescia;province;BS;19480
+Italy;IT;ITA;112;Brindisi;Brindisi;province;BR;19481
+Italy;IT;ITA;112;Cagliari;Cagliari;province;CA;19482
+Italy;IT;ITA;112;Calabria;Calabria;region;78;14896
+Italy;IT;ITA;112;Caltanissetta;Caltanissetta;province;CL;19483
+Italy;IT;ITA;112;Campania;Campania;region;72;14898
+Italy;IT;ITA;112;Campobasso;Campobasso;province;CB;19484
+Italy;IT;ITA;112;Carbonia-Iglesias;Carbonia-Iglesias;province;CI;19485
+Italy;IT;ITA;112;Caserta;Caserta;province;CE;19486
+Italy;IT;ITA;112;Catania;Catania;province;CT;19487
+Italy;IT;ITA;112;Catanzaro;Catanzaro;province;CZ;19488
+Italy;IT;ITA;112;Chieti;Chieti;province;CH;19489
+Italy;IT;ITA;112;Como;Como;province;CO;19490
+Italy;IT;ITA;112;Cosenza;Cosenza;province;CS;19491
+Italy;IT;ITA;112;Cremona;Cremona;province;CR;19492
+Italy;IT;ITA;112;Crotone;Crotone;province;KR;19493
+Italy;IT;ITA;112;Cuneo;Cuneo;province;CN;19494
+Italy;IT;ITA;112;Emilia-Romagna;Emilia-Romagna;region;45;14886
+Italy;IT;ITA;112;Enna;Enna;province;EN;19495
+Italy;IT;ITA;112;Fermo;Fermo;province;FM;48086
+Italy;IT;ITA;112;Ferrara;Ferrara;province;FE;19496
+Italy;IT;ITA;112;Firenze;Firenze;province;FI;19497
+Italy;IT;ITA;112;Foggia;Foggia;province;FG;19498
+Italy;IT;ITA;112;Forli-Cesena;Forli-Cesena;province;FC;19499
+Italy;IT;ITA;112;Forlì;Forli;;FO;48085
+Italy;IT;ITA;112;"Friuli-Venezia Giulia";"Friuli-Venezia Giulia";region;36;14885
+Italy;IT;ITA;112;Frosinone;Frosinone;province;FR;19500
+Italy;IT;ITA;112;Genova;Genova;province;GE;19501
+Italy;IT;ITA;112;Gorizia;Gorizia;province;GO;19502
+Italy;IT;ITA;112;Grosseto;Grosseto;province;GR;19503
+Italy;IT;ITA;112;Imperia;Imperia;province;IM;19504
+Italy;IT;ITA;112;Isernia;Isernia;province;IS;19505
+Italy;IT;ITA;112;L'Aquila;L'Aquila;province;AQ;19507
+Italy;IT;ITA;112;"La Spezia";"La Spezia";province;SP;19506
+Italy;IT;ITA;112;Latina;Latina;province;LT;19508
+Italy;IT;ITA;112;Lazio;Lazio;region;62;14887
+Italy;IT;ITA;112;Lecce;Lecce;province;LE;19509
+Italy;IT;ITA;112;Lecco;Lecco;province;LC;19510
+Italy;IT;ITA;112;Liguria;Liguria;region;42;14899
+Italy;IT;ITA;112;Livorno;Livorno;province;LI;19511
+Italy;IT;ITA;112;Lodi;Lodi;province;LO;19512
+Italy;IT;ITA;112;Lombardia;Lombardia;region;25;14888
+Italy;IT;ITA;112;Lucca;Lucca;province;LU;19513
+Italy;IT;ITA;112;Macerata;Macerata;province;MC;19514
+Italy;IT;ITA;112;Mantova;Mantova;province;MN;19515
+Italy;IT;ITA;112;Marche;Marche;region;57;14889
+Italy;IT;ITA;112;Massa-Carrara;Massa-Carrara;province;MS;19516
+Italy;IT;ITA;112;Matera;Matera;province;MT;19517
+Italy;IT;ITA;112;"Medio Campidano";"Medio Campidano";province;VS;19518
+Italy;IT;ITA;112;"Medio Campidano";"Medio Campidano";province;MA;48224
+Italy;IT;ITA;112;Messina;Messina;province;ME;19519
+Italy;IT;ITA;112;Milano;Milano;province;MI;19520
+Italy;IT;ITA;112;Modena;Modena;province;MO;19521
+Italy;IT;ITA;112;Molise;Molise;region;67;14884
+Italy;IT;ITA;112;"Monza e Brianza";"Monza e Brianza";province;MB;48087
+Italy;IT;ITA;112;Napoli;Napoli;province;NA;19522
+Italy;IT;ITA;112;Novara;Novara;province;NO;19523
+Italy;IT;ITA;112;Nuoro;Nuoro;province;NU;19524
+Italy;IT;ITA;112;Ogliastra;Ogliastra;province;OG;19525
+Italy;IT;ITA;112;Olbia-Tempio;Olbia-Tempio;province;OT;19526
+Italy;IT;ITA;112;Olbia-Tempio;Olbia-Tempio;province;OL;48223
+Italy;IT;ITA;112;Oristano;Oristano;province;OR;19527
+Italy;IT;ITA;112;Padova;Padova;province;PD;19528
+Italy;IT;ITA;112;Palermo;Palermo;province;PA;19529
+Italy;IT;ITA;112;Parma;Parma;province;PR;19530
+Italy;IT;ITA;112;Pavia;Pavia;province;PV;19531
+Italy;IT;ITA;112;Perugia;Perugia;province;PG;19532
+Italy;IT;ITA;112;"Pesaro e Urbino";"Pesaro e Urbino";province;PS;48222
+Italy;IT;ITA;112;"Pesaro e Urbino";"Pesaro e Urbino";province;PU;19533
+Italy;IT;ITA;112;Pescara;Pescara;province;PE;19534
+Italy;IT;ITA;112;Piacenza;Piacenza;province;PC;19535
+Italy;IT;ITA;112;Piemonte;Piemonte;region;21;14900
+Italy;IT;ITA;112;Pisa;Pisa;province;PI;19536
+Italy;IT;ITA;112;Pistoia;Pistoia;province;PT;19537
+Italy;IT;ITA;112;Pordenone;Pordenone;province;PN;19538
+Italy;IT;ITA;112;Potenza;Potenza;province;PZ;19539
+Italy;IT;ITA;112;Prato;Prato;province;PO;19540
+Italy;IT;ITA;112;Puglia;Puglia;region;75;14890
+Italy;IT;ITA;112;Ragusa;Ragusa;province;RG;19541
+Italy;IT;ITA;112;Ravenna;Ravenna;province;RA;19542
+Italy;IT;ITA;112;"Reggio Calabria";"Reggio Calabria";province;RC;19543
+Italy;IT;ITA;112;"Reggio Emilia";"Reggio Emilia";province;RE;19544
+Italy;IT;ITA;112;Rieti;Rieti;province;RI;19545
+Italy;IT;ITA;112;Rimini;Rimini;province;RN;19546
+Italy;IT;ITA;112;Roma;Roma;province;RM;19547
+Italy;IT;ITA;112;Rovigo;Rovigo;province;RO;19548
+Italy;IT;ITA;112;Salerno;Salerno;province;SA;19549
+Italy;IT;ITA;112;Sardegna;Sardegna;region;88;14883
+Italy;IT;ITA;112;Sassari;Sassari;province;SS;19550
+Italy;IT;ITA;112;Savona;Savona;province;SV;19551
+Italy;IT;ITA;112;Sicilia;Sicilia;region;82;14891
+Italy;IT;ITA;112;Siena;Siena;province;SI;19552
+Italy;IT;ITA;112;Siracusa;Siracusa;province;SR;19553
+Italy;IT;ITA;112;Sondrio;Sondrio;province;SO;19554
+Italy;IT;ITA;112;Taranto;Taranto;province;TA;19555
+Italy;IT;ITA;112;Teramo;Teramo;province;TE;19556
+Italy;IT;ITA;112;Terni;Terni;province;TR;19557
+Italy;IT;ITA;112;Torino;Torino;province;TO;19558
+Italy;IT;ITA;112;Toscana;Toscana;region;52;14901
+Italy;IT;ITA;112;Trapani;Trapani;province;TP;19559
+Italy;IT;ITA;112;"Trentino-Alto Adige";"Trentino-Alto Adige";region;32;14892
+Italy;IT;ITA;112;Trento;Trento;province;TN;19560
+Italy;IT;ITA;112;Treviso;Treviso;province;TV;19561
+Italy;IT;ITA;112;Trieste;Trieste;province;TS;19562
+Italy;IT;ITA;112;Udine;Udine;province;UD;19563
+Italy;IT;ITA;112;Umbria;Umbria;region;55;14893
+Italy;IT;ITA;112;"Valle d'Aosta";"Valle d'Aosta";region;23;14882
+Italy;IT;ITA;112;Varese;Varese;province;VA;19564
+Italy;IT;ITA;112;Veneto;Veneto;region;34;14894
+Italy;IT;ITA;112;Venezia;Venezia;province;VE;19565
+Italy;IT;ITA;112;Verbano-Cusio-Ossola;Verbano-Cusio-Ossola;province;VB;19566
+Italy;IT;ITA;112;Vercelli;Vercelli;province;VC;19567
+Italy;IT;ITA;112;Verona;Verona;province;VR;19568
+Italy;IT;ITA;112;"Vibo Valentia";"Vibo Valentia";province;VV;19569
+Italy;IT;ITA;112;Vicenza;Vicenza;province;VI;19570
+Italy;IT;ITA;112;Viterbo;Viterbo;province;VT;19571
+Jamaica;JM;JAM;113;Clarendon;Clarendon;parish;13;14905
+Jamaica;JM;JAM;113;Hanover;Hanover;parish;09;14915
+Jamaica;JM;JAM;113;Kingston;Kingston;parish;01;14906
+Jamaica;JM;JAM;113;Manchester;Manchester;parish;12;14914
+Jamaica;JM;JAM;113;Portland;Portland;parish;04;14907
+Jamaica;JM;JAM;113;"Saint Andrew";"Saint Andrew";parish;02;14908
+Jamaica;JM;JAM;113;"Saint Ann";"Saint Ann";parish;06;14904
+Jamaica;JM;JAM;113;"Saint Catherine";"Saint Catherine";parish;14;14909
+Jamaica;JM;JAM;113;"Saint Elizabeth";"Saint Elizabeth";parish;11;14903
+Jamaica;JM;JAM;113;"Saint James";"Saint James";parish;08;14910
+Jamaica;JM;JAM;113;"Saint Mary";"Saint Mary";parish;05;14911
+Jamaica;JM;JAM;113;"Saint Thomas";"Saint Thomas";parish;03;14902
+Jamaica;JM;JAM;113;Trelawny;Trelawny;parish;07;14912
+Jamaica;JM;JAM;113;Westmoreland;Westmoreland;parish;10;14913
+Japan;JP;JPN;114;"Aiti (Aichi)";"Aiti (Aichi)";prefecture;23;14931
+Japan;JP;JPN;114;Akita;Akita;prefecture;05;14954
+Japan;JP;JPN;114;Aomori;Aomori;prefecture;02;14932
+Japan;JP;JPN;114;Ehime;Ehime;prefecture;38;14955
+Japan;JP;JPN;114;"Gihu (Gifu)";"Gihu (Gifu)";prefecture;21;14936
+Japan;JP;JPN;114;Gunma;Gunma;prefecture;10;14937
+Japan;JP;JPN;114;"Hirosima (Hiroshima)";"Hirosima (Hiroshima)";prefecture;34;14938
+Japan;JP;JPN;114;"Hokkaidô (Hokkaido)";"Hokkaido (Hokkaido)";territory;01;14957
+Japan;JP;JPN;114;"Hukui (Fukui)";"Hukui (Fukui)";prefecture;18;14934
+Japan;JP;JPN;114;"Hukuoka (Fukuoka)";"Hukuoka (Fukuoka)";prefecture;40;14935
+Japan;JP;JPN;114;"Hukusima (Fukushima)";"Hukusima (Fukushima)";prefecture;07;14956
+Japan;JP;JPN;114;"Hyôgo (Hyogo)";"Hyogo (Hyogo)";prefecture;28;14939
+Japan;JP;JPN;114;Ibaraki;Ibaraki;prefecture;08;14958
+Japan;JP;JPN;114;"Isikawa (Ishikawa)";"Isikawa (Ishikawa)";prefecture;17;14940
+Japan;JP;JPN;114;Iwate;Iwate;prefecture;03;14941
+Japan;JP;JPN;114;Kagawa;Kagawa;prefecture;37;14942
+Japan;JP;JPN;114;"Kagosima (Kagoshima)";"Kagosima (Kagoshima)";prefecture;46;14959
+Japan;JP;JPN;114;Kanagawa;Kanagawa;prefecture;14;14943
+Japan;JP;JPN;114;Kumamoto;Kumamoto;prefecture;43;14960
+Japan;JP;JPN;114;"Kyôto (Kyoto)";"Kyoto (Kyoto)";"urban prefecture";26;14945
+Japan;JP;JPN;114;"Kôti (Kochi)";"Koti (Kochi)";prefecture;39;14944
+Japan;JP;JPN;114;Mie;Mie;prefecture;24;14946
+Japan;JP;JPN;114;Miyagi;Miyagi;prefecture;04;14921
+Japan;JP;JPN;114;Miyazaki;Miyazaki;prefecture;45;14947
+Japan;JP;JPN;114;Nagano;Nagano;prefecture;20;14948
+Japan;JP;JPN;114;Nagasaki;Nagasaki;prefecture;42;14961
+Japan;JP;JPN;114;Nara;Nara;prefecture;29;14949
+Japan;JP;JPN;114;Niigata;Niigata;prefecture;15;14950
+Japan;JP;JPN;114;Okayama;Okayama;prefecture;33;14951
+Japan;JP;JPN;114;Okinawa;Okinawa;prefecture;47;14952
+Japan;JP;JPN;114;Saga;Saga;prefecture;41;14953
+Japan;JP;JPN;114;Saitama;Saitama;prefecture;11;14922
+Japan;JP;JPN;114;"Siga (Shiga)";"Siga (Shiga)";prefecture;25;14919
+Japan;JP;JPN;114;"Simane (Shimane)";"Simane (Shimane)";prefecture;32;14923
+Japan;JP;JPN;114;"Sizuoka (Shizuoka)";"Sizuoka (Shizuoka)";prefecture;22;14924
+Japan;JP;JPN;114;"Tiba (Chiba)";"Tiba (Chiba)";prefecture;12;14933
+Japan;JP;JPN;114;"Tokusima (Tokushima)";"Tokusima (Tokushima)";prefecture;36;14925
+Japan;JP;JPN;114;"Totigi (Tochigi)";"Totigi (Tochigi)";prefecture;09;14918
+Japan;JP;JPN;114;Tottori;Tottori;prefecture;31;14917
+Japan;JP;JPN;114;Toyama;Toyama;prefecture;16;14927
+Japan;JP;JPN;114;"Tôkyô (Tokyo)";"Tokyo (Tokyo)";metropolis;13;14926
+Japan;JP;JPN;114;Wakayama;Wakayama;prefecture;30;14928
+Japan;JP;JPN;114;Yamagata;Yamagata;prefecture;06;14916
+Japan;JP;JPN;114;"Yamaguti (Yamaguchi)";"Yamaguti (Yamaguchi)";prefecture;35;14929
+Japan;JP;JPN;114;"Yamanasi (Yamanashi)";"Yamanasi (Yamanashi)";prefecture;19;14930
+Japan;JP;JPN;114;"Ôita (Oita)";"Oita (Oita)";prefecture;44;14920
+Japan;JP;JPN;114;"Ôsaka (Osaka)";"Osaka (Osaka)";"urban prefecture";27;14962
+Jordan;JO;JOR;116;"Al Balqa'";"Al Balqa'";province;BA;14979
+Jordan;JO;JOR;116;"Al Karak";"Al Karak";province;KA;14984
+Jordan;JO;JOR;116;"Al Mafraq";"Al Mafraq";province;MA;14981
+Jordan;JO;JOR;116;"Al ‘Aqabah";"Al 'Aqabah";province;AQ;14985
+Jordan;JO;JOR;116;"At Tafilah";"At Tafilah";province;AT;14975
+Jordan;JO;JOR;116;"Az Zarqā'";"Az Zarqa'";province;AZ;14976
+Jordan;JO;JOR;116;Irbid;Irbid;province;IR;14986
+Jordan;JO;JOR;116;Jarash;Jarash;province;JA;14980
+Jordan;JO;JOR;116;Ma`an;Ma'an;province;MN;14977
+Jordan;JO;JOR;116;Mādabā;Madaba;province;MD;14983
+Jordan;JO;JOR;116;‘Ajlūn;'Ajlun;province;AJ;14982
+Jordan;JO;JOR;116;"‘Ammān (Al ‘A̅ şimah)";"'Amman (Al ‘A simah)";province;AM;14978
+Kazakhstan;KZ;KAZ;117;Almaty;Almaty;city;ALA;14993
+Kazakhstan;KZ;KAZ;117;"Almaty oblysy";"Almaty oblysy";region;ALM;20264
+Kazakhstan;KZ;KAZ;117;"Aqmola oblysy";"Aqmola oblysy";region;AKM;14991
+Kazakhstan;KZ;KAZ;117;"Aqtöbe oblysy";"Aqtobe oblysy";region;AKT;14992
+Kazakhstan;KZ;KAZ;117;Astana;Astana;city;AST;20265
+Kazakhstan;KZ;KAZ;117;"Atyrau oblysy";"Atyrau oblysy";region;ATY;14994
+Kazakhstan;KZ;KAZ;117;"Batys Qazaqstan oblysy";"Batys Qazaqstan oblysy";region;ZAP;14988
+Kazakhstan;KZ;KAZ;117;Bayqongyr;Bayqongyr;city;BAY;21376
+Kazakhstan;KZ;KAZ;117;"Mangghystau oblysy";"Mangghystau oblysy";region;MAN;14995
+Kazakhstan;KZ;KAZ;117;"Ongtüstik Qazaqstan oblysy";"Ongtustik Qazaqstan oblysy";region;YUZ;14999
+Kazakhstan;KZ;KAZ;117;"Pavlodar oblysy";"Pavlodar oblysy";region;PAV;14998
+Kazakhstan;KZ;KAZ;117;"Qaraghandy oblysy";"Qaraghandy oblysy";region;KAR;14997
+Kazakhstan;KZ;KAZ;117;"Qostanay oblysy";"Qostanay oblysy";region;KUS;15000
+Kazakhstan;KZ;KAZ;117;"Qyzylorda oblysy";"Qyzylorda oblysy";region;KZY;14990
+Kazakhstan;KZ;KAZ;117;"Shyghys Qazaqstan oblysy";"Shyghys Qazaqstan oblysy";region;VOS;14996
+Kazakhstan;KZ;KAZ;117;"Soltüstik Qazaqstan oblysy";"Soltustik Qazaqstan oblysy";region;SEV;14989
+Kazakhstan;KZ;KAZ;117;"Zhambyl oblysy";"Zhambyl oblysy";region;ZHA;14987
+Kenya;KE;KEN;118;Central;Central;province;200;15009
+Kenya;KE;KEN;118;Coast;Coast;province;300;15005
+Kenya;KE;KEN;118;Eastern;Eastern;province;400;15006
+Kenya;KE;KEN;118;Nairobi;Nairobi;province;110;15010
+Kenya;KE;KEN;118;North-Eastern;North-Eastern;province;500;15004
+Kenya;KE;KEN;118;Nyanza;Nyanza;province;600;15001
+Kenya;KE;KEN;118;"Rift Valley";"Rift Valley";province;700;15007
+Kenya;KE;KEN;118;Western;Western;province;900;15003
+Kiribati;KI;KIR;119;"Gilbert Islands";"Gilbert Islands";"island group";G;19016
+Kiribati;KI;KIR;119;"Line Islands";"Line Islands";"island group";L;15018
+Kiribati;KI;KIR;119;"Phoenix Islands";"Phoenix Islands";"island group";P;15033
+"Democratic People's Republic Of Korea";KP;PRK;121;Chagang-do;Chagang-do;province;04;21370
+"Democratic People's Republic Of Korea";KP;PRK;121;Chagang-do;Chagang-do;province;CHA;48098
+"Democratic People's Republic Of Korea";KP;PRK;121;Hamgyong-bukdo;Hamgyong-bukdo;province;09;21369
+"Democratic People's Republic Of Korea";KP;PRK;121;Hamgyong-namdo;Hamgyong-namdo;province;08;21368
+"Democratic People's Republic Of Korea";KP;PRK;121;Hamgyongbuk-do;Hamgyongbuk-do;province;HAB;48096
+"Democratic People's Republic Of Korea";KP;PRK;121;Hamgyongnam-do;Hamgyongnam-do;province;HAN;48095
+"Democratic People's Republic Of Korea";KP;PRK;121;Hwanghae-bukto;Hwanghae-bukto;province;06;21367
+"Democratic People's Republic Of Korea";KP;PRK;121;Hwanghae-namdo;Hwanghae-namdo;province;05;21366
+"Democratic People's Republic Of Korea";KP;PRK;121;Hwanghaebuk-do;Hwanghaebuk-do;province;HWB;48092
+"Democratic People's Republic Of Korea";KP;PRK;121;Hwanghaenam-do;Hwanghaenam-do;province;HWN;48091
+"Democratic People's Republic Of Korea";KP;PRK;121;Kaesong-si;Kaesong-si;"special city";KAE;21373
+"Democratic People's Republic Of Korea";KP;PRK;121;Kangwon-do;Kangwon-do;province;KAN;48097
+"Democratic People's Republic Of Korea";KP;PRK;121;Kangwon-do;Kangwon-do;province;07;15053
+"Democratic People's Republic Of Korea";KP;PRK;121;"Najin Sonbong-si";"Najin Sonbong-si";"special city";NAJ;21374
+"Democratic People's Republic Of Korea";KP;PRK;121;Nampo-si;Nampo-si;"special city";NAM;21375
+"Democratic People's Republic Of Korea";KP;PRK;121;Nason;Nason;"special city";13;21371
+"Democratic People's Republic Of Korea";KP;PRK;121;Pyongan-bukdo;Pyongan-bukdo;province;03;21363
+"Democratic People's Republic Of Korea";KP;PRK;121;Pyongan-namdo;Pyongan-namdo;province;02;21364
+"Democratic People's Republic Of Korea";KP;PRK;121;Pyonganbuk-do;Pyonganbuk-do;province;PYB;48093
+"Democratic People's Republic Of Korea";KP;PRK;121;Pyongannam-do;Pyongannam-do;province;PYN;48094
+"Democratic People's Republic Of Korea";KP;PRK;121;Pyongyang;Pyongyang;"capital city";01;21372
+"Democratic People's Republic Of Korea";KP;PRK;121;Pyongyang-si;Pyongyang-si;"special city";PYO;48099
+"Democratic People's Republic Of Korea";KP;PRK;121;Rason;Rason;;X1~;48089
+"Democratic People's Republic Of Korea";KP;PRK;121;Yanggang-do;Yanggang-do;province;10;21365
+"Democratic People's Republic Of Korea";KP;PRK;121;Yanggang-do;Yanggang-do;province;YAN;48090
+"Republic of Korea";KR;KOR;120;"Busan Gwang'yeogsi (Pusan-Kwangyokshi)";"Busan Gwang'yeogsi (Pusan-Kwangyokshi)";"metropolitan city";26;20247
+"Republic of Korea";KR;KOR;120;"Chungcheongbugdo (Ch'ungch'ongbuk-do)";"Chungcheongbugdo (Ch'ungch'ongbuk-do)";province;43;20255
+"Republic of Korea";KR;KOR;120;"Chungcheongnamdo (Ch'ungch'ongnam-do)";"Chungcheongnamdo (Ch'ungch'ongnam-do)";province;44;20256
+"Republic of Korea";KR;KOR;120;"Daegu Gwang'yeogsi (Taegu-Kwangyokshi)";"Daegu Gwang'yeogsi (Taegu-Kwangyokshi)";"metropolitan city";27;20248
+"Republic of Korea";KR;KOR;120;"Daejeon Gwang'yeogsi (Taejon-Kwangyokshi)";"Daejeon Gwang'yeogsi (Taejon-Kwangyokshi)";"metropolitan city";30;20251
+"Republic of Korea";KR;KOR;120;"Gang'weondo (Kang-won-do)";"Gang'weondo (Kang-won-do)";province;42;15042
+"Republic of Korea";KR;KOR;120;"Gwangju Gwang'yeogsi (Kwangju-Kwangyokshi)";"Gwangju Gwang'yeogsi (Kwangju-Kwangyokshi)";"metropolitan city";29;20250
+"Republic of Korea";KR;KOR;120;"Gyeonggido (Kyonggi-do)";"Gyeonggido (Kyonggi-do)";province;41;20253
+"Republic of Korea";KR;KOR;120;"Gyeongsangbugdo (Kyongsangbuk-do)";"Gyeongsangbugdo (Kyongsangbuk-do)";province;47;20259
+"Republic of Korea";KR;KOR;120;"Gyeongsangnamdo (Kyongsangnam-do)";"Gyeongsangnamdo (Kyongsangnam-do)";province;48;20260
+"Republic of Korea";KR;KOR;120;"Incheon Gwang'yeogsi (Inch'n-Kwangyokshi)";"Incheon Gwang'yeogsi (Inch'n-Kwangyokshi)";"metropolitan city";28;20249
+"Republic of Korea";KR;KOR;120;"Jejudo (Cheju-do)";"Jejudo (Cheju-do)";province;49;20261
+"Republic of Korea";KR;KOR;120;Jeonrabugdo(Chollabuk-do);Jeonrabugdo(Chollabuk-do);province;45;20257
+"Republic of Korea";KR;KOR;120;"Jeonranamdo (Chollanam-do)";"Jeonranamdo (Chollanam-do)";province;46;20258
+"Republic of Korea";KR;KOR;120;"Seoul Teugbyeolsi (Seoul-T'ukpyolshi)";"Seoul Teugbyeolsi (Seoul-T'ukpyolshi)";"capital metropolitan city";11;20246
+"Republic of Korea";KR;KOR;120;"Ulsan Gwang'yeogsi (Ulsan-Kwangyokshi)";"Ulsan Gwang'yeogsi (Ulsan-Kwangyokshi)";"metropolitan city";31;20252
+Kuwait;KW;KWT;122;"Al Ahmadi";"Al Ahmadi";governorate;AH;15064
+Kuwait;KW;KWT;122;"Al Farwaniyah";"Al Farwaniyah";governorate;FA;15068
+Kuwait;KW;KWT;122;"Al Jahrah";"Al Jahrah";governorate;JA;15063
+Kuwait;KW;KWT;122;"Al Kuwayt (Al ‘Āşimah)";"Al Kuwayt (Al 'Asimah)";governorate;KU;15066
+Kuwait;KW;KWT;122;Hawalli;Hawalli;governorate;HA;15067
+Kuwait;KW;KWT;122;"Mubarak al-Kabir";"Mubarak al-Kabir";governorate;MU;15065
+Kyrgyzstan;KG;KGZ;123;Batken;Batken;region;B;15070
+Kyrgyzstan;KG;KGZ;123;Bishkek;Bishkek;city;GB;15072
+Kyrgyzstan;KG;KGZ;123;Chü;Chu;region;C;15078
+Kyrgyzstan;KG;KGZ;123;Jalal-Abad;Jalal-Abad;region;J;15077
+Kyrgyzstan;KG;KGZ;123;Naryn;Naryn;region;N;15071
+Kyrgyzstan;KG;KGZ;123;Osh;Osh;region;O;15069
+Kyrgyzstan;KG;KGZ;123;Talas;Talas;region;T;15075
+Kyrgyzstan;KG;KGZ;123;Ysyk-Köl;Ysyk-Kol;region;Y;15074
+"Lao People's Democratic Republic";LA;LAO;124;"Attapu (Attopeu)";"Attapu (Attopeu)";province;AT;15080
+"Lao People's Democratic Republic";LA;LAO;124;Bokèo;Bokeo;province;BK;15081
+"Lao People's Democratic Republic";LA;LAO;124;"Bolikhamxai (Borikhane)";"Bolikhamxai (Borikhane)";province;BL;15089
+"Lao People's Democratic Republic";LA;LAO;124;"Champasak (Champassak)";"Champasak (Champassak)";province;CH;15082
+"Lao People's Democratic Republic";LA;LAO;124;Houaphan;Houaphan;province;HO;15093
+"Lao People's Democratic Republic";LA;LAO;124;Khammouan;Khammouan;province;KH;15094
+"Lao People's Democratic Republic";LA;LAO;124;"Louang Namtha";"Louang Namtha";province;LM;15083
+"Lao People's Democratic Republic";LA;LAO;124;"Louangphabang (Louang Prabang)";"Louangphabang (Louang Prabang)";province;LP;15092
+"Lao People's Democratic Republic";LA;LAO;124;"Oudômxai (Oudomsai)";"Oudomxai (Oudomsai)";province;OU;15084
+"Lao People's Democratic Republic";LA;LAO;124;"Phôngsali (Phong Saly)";"Phongsali (Phong Saly)";province;PH;15085
+"Lao People's Democratic Republic";LA;LAO;124;"Salavan (Saravane)";"Salavan (Saravane)";province;SL;15091
+"Lao People's Democratic Republic";LA;LAO;124;Savannakhét;Savannakhet;province;SV;15086
+"Lao People's Democratic Republic";LA;LAO;124;Vientiane;Vientiane;province;VI;15095
+"Lao People's Democratic Republic";LA;LAO;124;"Vientiane Prefecture";"Vientiane Prefecture";prefecture;VT;15087
+"Lao People's Democratic Republic";LA;LAO;124;"Xaignabouli (Sayaboury)";"Xaignabouli (Sayaboury)";province;XA;15088
+"Lao People's Democratic Republic";LA;LAO;124;Xaisômboun;Xaisomboun;"special zone";XN;15096
+"Lao People's Democratic Republic";LA;LAO;124;"Xiangkhoang (Xieng Khouang)";"Xiangkhoang (Xieng Khouang)";province;XI;15079
+"Lao People's Democratic Republic";LA;LAO;124;"Xékong (Sékong)";"Xekong (Sekong)";province;XE;15090
+Latvia;LV;LVA;125;"Aglonas novads (Aglona)";"Aglonas novads (Aglona)";district;001;48896
+Latvia;LV;LVA;125;"Aizkraukles Aprinkis";"Aizkraukles Aprinkis";district;AI;15106
+Latvia;LV;LVA;125;"Aizkraukles novads (Aizkraukle)";"Aizkraukles novads (Aizkraukle)";district;002;48728
+Latvia;LV;LVA;125;"Aizputes novads (Aizpute)";"Aizputes novads (Aizpute)";district;003;48729
+Latvia;LV;LVA;125;"Aknīstes novads (Aknīste)";"Aknistes novads (Akniste)";district;004;48730
+Latvia;LV;LVA;125;"Alojas novads (Aloja)";"Alojas novads (Aloja)";district;005;48731
+Latvia;LV;LVA;125;"Alsungas novads (Alsunga)";"Alsungas novads (Alsunga)";district;006;48732
+Latvia;LV;LVA;125;"Aluksnes Aprinkis";"Aluksnes Aprinkis";district;AL;15107
+Latvia;LV;LVA;125;"Alūksnes novads (Alūksne)";"Aluksnes novads (Aluksne)";district;007;48733
+Latvia;LV;LVA;125;"Amatas novads (Amata)";"Amatas novads (Amata)";district;008;48734
+Latvia;LV;LVA;125;"Apes novads (Ape)";"Apes novads (Ape)";district;009;48735
+Latvia;LV;LVA;125;"Auces novads (Auce)";"Auces novads (Auce)";district;010;48736
+Latvia;LV;LVA;125;"Babītes novads (Babīte)";"Babites novads (Babite)";district;012;48738
+Latvia;LV;LVA;125;"Baldones novads (Baldone)";"Baldones novads (Baldone)";district;013;48739
+Latvia;LV;LVA;125;"Baltinavas novads (Baltinava)";"Baltinavas novads (Baltinava)";district;014;48740
+Latvia;LV;LVA;125;"Balvu Aprinkis";"Balvu Aprinkis";district;BL;15108
+Latvia;LV;LVA;125;"Balvu novads (Balvi)";"Balvu novads (Balvi)";district;015;48741
+Latvia;LV;LVA;125;"Bauskas Aprinkis";"Bauskas Aprinkis";district;BU;15109
+Latvia;LV;LVA;125;"Bauskas novads (Bauska)";"Bauskas novads (Bauska)";district;016;48742
+Latvia;LV;LVA;125;"Beverīnas novads (Beverīna)";"Beverinas novads (Beverina)";district;017;48743
+Latvia;LV;LVA;125;"Brocēnu novads (Brocēni)";"Brocenu novads (Broceni)";district;018;48744
+Latvia;LV;LVA;125;"Burtnieku novads (Burtnieki)";"Burtnieku novads (Burtnieki)";district;019;48745
+Latvia;LV;LVA;125;"Carnikavas novads (Carnikava)";"Carnikavas novads (Carnikava)";district;020;48746
+Latvia;LV;LVA;125;"Cesu Aprinkis";"Cesu Aprinkis";district;CE;15110
+Latvia;LV;LVA;125;"Cesvaines novads (Cesvaine)";"Cesvaines novads (Cesvaine)";district;021;48747
+Latvia;LV;LVA;125;"Ciblas novads (Cibla)";"Ciblas novads (Cibla)";district;023;48749
+Latvia;LV;LVA;125;"Cēsu novads (Cēsis)";"Cesu novads (Cesis)";district;022;48748
+Latvia;LV;LVA;125;"Dagdas novads (Dagda)";"Dagdas novads (Dagda)";district;024;48750
+Latvia;LV;LVA;125;Daugavpils;Daugavpils;city;DGV;15111
+Latvia;LV;LVA;125;"Daugavpils Aprinkis";"Daugavpils Aprinkis";district;DA;15112
+Latvia;LV;LVA;125;"Daugavpils novads (Daugavpils)";"Daugavpils novads (Daugavpils)";district;025;48751
+Latvia;LV;LVA;125;"Dobeles Aprinkis";"Dobeles Aprinkis";district;DO;15113
+Latvia;LV;LVA;125;"Dobeles novads (Dobele)";"Dobeles novads (Dobele)";district;026;48752
+Latvia;LV;LVA;125;"Dundagas novads (Dundaga)";"Dundagas novads (Dundaga)";district;027;48753
+Latvia;LV;LVA;125;"Durbes novads (Durbe)";"Durbes novads (Durbe)";district;028;48754
+Latvia;LV;LVA;125;"Engures novads (Engure)";"Engures novads (Engure)";district;029;48755
+Latvia;LV;LVA;125;"Garkalnes novads (Garkalne)";"Garkalnes novads (Garkalne)";district;031;48757
+Latvia;LV;LVA;125;"Grobiņas novads (Grobiņa)";"Grobinas novads (Grobina)";district;032;48758
+Latvia;LV;LVA;125;"Gulbenes Aprinkis";"Gulbenes Aprinkis";district;GU;15124
+Latvia;LV;LVA;125;"Gulbenes novads (Gulbene)";"Gulbenes novads (Gulbene)";district;033;48759
+Latvia;LV;LVA;125;"Iecavas novads (Iecava)";"Iecavas novads (Iecava)";district;034;48760
+Latvia;LV;LVA;125;"Ikšķiles novads (Ikšķile)";"Ikskiles novads (Ikskile)";district;035;48761
+Latvia;LV;LVA;125;"Ilūkstes novads (Ilūkste)";"Ilukstes novads (Ilukste)";district;036;48762
+Latvia;LV;LVA;125;"Inčukalna novads (Inčukalns)";"Incukalna novads (Incukalns)";district;037;48763
+Latvia;LV;LVA;125;"Jaunjelgavas novads (Jaunjelgava)";"Jaunjelgavas novads (Jaunjelgava)";district;038;48764
+Latvia;LV;LVA;125;"Jaunpiebalgas novads (Jaunpiebalga)";"Jaunpiebalgas novads (Jaunpiebalga)";district;039;48765
+Latvia;LV;LVA;125;"Jaunpils novads (Jaunpils)";"Jaunpils novads (Jaunpils)";district;040;48766
+Latvia;LV;LVA;125;"Jekabpils Aprinkis";"Jekabpils Aprinkis";district;JK;15114
+Latvia;LV;LVA;125;Jelgava;Jelgava;city;JEL;15125
+Latvia;LV;LVA;125;"Jelgavas Aprinkis";"Jelgavas Aprinkis";district;JL;15126
+Latvia;LV;LVA;125;"Jelgavas novads (Jelgava)";"Jelgavas novads (Jelgava)";district;041;48767
+Latvia;LV;LVA;125;Jurmala;Jurmala;city;JUR;15127
+Latvia;LV;LVA;125;Jēkabpils;Jekabpils;city;JKB;48838
+Latvia;LV;LVA;125;"Jēkabpils novads (Jēkabpils)";"Jekabpils novads (Jekabpils)";district;042;48768
+Latvia;LV;LVA;125;"Kandavas novads (Kandava)";"Kandavas novads (Kandava)";district;043;48769
+Latvia;LV;LVA;125;"Kocēnu novads";"Kocenu novads";district;045;48771
+Latvia;LV;LVA;125;"Kokneses novads (Koknese)";"Kokneses novads (Koknese)";district;046;48772
+Latvia;LV;LVA;125;"Kraslavas Aprinkis";"Kraslavas Aprinkis";district;KR;15115
+Latvia;LV;LVA;125;"Krimuldas novads (Krimulda)";"Krimuldas novads (Krimulda)";district;048;48774
+Latvia;LV;LVA;125;"Krustpils novads (Krustpils)";"Krustpils novads (Krustpils)";district;049;48775
+Latvia;LV;LVA;125;"Krāslavas novads (Krāslava)";"Kraslavas novads (Kraslava)";district;047;48773
+Latvia;LV;LVA;125;"Kuldigas Aprinkis";"Kuldigas Aprinkis";district;KU;15116
+Latvia;LV;LVA;125;"Kuldīgas novads (Kuldīga)";"Kuldigas novads (Kuldiga)";district;050;48776
+Latvia;LV;LVA;125;"Kārsavas novads (Kārsava)";"Karsavas novads (Karsava)";district;044;48770
+Latvia;LV;LVA;125;"Lielvārdes novads (Lielvārde)";"Lielvardes novads (Lielvarde)";district;053;48779
+Latvia;LV;LVA;125;Liepaja;Liepaja;city;LPX;15128
+Latvia;LV;LVA;125;"Liepajas Aprinkis";"Liepajas Aprinkis";district;LE;15117
+Latvia;LV;LVA;125;"Limbažu Aprinkis";"Limbazu Aprinkis";district;LM;15118
+Latvia;LV;LVA;125;"Limbažu novads (Limbaži)";"Limbazu novads (Limbazi)";district;054;48781
+Latvia;LV;LVA;125;"Lubānas novads (Lubāna)";"Lubanas novads (Lubana)";district;057;48784
+Latvia;LV;LVA;125;"Ludzas Aprinkis";"Ludzas Aprinkis";district;LU;15123
+Latvia;LV;LVA;125;"Ludzas novads (Ludza)";"Ludzas novads (Ludza)";district;058;48785
+Latvia;LV;LVA;125;"Līgatnes novads (Līgatne)";"Ligatnes novads (Ligatne)";district;055;48782
+Latvia;LV;LVA;125;"Līvānu novads (Līvāni)";"Livanu novads (Livani)";district;056;48783
+Latvia;LV;LVA;125;"Madonas Aprinkis";"Madonas Aprinkis";district;MA;15119
+Latvia;LV;LVA;125;"Madonas novads (Madona)";"Madonas novads (Madona)";district;059;48786
+Latvia;LV;LVA;125;"Mazsalacas novads (Mazsalaca)";"Mazsalacas novads (Mazsalaca)";district;060;48787
+Latvia;LV;LVA;125;"Mālpils novads (Mālpils)";"Malpils novads (Malpils)";district;061;48788
+Latvia;LV;LVA;125;"Mārupes novads (Mārupe)";"Marupes novads (Marupe)";district;062;48789
+Latvia;LV;LVA;125;"Mērsraga novads";"Mersraga novads";district;063;48790
+Latvia;LV;LVA;125;"Naukšēnu novads (Naukšēni)";"Nauksenu novads (Naukseni)";district;064;48791
+Latvia;LV;LVA;125;"Neretas novads (Nereta)";"Neretas novads (Nereta)";district;065;48792
+Latvia;LV;LVA;125;"Nīcas novads (Nīca)";"Nicas novads (Nica)";district;066;48793
+Latvia;LV;LVA;125;"Ogres Aprinkis";"Ogres Aprinkis";district;OG;15098
+Latvia;LV;LVA;125;"Ogres novads (Ogre)";"Ogres novads (Ogre)";district;067;48794
+Latvia;LV;LVA;125;"Olaines novads (Olaine)";"Olaines novads (Olaine)";district;068;48795
+Latvia;LV;LVA;125;"Ozolnieku novads (Ozolnieki)";"Ozolnieku novads (Ozolnieki)";district;069;48796
+Latvia;LV;LVA;125;"Preilu Aprinkis";"Preilu Aprinkis";district;PR;15122
+Latvia;LV;LVA;125;"Preiļu novads (Preiļi)";"Preilu novads (Preili)";district;073;48800
+Latvia;LV;LVA;125;"Priekules novads (Priekule)";"Priekules novads (Priekule)";district;074;48801
+Latvia;LV;LVA;125;"Priekuļu novads (Priekuļi)";"Priekulu novads (Priekuli)";district;075;48802
+Latvia;LV;LVA;125;"Pārgaujas novads (Pārgauja)";"Pargaujas novads (Pargauja)";district;070;48797
+Latvia;LV;LVA;125;"Pāvilostas novads (Pāvilosta)";"Pavilostas novads (Pavilosta)";district;071;48798
+Latvia;LV;LVA;125;"Pļaviņu novads (Pļaviņas)";"Plavinu novads (Plavinas)";district;072;48799
+Latvia;LV;LVA;125;"Raunas novads (Rauna)";"Raunas novads (Rauna)";district;076;48803
+Latvia;LV;LVA;125;Rezekne;Rezekne;city;REZ;15099
+Latvia;LV;LVA;125;"Rezeknes Aprinkis";"Rezeknes Aprinkis";district;RE;15100
+Latvia;LV;LVA;125;"Riebiņu novads (Riebiņi)";"Riebinu novads (Riebini)";district;078;48805
+Latvia;LV;LVA;125;Riga;Riga;city;RIX;15121
+Latvia;LV;LVA;125;"Rigas Aprinkis";"Rigas Aprinkis";district;RI;15101
+Latvia;LV;LVA;125;"Rojas novads (Roja)";"Rojas novads (Roja)";district;079;48806
+Latvia;LV;LVA;125;"Ropažu novads (Ropaži)";"Ropazu novads (Ropazi)";district;080;48807
+Latvia;LV;LVA;125;"Rucavas novads (Rucava)";"Rucavas novads (Rucava)";district;081;48808
+Latvia;LV;LVA;125;"Rugāju novads (Rugāji)";"Rugaju novads (Rugaji)";district;082;48809
+Latvia;LV;LVA;125;"Rundāles novads (Rundāle)";"Rundales novads (Rundale)";district;083;48810
+Latvia;LV;LVA;125;"Rēzeknes novads (Rēzekne)";"Rezeknes novads (Rezekne)";district;077;48804
+Latvia;LV;LVA;125;"Rūjienas novads (Rūjiena)";"Rujienas novads (Rujiena)";district;084;48811
+Latvia;LV;LVA;125;"Salacgrīvas novads (Salacgrīva)";"Salacgrivas novads (Salacgriva)";district;086;48813
+Latvia;LV;LVA;125;"Salas novads (Sala)";"Salas novads (Sala)";district;085;48812
+Latvia;LV;LVA;125;"Salaspils novads (Salaspils)";"Salaspils novads (Salaspils)";district;087;48814
+Latvia;LV;LVA;125;"Saldus Aprinkis";"Saldus Aprinkis";district;SA;15102
+Latvia;LV;LVA;125;"Saldus novads (Saldus)";"Saldus novads (Saldus)";district;088;48815
+Latvia;LV;LVA;125;"Saulkrastu novads (Saulkrasti)";"Saulkrastu novads (Saulkrasti)";district;089;48816
+Latvia;LV;LVA;125;"Siguldas novads (Sigulda)";"Siguldas novads (Sigulda)";district;091;48818
+Latvia;LV;LVA;125;"Skrundas novads (Skrunda)";"Skrundas novads (Skrunda)";district;093;48820
+Latvia;LV;LVA;125;"Skrīveru novads (Skrīveri)";"Skriveru novads (Skriveri)";district;092;48819
+Latvia;LV;LVA;125;"Smiltenes novads (Smiltene)";"Smiltenes novads (Smiltene)";district;094;48821
+Latvia;LV;LVA;125;"Stopiņu novads (Stopiņi)";"Stopinu novads (Stopini)";district;095;48822
+Latvia;LV;LVA;125;"Strenču novads (Strenči)";"Strencu novads (Strenci)";district;096;48823
+Latvia;LV;LVA;125;"Sējas novads (Sēja)";"Sejas novads (Seja)";district;090;48817
+Latvia;LV;LVA;125;"Talsu Aprinkis";"Talsu Aprinkis";district;TA;15129
+Latvia;LV;LVA;125;"Talsu novads (Talsi)";"Talsu novads (Talsi)";district;097;48824
+Latvia;LV;LVA;125;"Tukuma Aprinkis";"Tukuma Aprinkis";district;TU;15103
+Latvia;LV;LVA;125;"Tukuma novads (Tukums)";"Tukuma novads (Tukums)";district;099;48826
+Latvia;LV;LVA;125;"Tērvetes novads (Tērvete)";"Tervetes novads (Tervete)";district;098;48825
+Latvia;LV;LVA;125;"Vaiņodes novads (Vaiņode)";"Vainodes novads (Vainode)";district;100;48827
+Latvia;LV;LVA;125;"Valkas Aprinkis";"Valkas Aprinkis";district;VK;15104
+Latvia;LV;LVA;125;"Valkas novads (Valka)";"Valkas novads (Valka)";district;101;48828
+Latvia;LV;LVA;125;Valmiera;Valmiera;city;VMR;48839
+Latvia;LV;LVA;125;"Valmieras Aprinkis";"Valmieras Aprinkis";district;VM;15130
+Latvia;LV;LVA;125;"Varakļānu novads (Varakļāni)";"Varaklanu novads (Varaklani)";district;102;48829
+Latvia;LV;LVA;125;"Vecpiebalgas novads (Vecpiebalga)";"Vecpiebalgas novads (Vecpiebalga)";district;104;48831
+Latvia;LV;LVA;125;"Vecumnieku novads (Vecumnieki)";"Vecumnieku novads (Vecumnieki)";district;105;48832
+Latvia;LV;LVA;125;Ventspils;Ventspils;city;VEN;15105
+Latvia;LV;LVA;125;"Ventspils Aprinkis";"Ventspils Aprinkis";district;VE;15097
+Latvia;LV;LVA;125;"Ventspils novads (Ventspils)";"Ventspils novads (Ventspils)";district;106;48833
+Latvia;LV;LVA;125;"Viesītes novads (Viesīte)";"Viesites novads (Viesite)";district;107;48834
+Latvia;LV;LVA;125;"Viļakas novads (Viļaka)";"Vilakas novads (Vilaka)";district;108;48835
+Latvia;LV;LVA;125;"Viļānu novads (Viļāni)";"Vilanu novads (Vilani)";district;109;48836
+Latvia;LV;LVA;125;"Vārkavas novads (Vārkava)";"Varkavas novads (Varkava)";district;103;48830
+Latvia;LV;LVA;125;"Zilupes novads (Zilupe)";"Zilupes novads (Zilupe)";district;110;48837
+Latvia;LV;LVA;125;"Ādažu novads (Ādaži)";"Adazu novads (Adazi)";district;011;48737
+Latvia;LV;LVA;125;"Ērgļu novads (Ērgļi)";"Erglu novads (Ergli)";district;030;48756
+Latvia;LV;LVA;125;"Ķeguma novads (Ķegums)";"keguma novads (kegums)";district;051;48777
+Latvia;LV;LVA;125;"Ķekavas novads (Ķekava)";"kekavas novads (kekava)";district;052;48778
+Lebanon;LB;LBN;126;Aakkar;Aakkar;province;AK;48255
+Lebanon;LB;LBN;126;Baalbek-Hermel;Baalbek-Hermel;province;BH;48256
+Lebanon;LB;LBN;126;Beirut;Beirut;province;BA;15134
+Lebanon;LB;LBN;126;"El Béqaa";"El Beqaa";province;BI;15135
+Lebanon;LB;LBN;126;"Jabal Loubnâne";"Jabal Loubnane";province;JL;15133
+Lebanon;LB;LBN;126;"Loubnâne ech Chemâli";"Loubnane ech Chemali";province;AS;15131
+Lebanon;LB;LBN;126;"Loubnâne ej Jnoûbi";"Loubnane ej Jnoubi";province;JA;15136
+Lebanon;LB;LBN;126;Nabatîyé;Nabatiye;province;NA;15132
+Lesotho;LS;LSO;127;Berea;Berea;district;D;15138
+Lesotho;LS;LSO;127;Butha-Buthe;Butha-Buthe;district;B;15139
+Lesotho;LS;LSO;127;Leribe;Leribe;district;C;15145
+Lesotho;LS;LSO;127;Mafeteng;Mafeteng;district;E;15140
+Lesotho;LS;LSO;127;Maseru;Maseru;district;A;15146
+Lesotho;LS;LSO;127;"Mohale's Hoek";"Mohale's Hoek";district;F;15141
+Lesotho;LS;LSO;127;Mokhotlong;Mokhotlong;district;J;15142
+Lesotho;LS;LSO;127;"Qacha's Nek";"Qacha's Nek";district;H;15137
+Lesotho;LS;LSO;127;Quthing;Quthing;district;G;15143
+Lesotho;LS;LSO;127;Thaba-Tseka;Thaba-Tseka;district;K;15144
+Liberia;LR;LBR;128;Bomi;Bomi;county;BM;15152
+Liberia;LR;LBR;128;Bong;Bong;county;BG;15148
+Liberia;LR;LBR;128;Gbarpolu;Gbarpolu;county;X1~;19021
+Liberia;LR;LBR;128;"Grand Bassa";"Grand Bassa";county;GB;15153
+Liberia;LR;LBR;128;"Grand Cape Mount";"Grand Cape Mount";county;CM;15156
+Liberia;LR;LBR;128;"Grand Gedeh";"Grand Gedeh";county;GG;15151
+Liberia;LR;LBR;128;"Grand Kru";"Grand Kru";county;GK;19023
+Liberia;LR;LBR;128;Lofa;Lofa;county;LO;15154
+Liberia;LR;LBR;128;Margibi;Margibi;county;MG;15158
+Liberia;LR;LBR;128;Maryland;Maryland;county;MY;15150
+Liberia;LR;LBR;128;Montserrado;Montserrado;county;MO;15157
+Liberia;LR;LBR;128;Nimba;Nimba;county;NI;15155
+Liberia;LR;LBR;128;"River Gee";"River Gee";county;X2~;19022
+Liberia;LR;LBR;128;Rivercess;Rivercess;county;RI;15149
+Liberia;LR;LBR;128;Sinoe;Sinoe;county;SI;15147
+Libya;LY;LBY;129;Ajdabiya;Ajdabiya;;AJ;15169
+Libya;LY;LBY;129;"Al ?izam al Akh?ar";"Al izam al Akhar";;HZ;15180
+Libya;LY;LBY;129;"Al Butnan";"Al Butnan";popularate;BU;15171
+Libya;LY;LBY;129;"Al Jabal al Akh?ar";"Al Jabal al Akhar";popularate;JA;15174
+Libya;LY;LBY;129;"Al Jabal al Gharbī";"Al Jabal al Gharbi";popularate;JG;48229
+Libya;LY;LBY;129;"Al Jifarah";"Al Jifarah";popularate;JI;15181
+Libya;LY;LBY;129;"Al Jufrah";"Al Jufrah";popularate;JU;15175
+Libya;LY;LBY;129;"Al Kufrah";"Al Kufrah";popularate;KF;15176
+Libya;LY;LBY;129;"Al Marj";"Al Marj";popularate;MJ;15182
+Libya;LY;LBY;129;"Al Marqab";"Al Marqab";popularate;MB;15160
+Libya;LY;LBY;129;"Al Qatrun";"Al Qatrun";;QT;20297
+Libya;LY;LBY;129;"Al Qubbah";"Al Qubbah";;QB;15163
+Libya;LY;LBY;129;"Al Wāḩāt";"Al Wahat";popularate;WA;15167
+Libya;LY;LBY;129;"An Nuqat al Khams";"An Nuqat al Khams";popularate;NQ;15185
+Libya;LY;LBY;129;"Ash Shati'";"Ash Shati'";district;SH;15189
+Libya;LY;LBY;129;"Az Zawiyah";"Az Zawiyah";popularate;ZA;15168
+Libya;LY;LBY;129;Banghazi;Banghazi;popularate;BA;15177
+Libya;LY;LBY;129;"Bani Walid";"Bani Walid";;BW;15170
+Libya;LY;LBY;129;Darnah;Darnah;popularate;DR;15178
+Libya;LY;LBY;129;Ghadamis;Ghadamis;;GD;15172
+Libya;LY;LBY;129;Gharyan;Gharyan;;GR;15179
+Libya;LY;LBY;129;Ghat;Ghat;popularate;GT;15173
+Libya;LY;LBY;129;Jaghbub;Jaghbub;;JB;20286
+Libya;LY;LBY;129;Misratah;Misratah;popularate;MI;15161
+Libya;LY;LBY;129;Mizdah;Mizdah;;MZ;15187
+Libya;LY;LBY;129;Murzuq;Murzuq;popularate;MQ;15186
+Libya;LY;LBY;129;Nalut;Nalut;popularate;NL;15162
+Libya;LY;LBY;129;Sabha;Sabha;popularate;SB;15184
+Libya;LY;LBY;129;"Sabratah Surman";"Sabratah Surman";;SS;15164
+Libya;LY;LBY;129;Surt;Surt;popularate;SR;15183
+Libya;LY;LBY;129;"Tajura' wa an Nawahi Arba";"Tajura' wa an Nawahi Arba";;TN;20303
+Libya;LY;LBY;129;Tarabulus;Tarabulus;popularate;TB;15165
+Libya;LY;LBY;129;Tarhunah-Masallatah;Tarhunah-Masallatah;;TM;15188
+Libya;LY;LBY;129;"Wadi al ?ayat";"Wadi al ayat";popularate;WD;15166
+Libya;LY;LBY;129;"Wādī ash Shāţiʾ";"Wadi ash Shati'";popularate;WS;48230
+Libya;LY;LBY;129;Yafran-Jadu;Yafran-Jadu;;YJ;15159
+Liechtenstein;LI;LIE;130;Balzers;Balzers;commune;01;15193
+Liechtenstein;LI;LIE;130;Eschen;Eschen;commune;02;15194
+Liechtenstein;LI;LIE;130;Gamprin;Gamprin;commune;03;15192
+Liechtenstein;LI;LIE;130;Mauren;Mauren;commune;04;15195
+Liechtenstein;LI;LIE;130;Planken;Planken;commune;05;15196
+Liechtenstein;LI;LIE;130;Ruggell;Ruggell;commune;06;15191
+Liechtenstein;LI;LIE;130;Schaan;Schaan;commune;07;15197
+Liechtenstein;LI;LIE;130;Schellenberg;Schellenberg;commune;08;15200
+Liechtenstein;LI;LIE;130;Triesen;Triesen;commune;09;15198
+Liechtenstein;LI;LIE;130;Triesenberg;Triesenberg;commune;10;15199
+Liechtenstein;LI;LIE;130;Vaduz;Vaduz;commune;11;15190
+Lithuania;LT;LTU;131;"Alytaus Apskritis";"Alytaus Apskritis";county;AL;15209
+Lithuania;LT;LTU;131;"Kauno Apskritis";"Kauno Apskritis";county;KU;15205
+Lithuania;LT;LTU;131;"Klaipedos Apskritis";"Klaipedos Apskritis";county;KL;15208
+Lithuania;LT;LTU;131;"Marijampoles Apskritis";"Marijampoles Apskritis";county;MR;15206
+Lithuania;LT;LTU;131;"Panevežio Apskritis";"Panevezio Apskritis";county;PN;15202
+Lithuania;LT;LTU;131;"Taurages Apskritis";"Taurages Apskritis";county;TA;15210
+Lithuania;LT;LTU;131;"Telšiu Apskritis";"Telsiu Apskritis";county;TE;15207
+Lithuania;LT;LTU;131;"Utenos Apskritis";"Utenos Apskritis";county;UT;15203
+Lithuania;LT;LTU;131;"Vilniaus Apskritis";"Vilniaus Apskritis";county;VL;15201
+Lithuania;LT;LTU;131;"Šiauliu Apskritis";"Siauliu Apskritis";county;SA;15204
+Luxembourg;LU;LUX;132;Diekirch;Diekirch;district;D;15216
+Luxembourg;LU;LUX;132;Grevenmacher;Grevenmacher;district;G;15215
+Luxembourg;LU;LUX;132;"Luxembourg (fr)";"Luxembourg (fr)";district;L;15220
+Macao;MO;MAC;133;Ilhas;Ilhas;;I;48266
+Macao;MO;MAC;133;Macau;Macau;;M;48267
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Aerodrom;Aerodrom;municipality;01;48906
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Aerodrom *";"Aerodrom ";municipality;AD;20121
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Aracinovo;Aracinovo;municipality;AR;20122
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Aračinovo;Aracinovo;municipality;02;48907
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Berovo;Berovo;municipality;BR;15224
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Berovo;Berovo;municipality;03;48908
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bitola;Bitola;municipality;04;48909
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bitola;Bitola;municipality;TL;15225
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bogdanci;Bogdanci;municipality;05;48910
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bogdanci;Bogdanci;municipality;BG;20123
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bogovinje;Bogovinje;municipality;06;48911
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bogovinje;Bogovinje;municipality;VJ;20124
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bosilovo;Bosilovo;municipality;BS;20125
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Bosilovo;Bosilovo;municipality;07;48912
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Brvenica;Brvenica;municipality;BN;20126
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Brvenica;Brvenica;municipality;08;48913
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Butel;Butel;municipality;09;48914
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Butel *";"Butel ";municipality;BU;20127
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Cair *";"Cair ";municipality;CI;20128
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Caška;Caska;municipality;CA;20129
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Centar;Centar;municipality;77;48915
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Centar *";"Centar ";municipality;CE;20130
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Centar Župa";"Centar Zupa";municipality;CZ;20131
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Centar Župa";"Centar Zupa";municipality;78;48916
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Cešinovo-Obleševo;Cesinovo-Oblesevo;municipality;CH;20132
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Cucer Sandevo";"Cucer Sandevo";municipality;CS;20133
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Debar;Debar;municipality;DB;15227
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Debar;Debar;municipality;21;48921
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Debarca;Debarca;municipality;22;48922
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Debarca;Debarca;municipality;DA;20138
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Delcevo;Delcevo;municipality;DL;15228
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Delčevo;Delcevo;municipality;23;48923
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Hisar";"Demir Hisar";municipality;25;48924
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Hisar";"Demir Hisar";municipality;DM;15229
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Kapija";"Demir Kapija";municipality;DK;20134
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Demir Kapija";"Demir Kapija";municipality;24;48925
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Dojran;Dojran;municipality;SD;20135
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Dojran;Dojran;municipality;26;48926
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Dolneni;Dolneni;municipality;27;48927
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Dolneni;Dolneni;municipality;DE;20136
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Drugovo;Drugovo;municipality;DR;20137
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Drugovo;Drugovo;municipality;28;48928
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gazi Baba";"Gazi Baba";municipality;17;48929
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gazi Baba *";"Gazi Baba ";municipality;GB;20310
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Gevgelija;Gevgelija;municipality;18;48930
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Gevgelija;Gevgelija;municipality;GV;15230
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gjorce Petrov *";"Gjorce Petrov ";municipality;GP;20311
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Gjorče Petrov";"Gjorce Petrov";municipality;29;48931
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Gostivar;Gostivar;municipality;19;48932
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Gostivar;Gostivar;municipality;GT;15233
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Gradsko;Gradsko;municipality;GR;20312
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Gradsko;Gradsko;municipality;20;48933
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Ilinden;Ilinden;municipality;IL;20313
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Ilinden;Ilinden;municipality;34;48934
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Jegunovce;Jegunovce;municipality;JG;20314
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Jegunovce;Jegunovce;municipality;35;48935
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Karbinci;Karbinci;municipality;37;48936
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Karbinci;Karbinci;municipality;KB;20315
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Karpoš;Karpos;municipality;38;48937
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Karpoš *";"Karpos ";municipality;KX;20316
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kavadarci;Kavadarci;municipality;36;48938
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kavadarci;Kavadarci;municipality;AV;15231
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kicevo;Kicevo;municipality;KH;15234
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kisela Voda";"Kisela Voda";municipality;39;48940
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kisela Voda *";"Kisela Voda ";municipality;VD;20139
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kičevo;Kicevo;municipality;40;48939
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kocani;Kocani;municipality;OC;15232
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Konce;Konce;municipality;KN;20140
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Konče;Konce;municipality;41;48942
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kočani;Kocani;municipality;42;48941
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kratovo;Kratovo;municipality;43;48943
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kratovo;Kratovo;municipality;KY;15235
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kriva Palanka";"Kriva Palanka";municipality;KZ;15249
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Kriva Palanka";"Kriva Palanka";municipality;44;48944
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Krivogaštani;Krivogastani;municipality;45;48945
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Krivogaštani;Krivogastani;municipality;KG;20141
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kruševo;Krusevo;municipality;46;48946
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kruševo;Krusevo;municipality;KS;15236
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kumanovo;Kumanovo;municipality;47;48947
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Kumanovo;Kumanovo;municipality;UM;15250
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Lipkovo;Lipkovo;municipality;LI;20142
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Lipkovo;Lipkovo;municipality;48;48948
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Lozovo;Lozovo;municipality;LO;20143
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Lozovo;Lozovo;municipality;49;48949
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonska Kamenica";"Makedonska Kamenica";municipality;51;48950
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonska Kamenica";"Makedonska Kamenica";municipality;MK;20144
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonski Brod";"Makedonski Brod";municipality;52;48951
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Makedonski Brod";"Makedonski Brod";municipality;MD;20145
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Mavrovo i Rostuša";"Mavrovo i Rostusa";municipality;50;48952
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Mavrovo-i-Rostuša;Mavrovo-i-Rostusa;municipality;MR;20146
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Mogila;Mogila;municipality;MG;20147
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Mogila;Mogila;municipality;53;48953
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Negotino;Negotino;municipality;54;48954
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Negotino;Negotino;municipality;NG;15237
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Novaci;Novaci;municipality;NV;20148
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Novaci;Novaci;municipality;55;48955
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Novo Selo";"Novo Selo";municipality;NS;20149
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Novo Selo";"Novo Selo";municipality;56;48956
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Ohrid;Ohrid;municipality;58;48957
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Ohrid;Ohrid;municipality;OD;15238
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Oslomej;Oslomej;municipality;OS;20150
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Oslomej;Oslomej;municipality;57;48958
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Pehcevo;Pehcevo;municipality;PH;20151
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Pehčevo;Pehcevo;municipality;60;48959
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Petrovec;Petrovec;municipality;59;48960
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Petrovec;Petrovec;municipality;PE;20152
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Plasnica;Plasnica;municipality;61;48961
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Plasnica;Plasnica;municipality;PN;20153
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Prilep;Prilep;municipality;PP;15248
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Prilep;Prilep;municipality;62;48962
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Probištip;Probistip;municipality;PT;15239
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Probištip;Probistip;municipality;63;48963
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Radoviš;Radovis;municipality;RV;15247
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Radoviš;Radovis;municipality;64;48964
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Rankovce;Rankovce;municipality;RN;20154
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Rankovce;Rankovce;municipality;65;48965
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Resen;Resen;municipality;66;48966
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Resen;Resen;municipality;RE;15240
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Rosoman;Rosoman;municipality;67;48967
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Rosoman;Rosoman;municipality;RM;20155
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Saraj;Saraj;municipality;68;48968
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Saraj *";"Saraj ";municipality;AJ;20156
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Skopje;Skopje;;X1~;15246
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Sopište;Sopiste;municipality;70;48969
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Sopište;Sopiste;municipality;SS;20157
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Staro Nagoricane";"Staro Nagoricane";municipality;NA;20158
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Staro Nagoričane";"Staro Nagoricane";municipality;71;48970
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Struga;Struga;municipality;UG;15242
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Struga;Struga;municipality;72;48971
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Strumica;Strumica;municipality;73;48972
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Strumica;Strumica;municipality;RU;15251
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Studenicani;Studenicani;municipality;SU;20159
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Studeničani;Studenicani;municipality;74;48973
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Sveti Nikole";"Sveti Nikole";municipality;SL;15243
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Sveti Nikole";"Sveti Nikole";municipality;69;48974
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Tearce;Tearce;municipality;75;48977
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Tearce;Tearce;municipality;TR;20160
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Tetovo;Tetovo;municipality;ET;15252
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Tetovo;Tetovo;municipality;76;48978
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Valandovo;Valandovo;municipality;10;48979
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Valandovo;Valandovo;municipality;VA;15244
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vasilevo;Vasilevo;municipality;11;48980
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vasilevo;Vasilevo;municipality;VL;20161
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Veles;Veles;municipality;VE;15223
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Veles;Veles;municipality;13;48981
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vevcani;Vevcani;municipality;VV;20162
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vevčani;Vevcani;municipality;12;48982
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vinica;Vinica;municipality;14;48983
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vinica;Vinica;municipality;NI;15245
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vraneštica;Vranestica;municipality;15;48984
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vraneštica;Vranestica;municipality;VC;20163
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vrapcište;Vrapciste;municipality;VH;20164
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Vrapčište;Vrapciste;municipality;16;48985
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Zajas;Zajas;municipality;31;48986
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Zajas;Zajas;municipality;ZA;20165
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Zelenikovo;Zelenikovo;municipality;32;48987
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Zelenikovo;Zelenikovo;municipality;ZK;20166
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Zrnovci;Zrnovci;municipality;33;48988
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Zrnovci;Zrnovci;municipality;ZR;20167
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Čair;Cair;municipality;79;48917
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Čaška;Caska;municipality;80;48918
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Češinovo-Obleševo;Cesinovo-Oblesevo;municipality;81;48919
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Čučer Sandevo";"Cucer Sandevo";municipality;82;48920
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Štip;Stip;municipality;83;48975
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Štip;Stip;municipality;ST;15241
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Šuto Orizari";"Suto Orizari";municipality;84;48976
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;"Šuto Orizari *";"Suto Orizari ";municipality;SO;20169
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Želino;Zelino;municipality;30;48989
+"the Former Yugoslav Republic Of Macedonia";MK;MKD;134;Želino;Zelino;municipality;ZE;20170
+Madagascar;MG;MDG;135;Antananarivo;Antananarivo;province;T;15255
+Madagascar;MG;MDG;135;Antsiranana;Antsiranana;province;D;15254
+Madagascar;MG;MDG;135;Fianarantsoa;Fianarantsoa;province;F;15258
+Madagascar;MG;MDG;135;Mahajanga;Mahajanga;province;M;15257
+Madagascar;MG;MDG;135;Toamasina;Toamasina;province;A;15253
+Madagascar;MG;MDG;135;Toliara;Toliara;province;U;15256
+Malawi;MW;MWI;136;Balaka;Balaka;district;BA;15279
+Malawi;MW;MWI;136;Blantyre;Blantyre;district;BL;15261
+Malawi;MW;MWI;136;"Central Region";"Central Region";region;C;48232
+Malawi;MW;MWI;136;Chikwawa;Chikwawa;district;CK;15280
+Malawi;MW;MWI;136;Chiradzulu;Chiradzulu;district;CR;15262
+Malawi;MW;MWI;136;Chitipa;Chitipa;district;CT;15281
+Malawi;MW;MWI;136;Dedza;Dedza;district;DE;15263
+Malawi;MW;MWI;136;Dowa;Dowa;district;DO;15264
+Malawi;MW;MWI;136;Karonga;Karonga;district;KR;15285
+Malawi;MW;MWI;136;Kasungu;Kasungu;district;KS;15265
+Malawi;MW;MWI;136;Likoma;Likoma;district;LK;19024
+Malawi;MW;MWI;136;Lilongwe;Lilongwe;district;LI;15286
+Malawi;MW;MWI;136;Machinga;Machinga;district;MH;15267
+Malawi;MW;MWI;136;Mangochi;Mangochi;district;MG;15268
+Malawi;MW;MWI;136;Mchinji;Mchinji;district;MC;15284
+Malawi;MW;MWI;136;Mulanje;Mulanje;district;MU;15269
+Malawi;MW;MWI;136;Mwanza;Mwanza;district;MW;15270
+Malawi;MW;MWI;136;Mzimba;Mzimba;district;MZ;15283
+Malawi;MW;MWI;136;Neno;Neno;district;NE;48231
+Malawi;MW;MWI;136;"Nkhata Bay";"Nkhata Bay";district;NB;15282
+Malawi;MW;MWI;136;Nkhotakota;Nkhotakota;district;NK;15272
+Malawi;MW;MWI;136;"Northern Region";"Northern Region";region;N;48233
+Malawi;MW;MWI;136;Nsanje;Nsanje;district;NS;15273
+Malawi;MW;MWI;136;Ntcheu;Ntcheu;district;NU;15287
+Malawi;MW;MWI;136;Ntchisi;Ntchisi;district;NI;15274
+Malawi;MW;MWI;136;Phalombe;Phalombe;district;PH;15275
+Malawi;MW;MWI;136;Rumphi;Rumphi;district;RU;15288
+Malawi;MW;MWI;136;Salima;Salima;district;SA;15276
+Malawi;MW;MWI;136;"Southern Region";"Southern Region";region;S;48234
+Malawi;MW;MWI;136;Thyolo;Thyolo;district;TH;15277
+Malawi;MW;MWI;136;Zomba;Zomba;district;ZO;15278
+Malaysia;MY;MYS;137;Johor;Johor;state;01;15290
+Malaysia;MY;MYS;137;Kedah;Kedah;state;02;15299
+Malaysia;MY;MYS;137;Kelantan;Kelantan;state;03;15291
+Malaysia;MY;MYS;137;Melaka;Melaka;state;04;15293
+Malaysia;MY;MYS;137;"Negeri Sembilan";"Negeri Sembilan";state;05;15301
+Malaysia;MY;MYS;137;Pahang;Pahang;state;06;15294
+Malaysia;MY;MYS;137;Perak;Perak;state;08;15295
+Malaysia;MY;MYS;137;Perlis;Perlis;state;09;15302
+Malaysia;MY;MYS;137;"Pulau Pinang";"Pulau Pinang";state;07;15296
+Malaysia;MY;MYS;137;Sabah;Sabah;state;12;15297
+Malaysia;MY;MYS;137;Sarawak;Sarawak;state;13;15303
+Malaysia;MY;MYS;137;Selangor;Selangor;state;10;15298
+Malaysia;MY;MYS;137;Terengganu;Terengganu;state;11;15289
+Malaysia;MY;MYS;137;"Wilayah Persekutuan Kuala Lumpur";"Wilayah Persekutuan Kuala Lumpur";"federal territory";14;15300
+Malaysia;MY;MYS;137;"Wilayah Persekutuan Labuan";"Wilayah Persekutuan Labuan";"federal territory";15;15292
+Malaysia;MY;MYS;137;"Wilayah Persekutuan Putrajaya";"Wilayah Persekutuan Putrajaya";"federal territory";16;19025
+Maldives;MV;MDV;138;Alif;Alif;"administrative atoll";02;15307
+Maldives;MV;MDV;138;"Alif Dhaal";"Alif Dhaal";;X1~;48268
+Maldives;MV;MDV;138;"Alif Dhaal";"Alif Dhaal";;00;15308
+Maldives;MV;MDV;138;Baa;Baa;"administrative atoll";20;15309
+Maldives;MV;MDV;138;Central;Central;province;CE;48272
+Maldives;MV;MDV;138;Dhaalu;Dhaalu;"administrative atoll";17;15310
+Maldives;MV;MDV;138;Faafu;Faafu;"administrative atoll";14;15311
+Maldives;MV;MDV;138;"Gaaf Alif";"Gaaf Alif";"administrative atoll";27;15312
+Maldives;MV;MDV;138;"Gaafu Dhaalu";"Gaafu Dhaalu";"administrative atoll";28;15313
+Maldives;MV;MDV;138;Gnaviyani;Gnaviyani;"administrative atoll";29;15306
+Maldives;MV;MDV;138;"Haa Alif";"Haa Alif";"administrative atoll";07;15314
+Maldives;MV;MDV;138;"Haa Dhaalu";"Haa Dhaalu";"administrative atoll";23;15315
+Maldives;MV;MDV;138;Kaafu;Kaafu;"administrative atoll";26;15305
+Maldives;MV;MDV;138;Laamu;Laamu;"administrative atoll";05;15316
+Maldives;MV;MDV;138;Lhaviyani;Lhaviyani;"administrative atoll";03;15321
+Maldives;MV;MDV;138;Male;Male;capital;MLE;15317
+Maldives;MV;MDV;138;Meemu;Meemu;"administrative atoll";12;15324
+Maldives;MV;MDV;138;Noonu;Noonu;"administrative atoll";25;15323
+Maldives;MV;MDV;138;North;North;province;NO;48275
+Maldives;MV;MDV;138;"North Central";"North Central";province;NC;48274
+Maldives;MV;MDV;138;Raa;Raa;"administrative atoll";13;15318
+Maldives;MV;MDV;138;Seenu;Seenu;"administrative atoll";01;15319
+Maldives;MV;MDV;138;Shaviyani;Shaviyani;"administrative atoll";24;15322
+Maldives;MV;MDV;138;South;South;province;SU;48269
+Maldives;MV;MDV;138;"South Central";"South Central";province;SC;48273
+Maldives;MV;MDV;138;Thaa;Thaa;"administrative atoll";08;15304
+Maldives;MV;MDV;138;"Upper North";"Upper North";province;UN;48271
+Maldives;MV;MDV;138;"Upper South";"Upper South";province;US;48270
+Maldives;MV;MDV;138;Vaavu;Vaavu;"administrative atoll";04;15320
+Mali;ML;MLI;139;Bamako;Bamako;district;BKO;15327
+Mali;ML;MLI;139;Gao;Gao;region;7;15329
+Mali;ML;MLI;139;Kayes;Kayes;region;1;15330
+Mali;ML;MLI;139;Kidal;Kidal;region;8;15328
+Mali;ML;MLI;139;Koulikoro;Koulikoro;region;2;15331
+Mali;ML;MLI;139;Mopti;Mopti;region;5;15326
+Mali;ML;MLI;139;Sikasso;Sikasso;region;3;15333
+Mali;ML;MLI;139;Ségou;Segou;region;4;15332
+Mali;ML;MLI;139;Tombouctou;Tombouctou;region;6;15325
+"Marshall Islands";MH;MHL;141;Ailinglaplap;Ailinglaplap;municipality;ALL;15362
+"Marshall Islands";MH;MHL;141;Ailuk;Ailuk;municipality;ALK;15347
+"Marshall Islands";MH;MHL;141;Arno;Arno;municipality;ARN;15348
+"Marshall Islands";MH;MHL;141;Aur;Aur;municipality;AUR;15363
+"Marshall Islands";MH;MHL;141;Ebon;Ebon;municipality;EBO;15351
+"Marshall Islands";MH;MHL;141;Enewetak;Enewetak;municipality;ENI;15365
+"Marshall Islands";MH;MHL;141;Jabat;Jabat;municipality;JAB;48101
+"Marshall Islands";MH;MHL;141;Jaluit;Jaluit;municipality;JAL;15353
+"Marshall Islands";MH;MHL;141;Kili;Kili;municipality;KIL;15367
+"Marshall Islands";MH;MHL;141;Kwajalein;Kwajalein;municipality;KWA;15355
+"Marshall Islands";MH;MHL;141;Lae;Lae;municipality;LAE;15368
+"Marshall Islands";MH;MHL;141;Lib;Lib;municipality;LIB;15356
+"Marshall Islands";MH;MHL;141;Likiep;Likiep;municipality;LIK;15357
+"Marshall Islands";MH;MHL;141;Majuro;Majuro;municipality;MAJ;15345
+"Marshall Islands";MH;MHL;141;Maloelap;Maloelap;municipality;MAL;15358
+"Marshall Islands";MH;MHL;141;Mejit;Mejit;municipality;MEJ;15369
+"Marshall Islands";MH;MHL;141;Mili;Mili;municipality;MIL;15359
+"Marshall Islands";MH;MHL;141;Namdrik;Namdrik;municipality;NMK;15360
+"Marshall Islands";MH;MHL;141;Namu;Namu;municipality;NMU;15344
+"Marshall Islands";MH;MHL;141;"Ralik chain";"Ralik chain";"chain of islands";L;48510
+"Marshall Islands";MH;MHL;141;"Ratak chain";"Ratak chain";"chain of islands";T;48674
+"Marshall Islands";MH;MHL;141;Rongelap;Rongelap;municipality;RON;15361
+"Marshall Islands";MH;MHL;141;Ujae;Ujae;municipality;UJA;15371
+"Marshall Islands";MH;MHL;141;Ujelang;Ujelang;municipality;UJL;15342
+"Marshall Islands";MH;MHL;141;Utirik;Utirik;municipality;UTI;15372
+"Marshall Islands";MH;MHL;141;Wotho;Wotho;municipality;WTH;15341
+"Marshall Islands";MH;MHL;141;Wotje;Wotje;municipality;WTJ;15340
+Mauritania;MR;MRT;143;Adrar;Adrar;region;07;15379
+Mauritania;MR;MRT;143;Assaba;Assaba;region;03;15378
+Mauritania;MR;MRT;143;Brakna;Brakna;region;05;15384
+Mauritania;MR;MRT;143;"Dakhlet Nouâdhibou";"Dakhlet Nouadhibou";region;08;15380
+Mauritania;MR;MRT;143;Gorgol;Gorgol;region;04;15387
+Mauritania;MR;MRT;143;Guidimaka;Guidimaka;region;10;15388
+Mauritania;MR;MRT;143;"Hodh ech Chargui";"Hodh ech Chargui";region;01;15386
+Mauritania;MR;MRT;143;"Hodh el Gharbi";"Hodh el Gharbi";region;02;15381
+Mauritania;MR;MRT;143;Inchiri;Inchiri;region;12;15382
+Mauritania;MR;MRT;143;Nouakchott;Nouakchott;district;NKC;15389
+Mauritania;MR;MRT;143;Tagant;Tagant;region;09;15385
+Mauritania;MR;MRT;143;"Tiris Zemmour";"Tiris Zemmour";region;11;15383
+Mauritania;MR;MRT;143;Trarza;Trarza;region;06;15377
+Mauritius;MU;MUS;144;"Agalega Islands";"Agalega Islands";dependency;AG;19026
+Mauritius;MU;MUS;144;"Beau Bassin-Rose Hill";"Beau Bassin-Rose Hill";city;BR;19027
+Mauritius;MU;MUS;144;"Black River";"Black River";district;BL;15392
+Mauritius;MU;MUS;144;"Cargados Carajos Shoals (Saint Brandon Islands)";"Cargados Carajos Shoals (Saint Brandon Islands)";dependency;CC;19028
+Mauritius;MU;MUS;144;Curepipe;Curepipe;city;CU;19029
+Mauritius;MU;MUS;144;Flacq;Flacq;district;FL;15395
+Mauritius;MU;MUS;144;"Grand Port";"Grand Port";district;GP;15393
+Mauritius;MU;MUS;144;Moka;Moka;district;MO;15394
+Mauritius;MU;MUS;144;Pamplemousses;Pamplemousses;district;PA;15396
+Mauritius;MU;MUS;144;"Plaines Wilhems";"Plaines Wilhems";district;PW;15391
+Mauritius;MU;MUS;144;"Port Louis City";"Port Louis City";district;PL;15397
+Mauritius;MU;MUS;144;"Port Louis District";"Port Louis District";city;PU;19030
+Mauritius;MU;MUS;144;"Quatre Bornes";"Quatre Bornes";city;QB;19033
+Mauritius;MU;MUS;144;"Rivière du Rempart";"Riviere du Rempart";district;RR;15399
+Mauritius;MU;MUS;144;"Rodrigues Island";"Rodrigues Island";dependency;RO;15398
+Mauritius;MU;MUS;144;Savanne;Savanne;district;SA;15390
+Mauritius;MU;MUS;144;Vacoas-Phoenix;Vacoas-Phoenix;city;VP;19032
+Mexico;MX;MEX;146;Aguascalientes;Aguascalientes;state;AGU;15423
+Mexico;MX;MEX;146;"Baja California";"Baja California";state;BCN;15412
+Mexico;MX;MEX;146;"Baja California Sur";"Baja California Sur";state;BCS;15413
+Mexico;MX;MEX;146;Campeche;Campeche;state;CAM;15424
+Mexico;MX;MEX;146;Chiapas;Chiapas;state;CHP;15414
+Mexico;MX;MEX;146;Chihuahua;Chihuahua;state;CHH;15425
+Mexico;MX;MEX;146;Coahuila;Coahuila;state;COA;15415
+Mexico;MX;MEX;146;Colima;Colima;state;COL;15416
+Mexico;MX;MEX;146;"Distrito Federal";"Distrito Federal";"federal district";DIF;15426
+Mexico;MX;MEX;146;Durango;Durango;state;DUR;15417
+Mexico;MX;MEX;146;Guanajuato;Guanajuato;state;GUA;15418
+Mexico;MX;MEX;146;Guerrero;Guerrero;state;GRO;15427
+Mexico;MX;MEX;146;Hidalgo;Hidalgo;state;HID;15419
+Mexico;MX;MEX;146;Jalisco;Jalisco;state;JAL;15420
+Mexico;MX;MEX;146;Michoacán;Michoacan;state;MIC;15421
+Mexico;MX;MEX;146;Morelos;Morelos;state;MOR;15422
+Mexico;MX;MEX;146;México;Mexico;state;MEX;15428
+Mexico;MX;MEX;146;Nayarit;Nayarit;state;NAY;15429
+Mexico;MX;MEX;146;"Nuevo León";"Nuevo Leon";state;NLE;15403
+Mexico;MX;MEX;146;Oaxaca;Oaxaca;state;OAX;15430
+Mexico;MX;MEX;146;Puebla;Puebla;state;PUE;15404
+Mexico;MX;MEX;146;Querétaro;Queretaro;state;QUE;15405
+Mexico;MX;MEX;146;"Quintana Roo";"Quintana Roo";state;ROO;15432
+Mexico;MX;MEX;146;"San Luis Potosí";"San Luis Potosi";state;SLP;15406
+Mexico;MX;MEX;146;Sinaloa;Sinaloa;state;SIN;15407
+Mexico;MX;MEX;146;Sonora;Sonora;state;SON;15433
+Mexico;MX;MEX;146;Tabasco;Tabasco;state;TAB;15408
+Mexico;MX;MEX;146;Tamaulipas;Tamaulipas;state;TAM;15431
+Mexico;MX;MEX;146;Tlaxcala;Tlaxcala;state;TLA;15409
+Mexico;MX;MEX;146;Veracruz;Veracruz;state;VER;15410
+Mexico;MX;MEX;146;Yucatán;Yucatan;state;YUC;15402
+Mexico;MX;MEX;146;Zacatecas;Zacatecas;state;ZAC;15411
+"Federated States Of Micronesia";FM;FSM;147;Chuuk;Chuuk;state;TRK;15437
+"Federated States Of Micronesia";FM;FSM;147;Kosrae;Kosrae;state;KSA;15436
+"Federated States Of Micronesia";FM;FSM;147;Pohnpei;Pohnpei;state;PNI;15434
+"Federated States Of Micronesia";FM;FSM;147;Yap;Yap;state;YAP;15438
+"Republic of Moldova";MD;MDA;148;"Anenii Noi";"Anenii Noi";district;AN;15471
+"Republic of Moldova";MD;MDA;148;Basarabeasca;Basarabeasca;district;BS;15454
+"Republic of Moldova";MD;MDA;148;Briceni;Briceni;district;BR;15472
+"Republic of Moldova";MD;MDA;148;Bălţi;Balti;city;BA;15453
+"Republic of Moldova";MD;MDA;148;Cahul;Cahul;district;CA;15455
+"Republic of Moldova";MD;MDA;148;Cantemir;Cantemir;district;CT;15458
+"Republic of Moldova";MD;MDA;148;Chisinau;Chisinau;city;CU;15459
+"Republic of Moldova";MD;MDA;148;"Chisinau City";"Chisinau City";city;CH;20309
+"Republic of Moldova";MD;MDA;148;Cimişlia;Cimislia;district;CM;15460
+"Republic of Moldova";MD;MDA;148;Criuleni;Criuleni;district;CR;15475
+"Republic of Moldova";MD;MDA;148;Călăraşi;Calarasi;district;CL;15473
+"Republic of Moldova";MD;MDA;148;Căuşeni;Causeni;district;CS;15474
+"Republic of Moldova";MD;MDA;148;Donduşeni;Donduseni;district;DO;15461
+"Republic of Moldova";MD;MDA;148;Drochia;Drochia;district;DR;15476
+"Republic of Moldova";MD;MDA;148;Dubăsari;Dubasari;district;DU;15444
+"Republic of Moldova";MD;MDA;148;Edinet;Edinet;district;ED;15477
+"Republic of Moldova";MD;MDA;148;Floreşti;Floresti;district;FL;15443
+"Republic of Moldova";MD;MDA;148;Făleşti;Falesti;district;FA;15445
+"Republic of Moldova";MD;MDA;148;"Unitatea teritoriala autonoma (UTAG) Gagauzia";"Unitatea teritoriala autonoma (UTAG) Gagauzia";"autonomous territorial unit";GA;15446
+"Republic of Moldova";MD;MDA;148;Glodeni;Glodeni;district;GL;15478
+"Republic of Moldova";MD;MDA;148;Hînceşti;Hincesti;district;HI;15448
+"Republic of Moldova";MD;MDA;148;Ialoveni;Ialoveni;district;IA;15442
+"Republic of Moldova";MD;MDA;148;Leova;Leova;district;LE;15449
+"Republic of Moldova";MD;MDA;148;Lăpuşina;Lapusina;district;LA;20171
+"Republic of Moldova";MD;MDA;148;Nisporeni;Nisporeni;district;NI;15450
+"Republic of Moldova";MD;MDA;148;Ocniţa;Ocnita;district;OC;15479
+"Republic of Moldova";MD;MDA;148;Orhei;Orhei;district;OR;15451
+"Republic of Moldova";MD;MDA;148;Rezina;Rezina;district;RE;15441
+"Republic of Moldova";MD;MDA;148;Rîşcani;Riscani;district;RI;15463
+"Republic of Moldova";MD;MDA;148;Soroca;Soroca;district;SO;15466
+"Republic of Moldova";MD;MDA;148;Străşeni;Straseni;district;ST;15467
+"Republic of Moldova";MD;MDA;148;"unitatea teritoriala din Stînga Nistrului";"unitatea teritoriala din Stinga Nistrului";"territorial unit";SN;20172
+"Republic of Moldova";MD;MDA;148;Sîngerei;Singerei;district;SI;15464
+"Republic of Moldova";MD;MDA;148;Taraclia;Taraclia;district;TA;15481
+"Republic of Moldova";MD;MDA;148;Teleneşti;Telenesti;district;TE;15468
+"Republic of Moldova";MD;MDA;148;Tighina;Tighina;city;BD;15469
+"Republic of Moldova";MD;MDA;148;Tighina;Tighina;district;TI;48215
+"Republic of Moldova";MD;MDA;148;Ungheni;Ungheni;district;UN;15470
+"Republic of Moldova";MD;MDA;148;Şoldăneşti;Soldanesti;district;SD;15465
+"Republic of Moldova";MD;MDA;148;"Ştefan Vodă";"Stefan Voda";district;SV;15440
+Monaco;MC;MCO;149;Fontvieille;Fontvieille;quarter;FO;48841
+Monaco;MC;MCO;149;"Jardin Exotique";"Jardin Exotique";quarter;JE;48842
+Monaco;MC;MCO;149;"La Colle";"La Colle";quarter;CL;48843
+Monaco;MC;MCO;149;"La Condamine";"La Condamine";quarter;CO;48840
+Monaco;MC;MCO;149;"La Gare";"La Gare";quarter;GA;48844
+Monaco;MC;MCO;149;"La Source";"La Source";quarter;SO;48845
+Monaco;MC;MCO;149;Larvotto;Larvotto;quarter;LA;48846
+Monaco;MC;MCO;149;Malbousquet;Malbousquet;quarter;MA;48847
+Monaco;MC;MCO;149;Monaco-Ville;Monaco-Ville;quarter;MO;48848
+Monaco;MC;MCO;149;Moneghetti;Moneghetti;quarter;MG;48849
+Monaco;MC;MCO;149;Monte-Carlo;Monte-Carlo;quarter;MC;48850
+Monaco;MC;MCO;149;Moulins;Moulins;quarter;MU;48851
+Monaco;MC;MCO;149;Port-Hercule;Port-Hercule;quarter;PH;48852
+Monaco;MC;MCO;149;Saint-Roman;Saint-Roman;quarter;SR;48853
+Monaco;MC;MCO;149;Sainte-Dévote;Sainte-Devote;quarter;SD;48854
+Monaco;MC;MCO;149;Spélugues;Spelugues;quarter;SP;48855
+Monaco;MC;MCO;149;"Vallon de la Rousse";"Vallon de la Rousse";quarter;VR;48856
+Mongolia;MN;MNG;150;Arhangay;Arhangay;province;073;15504
+Mongolia;MN;MNG;150;Bayan-Ölgiy;Bayan-Olgiy;province;071;15490
+Mongolia;MN;MNG;150;Bayanhongor;Bayanhongor;province;069;15491
+Mongolia;MN;MNG;150;Bulgan;Bulgan;province;067;15492
+Mongolia;MN;MNG;150;"Darhan uul";"Darhan uul";municipality;037;15493
+Mongolia;MN;MNG;150;Dornod;Dornod;province;061;15505
+Mongolia;MN;MNG;150;Dornogovi;Dornogovi;province;063;15494
+Mongolia;MN;MNG;150;Dundgovi;Dundgovi;province;059;15489
+Mongolia;MN;MNG;150;Dzavhan;Dzavhan;province;057;15503
+Mongolia;MN;MNG;150;Govi-Altay;Govi-Altay;province;065;15495
+Mongolia;MN;MNG;150;Govi-Sümber;Govi-Sumber;municipality;064;15506
+Mongolia;MN;MNG;150;Hentiy;Hentiy;province;039;15496
+Mongolia;MN;MNG;150;Hovd;Hovd;province;043;15497
+Mongolia;MN;MNG;150;Hövsgöl;Hovsgol;province;041;15488
+Mongolia;MN;MNG;150;Orhon;Orhon;municipality;035;15507
+Mongolia;MN;MNG;150;Selenge;Selenge;province;049;15487
+Mongolia;MN;MNG;150;Sühbaatar;Suhbaatar;province;051;15500
+Mongolia;MN;MNG;150;Töv;Tov;province;047;15501
+Mongolia;MN;MNG;150;Ulaanbaatar;Ulaanbaatar;municipality;1;15486
+Mongolia;MN;MNG;150;Uvs;Uvs;province;046;15502
+Mongolia;MN;MNG;150;Ömnögovi;Omnogovi;province;053;15498
+Mongolia;MN;MNG;150;Övörhangay;Ovorhangay;province;055;15499
+Montenegro;ME;MNE;151;Andrijevica;Andrijevica;commune;01;42617
+Montenegro;ME;MNE;151;Bar;Bar;commune;02;42616
+Montenegro;ME;MNE;151;Berane;Berane;commune;03;42615
+Montenegro;ME;MNE;151;"Bijelo Polje";"Bijelo Polje";commune;04;42614
+Montenegro;ME;MNE;151;Budva;Budva;commune;05;42613
+Montenegro;ME;MNE;151;Cetinje;Cetinje;commune;06;42598
+Montenegro;ME;MNE;151;Danilovgrad;Danilovgrad;commune;07;42612
+Montenegro;ME;MNE;151;Herceg-Novi;Herceg-Novi;commune;08;42599
+Montenegro;ME;MNE;151;Kolašin;Kolasin;commune;09;42610
+Montenegro;ME;MNE;151;Kotor;Kotor;commune;10;42609
+Montenegro;ME;MNE;151;Mojkovac;Mojkovac;commune;11;42608
+Montenegro;ME;MNE;151;Nikšic´;Niksic';commune;12;42607
+Montenegro;ME;MNE;151;Plav;Plav;commune;13;42606
+Montenegro;ME;MNE;151;Pljevlja;Pljevlja;commune;14;42604
+Montenegro;ME;MNE;151;Plužine;Pluzine;commune;15;42605
+Montenegro;ME;MNE;151;Podgorica;Podgorica;commune;16;42603
+Montenegro;ME;MNE;151;Rožaje;Rozaje;commune;17;42602
+Montenegro;ME;MNE;151;Tivat;Tivat;commune;19;42601
+Montenegro;ME;MNE;151;Ulcinj;Ulcinj;commune;20;42600
+Montenegro;ME;MNE;151;Šavnik;Savnik;commune;18;42597
+Montenegro;ME;MNE;151;Žabljak;Zabljak;commune;21;42611
+Morocco;MA;MAR;153;Agadir-Ida-Outanane;Agadir-Ida-Outanane;prefecture;AGD;15554
+Morocco;MA;MAR;153;"Al Haouz";"Al Haouz";province;HAO;15543
+Morocco;MA;MAR;153;"Al Hoceïma";"Al Hoceima";province;HOC;15516
+Morocco;MA;MAR;153;Aousserd;Aousserd;prefecture;AOU;48475
+Morocco;MA;MAR;153;Assa-Zag;Assa-Zag;province;ASZ;15541
+Morocco;MA;MAR;153;Azilal;Azilal;province;AZI;15583
+Morocco;MA;MAR;153;"Aït Baha";"Ait Baha";province;BAH;15518
+Morocco;MA;MAR;153;"Aït Melloul";"Ait Melloul";;MEL;15555
+Morocco;MA;MAR;153;"Ben Slimane";"Ben Slimane";province;BES;15572
+Morocco;MA;MAR;153;"Beni Mellal";"Beni Mellal";province;BEM;15558
+Morocco;MA;MAR;153;Berkane;Berkane;province;BER;15526
+Morocco;MA;MAR;153;"Boujdour (EH)";"Boujdour (EH)";province;BOD;20173
+Morocco;MA;MAR;153;Boulemane;Boulemane;province;BOM;15576
+Morocco;MA;MAR;153;"Casablanca (Dar el Beïda)*";"Casablanca (Dar el Beida)";prefecture;CAS;15579
+Morocco;MA;MAR;153;Chaouia-Ouardigh;Chaouia-Ouardigh;region;09;15529
+Morocco;MA;MAR;153;Chefchaouen;Chefchaouen;province;CHE;15559
+Morocco;MA;MAR;153;Chichaoua;Chichaoua;province;CHI;15522
+Morocco;MA;MAR;153;"Chtouka-Ait Baha";"Chtouka-Ait Baha";;CHT;48100
+Morocco;MA;MAR;153;"Connaught Salé";"Connaught Sale";prefecture;SAL;48482
+Morocco;MA;MAR;153;Doukkala-Abda;Doukkala-Abda;region;10;15565
+Morocco;MA;MAR;153;"El Hajeb";"El Hajeb";province;HAJ;15524
+Morocco;MA;MAR;153;"El Jadida";"El Jadida";province;JDI;15575
+Morocco;MA;MAR;153;Errachidia;Errachidia;province;ERR;15547
+Morocco;MA;MAR;153;"Es Smara (EH)";"Es Smara (EH)";province;ESM;20174
+Morocco;MA;MAR;153;Essaouira;Essaouira;province;ESI;15523
+Morocco;MA;MAR;153;"Fahs-Beni Makada";"Fahs-Beni Makada";prefecture;FAH;48476
+Morocco;MA;MAR;153;Fes-Boulemane;Fes-Boulemane;region;05;15566
+Morocco;MA;MAR;153;Figuig;Figuig;province;FIG;15549
+Morocco;MA;MAR;153;Fès-Dar-Dbibegh;Fes-Dar-Dbibegh;prefecture;FES;15536
+Morocco;MA;MAR;153;"Gharb-Chrarda-Beni Hssen";"Gharb-Chrarda-Beni Hssen";region;02;15530
+Morocco;MA;MAR;153;"Grand Casablanca";"Grand Casablanca";region;08;15564
+Morocco;MA;MAR;153;Guelmim;Guelmim;province;GUE;15520
+Morocco;MA;MAR;153;"Guelmim-Es Smar";"Guelmim-Es Smar";region;14;15567
+Morocco;MA;MAR;153;Ifrane;Ifrane;province;IFR;15525
+Morocco;MA;MAR;153;"Inezgane-Ait Melloul";"Inezgane-Ait Melloul";prefecture;INE;48477
+Morocco;MA;MAR;153;Jrada;Jrada;province;JRA;15550
+Morocco;MA;MAR;153;"Kelaat es Sraghna";"Kelaat es Sraghna";province;KES;15544
+Morocco;MA;MAR;153;Khemisset;Khemisset;province;KHE;15552
+Morocco;MA;MAR;153;Khenifra;Khenifra;province;KHN;15548
+Morocco;MA;MAR;153;Khouribga;Khouribga;province;KHO;15573
+Morocco;MA;MAR;153;Kénitra;Kenitra;province;KEN;15578
+Morocco;MA;MAR;153;L'Oriental;L'Oriental;region;04;15569
+Morocco;MA;MAR;153;"Laayoune-Boujdour-Sakia El Hamra";"Laayoune-Boujdour-Sakia El Hamra";region;15;21378
+Morocco;MA;MAR;153;"Laayoune-Boujdour-Sakia El Hamra";"Laayoune-Boujdour-Sakia El Hamra";;X1~;48276
+Morocco;MA;MAR;153;Larache;Larache;province;LAR;15560
+Morocco;MA;MAR;153;Laâyoune*;Laayoune;province;LAA;20175
+Morocco;MA;MAR;153;Marrakech*;Marrakech;;MAR;15545
+Morocco;MA;MAR;153;Marrakech-Medina;Marrakech-Medina;prefecture;MMD;48478
+Morocco;MA;MAR;153;Marrakech-Menara;Marrakech-Menara;prefecture;MMN;48479
+Morocco;MA;MAR;153;"Marrakech-Tensift-Al Haouz";"Marrakech-Tensift-Al Haouz";region;11;15531
+Morocco;MA;MAR;153;Mediouna;Mediouna;province;MED;15539
+Morocco;MA;MAR;153;Meknes-Tafilalet;Meknes-Tafilalet;region;06;15568
+Morocco;MA;MAR;153;Meknès;Meknes;prefecture;MEK;15546
+Morocco;MA;MAR;153;Mohammadia;Mohammadia;prefecture;MOH;48480
+Morocco;MA;MAR;153;"Moulay Yacoub";"Moulay Yacoub";;MOU;15537
+Morocco;MA;MAR;153;Nador;Nador;province;NAD;15527
+Morocco;MA;MAR;153;Nouaceur;Nouaceur;province;NOU;15580
+Morocco;MA;MAR;153;Ouarzazate;Ouarzazate;province;OUA;15582
+Morocco;MA;MAR;153;"Oued ed Dahab (EH)";"Oued ed Dahab (EH)";province;OUD;20176
+Morocco;MA;MAR;153;"Oued ed Dahab-Lagouira";"Oued ed Dahab-Lagouira";region;16;48474
+Morocco;MA;MAR;153;Oujda*;Oujda;prefecture;OUJ;15551
+Morocco;MA;MAR;153;Rabat;Rabat;prefecture;RAB;48481
+Morocco;MA;MAR;153;Rabat-Salé*;Rabat-Sale;;RBA;15532
+Morocco;MA;MAR;153;Rabat-Salé-Zemmour-Zaer;Rabat-Sale-Zemmour-Zaer;region;07;48277
+Morocco;MA;MAR;153;Safi;Safi;province;SAF;15535
+Morocco;MA;MAR;153;Sefrou;Sefrou;;SEF;15577
+Morocco;MA;MAR;153;Settat;Settat;province;SET;15574
+Morocco;MA;MAR;153;"Sidi Kacem";"Sidi Kacem";province;SIK;15538
+Morocco;MA;MAR;153;"Sidi Youssef Ben Ali";"Sidi Youssef Ben Ali";prefecture;SYB;48483
+Morocco;MA;MAR;153;Skhirate-Témara;Skhirate-Temara;prefecture;SKH;48484
+Morocco;MA;MAR;153;Souss-Massa-Draa;Souss-Massa-Draa;region;13;15570
+Morocco;MA;MAR;153;Tadla-Azilal;Tadla-Azilal;region;12;15533
+Morocco;MA;MAR;153;Tan-Tan;Tan-Tan;province;TNT;15542
+Morocco;MA;MAR;153;Tanger;Tanger;;TNG;15584
+Morocco;MA;MAR;153;Tanger-Assilah;Tanger-Assilah;prefecture;TNG;48485
+Morocco;MA;MAR;153;Tanger-Tetouan;Tanger-Tetouan;region;01;15571
+Morocco;MA;MAR;153;Taounate;Taounate;province;TAO;15562
+Morocco;MA;MAR;153;Taourirt;Taourirt;province;TAI;15528
+Morocco;MA;MAR;153;Taroudant;Taroudant;province;TAR;15556
+Morocco;MA;MAR;153;Tata;Tata;province;TAT;15521
+Morocco;MA;MAR;153;Taza;Taza;province;TAZ;15563
+Morocco;MA;MAR;153;"Taza-Al Hoceima-Taounate";"Taza-Al Hoceima-Taounate";region;03;15534
+Morocco;MA;MAR;153;Tiznit;Tiznit;province;TIZ;15517
+Morocco;MA;MAR;153;Tétouan*;Tetouan;;TET;15561
+Morocco;MA;MAR;153;Zagora;Zagora;province;ZAG;15557
+Mozambique;MZ;MOZ;154;"Cabo Delgado";"Cabo Delgado";province;P;15599
+Mozambique;MZ;MOZ;154;Gaza;Gaza;province;G;15602
+Mozambique;MZ;MOZ;154;Inhambane;Inhambane;province;I;15589
+Mozambique;MZ;MOZ;154;Manica;Manica;province;B;15590
+Mozambique;MZ;MOZ;154;Maputo;Maputo;province;L;15591
+Mozambique;MZ;MOZ;154;"Maputo City";"Maputo City";city;MPM;15603
+Mozambique;MZ;MOZ;154;Nampula;Nampula;province;N;15604
+Mozambique;MZ;MOZ;154;Niassa;Niassa;province;A;15592
+Mozambique;MZ;MOZ;154;Sofala;Sofala;province;S;15605
+Mozambique;MZ;MOZ;154;Tete;Tete;province;T;15593
+Mozambique;MZ;MOZ;154;Zambézia;Zambezia;province;Q;15606
+Myanmar;MM;MMR;155;Ayeyarwady;Ayeyarwady;division;07;15608
+Myanmar;MM;MMR;155;Bago;Bago;division;02;15609
+Myanmar;MM;MMR;155;Chin;Chin;state;14;15617
+Myanmar;MM;MMR;155;Kachin;Kachin;state;11;15610
+Myanmar;MM;MMR;155;Kayah;Kayah;state;12;15618
+Myanmar;MM;MMR;155;Kayin;Kayin;state;13;15611
+Myanmar;MM;MMR;155;Magway;Magway;division;03;15612
+Myanmar;MM;MMR;155;Mandalay;Mandalay;division;04;15620
+Myanmar;MM;MMR;155;Mon;Mon;state;15;15613
+Myanmar;MM;MMR;155;Rakhine;Rakhine;state;16;15619
+Myanmar;MM;MMR;155;Sagaing;Sagaing;division;01;15614
+Myanmar;MM;MMR;155;Shan;Shan;state;17;15615
+Myanmar;MM;MMR;155;Tanintharyi;Tanintharyi;division;05;15607
+Myanmar;MM;MMR;155;Yangon;Yangon;division;06;15616
+Namibia;NA;NAM;156;Caprivi;Caprivi;region;CA;15625
+Namibia;NA;NAM;156;Erongo;Erongo;region;ER;15626
+Namibia;NA;NAM;156;Hardap;Hardap;region;HA;15623
+Namibia;NA;NAM;156;Karas;Karas;region;KA;15627
+Namibia;NA;NAM;156;Khomas;Khomas;region;KH;15624
+Namibia;NA;NAM;156;Kunene;Kunene;region;KU;15629
+Namibia;NA;NAM;156;Ohangwena;Ohangwena;region;OW;15630
+Namibia;NA;NAM;156;Okavango;Okavango;region;OK;15628
+Namibia;NA;NAM;156;Omaheke;Omaheke;region;OH;15622
+Namibia;NA;NAM;156;Omusati;Omusati;region;OS;15631
+Namibia;NA;NAM;156;Oshana;Oshana;region;ON;15632
+Namibia;NA;NAM;156;Oshikoto;Oshikoto;region;OT;15621
+Namibia;NA;NAM;156;Otjozondjupa;Otjozondjupa;region;OD;15633
+Nauru;NR;NRU;157;Aiwo;Aiwo;district;01;15642
+Nauru;NR;NRU;157;Anabar;Anabar;district;02;15637
+Nauru;NR;NRU;157;Anetan;Anetan;district;03;15643
+Nauru;NR;NRU;157;Anibare;Anibare;district;04;15641
+Nauru;NR;NRU;157;Baiti;Baiti;district;05;15647
+Nauru;NR;NRU;157;Boe;Boe;district;06;15644
+Nauru;NR;NRU;157;Buada;Buada;district;07;15640
+Nauru;NR;NRU;157;Denigomodu;Denigomodu;district;08;15648
+Nauru;NR;NRU;157;Ewa;Ewa;district;09;15645
+Nauru;NR;NRU;157;Ijuw;Ijuw;district;10;15639
+Nauru;NR;NRU;157;Meneng;Meneng;district;11;15646
+Nauru;NR;NRU;157;Nibok;Nibok;district;12;15636
+Nauru;NR;NRU;157;Uaboe;Uaboe;district;13;15638
+Nauru;NR;NRU;157;Yaren;Yaren;district;14;15635
+Nepal;NP;NPL;158;Bagmati;Bagmati;zone;BA;20177
+Nepal;NP;NPL;158;Bheri;Bheri;zone;BH;20178
+Nepal;NP;NPL;158;Dhawalagiri;Dhawalagiri;zone;DH;20179
+Nepal;NP;NPL;158;Gandaki;Gandaki;zone;GA;20180
+Nepal;NP;NPL;158;Janakpur;Janakpur;zone;JA;20181
+Nepal;NP;NPL;158;Karnali;Karnali;zone;KA;20182
+Nepal;NP;NPL;158;"Kosi (Koshi)";"Kosi (Koshi)";zone;KO;20183
+Nepal;NP;NPL;158;Lumbini;Lumbini;zone;LU;20184
+Nepal;NP;NPL;158;"Madhya Pashchimanchal";"Madhya Pashchimanchal";"development region";2;48537
+Nepal;NP;NPL;158;Madhyamanchal;Madhyamanchal;"development region";1;48536
+Nepal;NP;NPL;158;Mahakali;Mahakali;zone;MA;20185
+Nepal;NP;NPL;158;Mechi;Mechi;zone;ME;20186
+Nepal;NP;NPL;158;Narayani;Narayani;zone;NA;20187
+Nepal;NP;NPL;158;Pashchimanchal;Pashchimanchal;"development region";3;48538
+Nepal;NP;NPL;158;Purwanchal;Purwanchal;"development region";4;48539
+Nepal;NP;NPL;158;Rapti;Rapti;zone;RA;20188
+Nepal;NP;NPL;158;Sagarmatha;Sagarmatha;zone;SA;20189
+Nepal;NP;NPL;158;Seti;Seti;zone;SE;20190
+Nepal;NP;NPL;158;"Sudur Pashchimanchal";"Sudur Pashchimanchal";"development region";5;48540
+Netherlands;NL;NLD;159;"Aruba (see also separate entry under AW)";"Aruba (see also separate entry under AW)";country;AW;48857
+Netherlands;NL;NLD;159;"Bonaire (see also separate entry under BQ)";"Bonaire (see also separate entry under BQ)";"special municipality";BQ1;48860
+Netherlands;NL;NLD;159;"Curaçao (see also separate entry under CW)";"Curacao (see also separate entry under CW)";country;CW;48858
+Netherlands;NL;NLD;159;Drenthe;Drenthe;province;DR;15727
+Netherlands;NL;NLD;159;Flevoland;Flevoland;province;FL;15731
+Netherlands;NL;NLD;159;Friesland;Friesland;province;FR;15730
+Netherlands;NL;NLD;159;Gelderland;Gelderland;province;GE;15726
+Netherlands;NL;NLD;159;Groningen;Groningen;province;GR;15732
+Netherlands;NL;NLD;159;Limburg;Limburg;province;LI;15735
+Netherlands;NL;NLD;159;Noord-Brabant;Noord-Brabant;province;NB;15729
+Netherlands;NL;NLD;159;Noord-Holland;Noord-Holland;province;NH;15736
+Netherlands;NL;NLD;159;Overijssel;Overijssel;province;OV;15733
+Netherlands;NL;NLD;159;"Saba (see also separate entry under BQ)";"Saba (see also separate entry under BQ)";"special municipality";BQ2;48861
+Netherlands;NL;NLD;159;"Sint Eustatius (see also separate entry under BQ)";"Sint Eustatius (see also separate entry under BQ)";"special municipality";BQ3;48862
+Netherlands;NL;NLD;159;"Sint Maarten (see also separate entry under SX)";"Sint Maarten (see also separate entry under SX)";country;SX;48859
+Netherlands;NL;NLD;159;Utrecht;Utrecht;province;UT;15725
+Netherlands;NL;NLD;159;Zeeland;Zeeland;province;ZE;15728
+Netherlands;NL;NLD;159;Zuid-Holland;Zuid-Holland;province;ZH;15734
+"New Zealand";NZ;NZL;162;Auckland;Auckland;"regional council";AUK;15748
+"New Zealand";NZ;NZL;162;"Bay of Plenty";"Bay of Plenty";"regional council";BOP;15753
+"New Zealand";NZ;NZL;162;Canterbury;Canterbury;"regional council";CAN;15754
+"New Zealand";NZ;NZL;162;"Chatham  Islands Territory";"Chatham  Islands Territory";"special island authority";X1~;48138
+"New Zealand";NZ;NZL;162;"Chatham  Islands Territory";"Chatham  Islands Territory";"special island authority";CIT;19036
+"New Zealand";NZ;NZL;162;"Gisborne District";"Gisborne District";"unitary authority";GIS;15749
+"New Zealand";NZ;NZL;162;"Hawkes's Bay";"Hawkes's Bay";"regional council";HKB;15755
+"New Zealand";NZ;NZL;162;Manawatu-Wanganui;Manawatu-Wanganui;"regional council";MWT;15750
+"New Zealand";NZ;NZL;162;"Marlborough District";"Marlborough District";"unitary authority";MBH;15756
+"New Zealand";NZ;NZL;162;"Nelson City";"Nelson City";"unitary authority";NSN;15757
+"New Zealand";NZ;NZL;162;"North Island";"North Island";island;N;48235
+"New Zealand";NZ;NZL;162;Northland;Northland;"regional council";NTL;15747
+"New Zealand";NZ;NZL;162;Otago;Otago;"regional council";OTA;15758
+"New Zealand";NZ;NZL;162;"South Island";"South Island";island;S;48236
+"New Zealand";NZ;NZL;162;Southland;Southland;"regional council";STL;15759
+"New Zealand";NZ;NZL;162;Taranaki;Taranaki;"regional council";TKI;15751
+"New Zealand";NZ;NZL;162;"Tasman District";"Tasman District";"unitary authority";TAS;15760
+"New Zealand";NZ;NZL;162;Waikato;Waikato;"regional council";WKO;15746
+"New Zealand";NZ;NZL;162;Wellington;Wellington;"regional council";WGN;15761
+"New Zealand";NZ;NZL;162;"West Coast";"West Coast";"regional council";WTC;15762
+Nicaragua;NI;NIC;163;"Atlántico Norte*";"Atlantico Norte";"autonomous region";AN;15779
+Nicaragua;NI;NIC;163;"Atlántico Sur*";"Atlantico Sur";"autonomous region";AS;15771
+Nicaragua;NI;NIC;163;Boaco;Boaco;department;BO;15772
+Nicaragua;NI;NIC;163;Carazo;Carazo;department;CA;15766
+Nicaragua;NI;NIC;163;Chinandega;Chinandega;department;CI;15770
+Nicaragua;NI;NIC;163;Chontales;Chontales;department;CO;15765
+Nicaragua;NI;NIC;163;Estelí;Esteli;department;ES;15773
+Nicaragua;NI;NIC;163;Granada;Granada;department;GR;15777
+Nicaragua;NI;NIC;163;Jinotega;Jinotega;department;JI;15769
+Nicaragua;NI;NIC;163;León;Leon;department;LE;15774
+Nicaragua;NI;NIC;163;Madriz;Madriz;department;MD;15778
+Nicaragua;NI;NIC;163;Managua;Managua;department;MN;15768
+Nicaragua;NI;NIC;163;Masaya;Masaya;department;MS;15764
+Nicaragua;NI;NIC;163;Matagalpa;Matagalpa;department;MT;15775
+Nicaragua;NI;NIC;163;"Nueva Segovia";"Nueva Segovia";department;NS;15767
+Nicaragua;NI;NIC;163;Rivas;Rivas;department;RI;15776
+Nicaragua;NI;NIC;163;"Río San Juan";"Rio San Juan";department;SJ;15763
+Niger;NE;NER;164;Agadez;Agadez;region;1;15782
+Niger;NE;NER;164;Diffa;Diffa;region;2;15783
+Niger;NE;NER;164;Dosso;Dosso;region;3;15784
+Niger;NE;NER;164;Maradi;Maradi;region;4;15785
+Niger;NE;NER;164;Niamey;Niamey;"capital district";8;15786
+Niger;NE;NER;164;Tahoua;Tahoua;region;5;15787
+Niger;NE;NER;164;Tillabéri;Tillaberi;region;6;15788
+Niger;NE;NER;164;Zinder;Zinder;region;7;15789
+Nigeria;NG;NGA;165;Abia;Abia;state;AB;21217
+Nigeria;NG;NGA;165;"Abuja Federal Capital Territory";"Abuja Federal Capital Territory";"capital territory";FC;15801
+Nigeria;NG;NGA;165;Adamawa;Adamawa;state;AD;15802
+Nigeria;NG;NGA;165;"Akwa Ibom";"Akwa Ibom";state;AK;15803
+Nigeria;NG;NGA;165;Anambra;Anambra;state;AN;15804
+Nigeria;NG;NGA;165;Bauchi;Bauchi;state;BA;15805
+Nigeria;NG;NGA;165;Bayelsa;Bayelsa;state;BY;15826
+Nigeria;NG;NGA;165;Benue;Benue;state;BE;15817
+Nigeria;NG;NGA;165;Borno;Borno;state;BO;15806
+Nigeria;NG;NGA;165;"Cross River";"Cross River";state;CR;15818
+Nigeria;NG;NGA;165;Delta;Delta;state;DE;15799
+Nigeria;NG;NGA;165;Ebonyi;Ebonyi;state;EB;15819
+Nigeria;NG;NGA;165;Edo;Edo;state;ED;15820
+Nigeria;NG;NGA;165;Ekiti;Ekiti;state;EK;15807
+Nigeria;NG;NGA;165;Enugu;Enugu;state;EN;15821
+Nigeria;NG;NGA;165;Gombe;Gombe;state;GO;15822
+Nigeria;NG;NGA;165;Imo;Imo;state;IM;15798
+Nigeria;NG;NGA;165;Jigawa;Jigawa;state;JI;15823
+Nigeria;NG;NGA;165;Kaduna;Kaduna;state;KD;15824
+Nigeria;NG;NGA;165;Kano;Kano;state;KN;15828
+Nigeria;NG;NGA;165;Katsina;Katsina;state;KT;15825
+Nigeria;NG;NGA;165;Kebbi;Kebbi;state;KE;15808
+Nigeria;NG;NGA;165;Kogi;Kogi;state;KO;15797
+Nigeria;NG;NGA;165;Kwara;Kwara;state;KW;15809
+Nigeria;NG;NGA;165;Lagos;Lagos;state;LA;15810
+Nigeria;NG;NGA;165;Nassarawa;Nassarawa;state;NA;15794
+Nigeria;NG;NGA;165;Niger;Niger;state;NI;15811
+Nigeria;NG;NGA;165;Ogun;Ogun;state;OG;15812
+Nigeria;NG;NGA;165;Ondo;Ondo;state;ON;15795
+Nigeria;NG;NGA;165;Osun;Osun;state;OS;15813
+Nigeria;NG;NGA;165;Oyo;Oyo;state;OY;15814
+Nigeria;NG;NGA;165;Plateau;Plateau;state;PL;15796
+Nigeria;NG;NGA;165;Rivers;Rivers;state;RI;15815
+Nigeria;NG;NGA;165;Sokoto;Sokoto;state;SO;15816
+Nigeria;NG;NGA;165;Taraba;Taraba;state;TA;15793
+Nigeria;NG;NGA;165;Yobe;Yobe;state;YO;15827
+Nigeria;NG;NGA;165;Zamfara;Zamfara;state;ZA;15792
+Norway;NO;NOR;169;Akershus;Akershus;county;02;15866
+Norway;NO;NOR;169;Aust-Agder;Aust-Agder;county;09;15853
+Norway;NO;NOR;169;Buskerud;Buskerud;county;06;15854
+Norway;NO;NOR;169;Finnmark;Finnmark;county;20;15852
+Norway;NO;NOR;169;Hedmark;Hedmark;county;04;15855
+Norway;NO;NOR;169;Hordaland;Hordaland;county;12;15867
+Norway;NO;NOR;169;"Jan Mayen (Arctic Region) (See also country code SJ)";"Jan Mayen (Arctic Region) (See also country code SJ)";;22;19038
+Norway;NO;NOR;169;"Møre og Romsdal";"More og Romsdal";county;15;15856
+Norway;NO;NOR;169;Nord-Trøndelag;Nord-Trondelag;county;17;15851
+Norway;NO;NOR;169;Nordland;Nordland;county;18;15857
+Norway;NO;NOR;169;Oppland;Oppland;county;05;15858
+Norway;NO;NOR;169;Oslo;Oslo;county;03;15859
+Norway;NO;NOR;169;Rogaland;Rogaland;county;11;15860
+Norway;NO;NOR;169;"Sogn og Fjordane";"Sogn og Fjordane";county;14;15861
+Norway;NO;NOR;169;"Svalbard (Arctic Region) (See also country code SJ)";"Svalbard (Arctic Region) (See also country code SJ)";;21;19039
+Norway;NO;NOR;169;Sør-Trøndelag;Sor-Trondelag;county;16;15849
+Norway;NO;NOR;169;Telemark;Telemark;county;08;15862
+Norway;NO;NOR;169;Troms;Troms;county;19;15863
+Norway;NO;NOR;169;Vest-Agder;Vest-Agder;county;10;15848
+Norway;NO;NOR;169;Vestfold;Vestfold;county;07;15864
+Norway;NO;NOR;169;Østfold;Ostfold;county;01;15850
+Oman;OM;OMN;170;"Ad Dakhiliyah";"Ad Dakhiliyah";region;DA;15871
+Oman;OM;OMN;170;"Al Batinah";"Al Batinah";region;BA;15873
+Oman;OM;OMN;170;"Al Buraymi";"Al Buraymi";governorate;X1~;48137
+Oman;OM;OMN;170;"Al Buraymi";"Al Buraymi";governorate;BU;21361
+Oman;OM;OMN;170;"Al Wustá";"Al Wusta";region;WU;15872
+Oman;OM;OMN;170;"Ash Sharqiyah";"Ash Sharqiyah";region;SH;15870
+Oman;OM;OMN;170;"Az̧ Z̧āhirah";"Az Zahirah";region;ZA;15868
+Oman;OM;OMN;170;Dhofar;Dhofar;governorate;JA;15869
+Oman;OM;OMN;170;Masqat;Masqat;governorate;MA;15875
+Oman;OM;OMN;170;Musandam;Musandam;governorate;MU;15874
+Oman;OM;OMN;170;Z̧ufār;Zufar;governorate;ZU;48237
+Pakistan;PK;PAK;171;"Azad Kashmir";"Azad Kashmir";"pakistan administered area";JK;15882
+Pakistan;PK;PAK;171;"Baluchistan (en)";"Baluchistan (en)";province;BA;15881
+Pakistan;PK;PAK;171;"Federally Administered Tribal Areas";"Federally Administered Tribal Areas";territory;TA;15878
+Pakistan;PK;PAK;171;Gilgit-Baltistan;Gilgit-Baltistan;"administered areas";GB;48707
+Pakistan;PK;PAK;171;Islamabad;Islamabad;"federal capital territory";IS;15883
+Pakistan;PK;PAK;171;"Khyber Pakhtunkhwa";"Khyber Pakhtunkhwa";province;KP;48709
+Pakistan;PK;PAK;171;"North-West Frontier";"North-West Frontier";province;NW;15879
+Pakistan;PK;PAK;171;"Northern Areas";"Northern Areas";"pakistan administered area";NA;15877
+Pakistan;PK;PAK;171;Punjab;Punjab;province;PB;15876
+Pakistan;PK;PAK;171;Sindh;Sindh;province;SD;15880
+Palau;PW;PLW;172;Aimeliik;Aimeliik;state;002;15887
+Palau;PW;PLW;172;Airai;Airai;state;004;15898
+Palau;PW;PLW;172;Angaur;Angaur;state;010;15889
+Palau;PW;PLW;172;Hatobohei;Hatobohei;state;050;15886
+Palau;PW;PLW;172;Kayangel;Kayangel;state;100;15890
+Palau;PW;PLW;172;Koror;Koror;state;150;15891
+Palau;PW;PLW;172;Melekeok;Melekeok;state;212;15888
+Palau;PW;PLW;172;Ngaraard;Ngaraard;state;214;15892
+Palau;PW;PLW;172;Ngarchelong;Ngarchelong;state;218;15899
+Palau;PW;PLW;172;Ngardmau;Ngardmau;state;222;15893
+Palau;PW;PLW;172;Ngatpang;Ngatpang;state;224;15894
+Palau;PW;PLW;172;Ngchesar;Ngchesar;state;226;15895
+Palau;PW;PLW;172;Ngeremlengui;Ngeremlengui;state;227;15885
+Palau;PW;PLW;172;Ngiwal;Ngiwal;state;228;15896
+Palau;PW;PLW;172;Peleliu;Peleliu;state;350;15897
+Palau;PW;PLW;172;Sonsorol;Sonsorol;state;370;15884
+"Occupied Palestinian Territory";PS;PSE;173;"Bethlehem Bayt Laḩm";"Bethlehem Bayt Lahm";governorate;BTH;48863
+"Occupied Palestinian Territory";PS;PSE;173;"Deir El Balah Dayr al Balaḩ";"Deir El Balah Dayr al Balah”;governorate;DEB;48864
+"Occupied Palestinian Territory";PS;PSE;173;"Gaza Ghazzah";"Gaza Ghazzah";governorate;GZA;48865
+"Occupied Palestinian Territory";PS;PSE;173;"Hebron Al Khalīl";"Hebron Al Khalil";governorate;HBN;48866
+"Occupied Palestinian Territory";PS;PSE;173;"Jenin Janīn";"Jenin Janin";governorate;JEN;48867
+"Occupied Palestinian Territory";PS;PSE;173;"Jericho – Al Aghwar Arīḩā wa al Aghwār";"Jericho - Al Aghwar Ariha wa al Aghwar";governorate;JRH;48868
+"Occupied Palestinian Territory";PS;PSE;173;"Jerusalem Al Quds";"Jerusalem Al Quds";governorate;JEM;48869
+"Occupied Palestinian Territory";PS;PSE;173;"Khan Yunis Khān Yūnis";"Khan Yunis Khan Yunis";governorate;KYS;48870
+"Occupied Palestinian Territory";PS;PSE;173;"Nablus Nāblus";"Nablus Nablus";governorate;NBS;48871
+"Occupied Palestinian Territory";PS;PSE;173;"North Gaza Shamāl Ghazzah";"North Gaza Shamal Ghazzah";governorate;NGZ;48872
+"Occupied Palestinian Territory";PS;PSE;173;"Qalqilya Qalqīlyah";"Qalqilya Qalqilyah";governorate;QQA;48873
+"Occupied Palestinian Territory";PS;PSE;173;"Rafah Rafaḩ";"Rafah Rafah”;governorate;RFH;48874
+"Occupied Palestinian Territory";PS;PSE;173;"Ramallah Rām Allāh wa al Bīrah";"Ramallah Ram Allah wa al Birah";governorate;RBH;48875
+"Occupied Palestinian Territory";PS;PSE;173;"Salfit Salfīt";"Salfit Salfit";governorate;SLT;48876
+"Occupied Palestinian Territory";PS;PSE;173;"Tubas Ţūbās";"Tubas Tubas";governorate;TBS;48877
+"Occupied Palestinian Territory";PS;PSE;173;"Tulkarm Ţūlkarm";"Tulkarm Tulkarm";governorate;TKM;48878
+Panama;PA;PAN;175;"Bocas del Toro";"Bocas del Toro";province;1;15928
+Panama;PA;PAN;175;Chiriquí;Chiriqui;province;4;15920
+Panama;PA;PAN;175;Coclé;Cocle;province;2;15929
+Panama;PA;PAN;175;Colón;Colon;province;3;15921
+Panama;PA;PAN;175;"Comarca de San Blas";"Comarca de San Blas";comarca;0;15925
+Panama;PA;PAN;175;Darién;Darien;province;5;15922
+Panama;PA;PAN;175;Emberá;Embera;"indigenous region";EM;15926
+Panama;PA;PAN;175;Herrera;Herrera;province;6;15923
+Panama;PA;PAN;175;"Los Santos";"Los Santos";province;7;15917
+Panama;PA;PAN;175;Ngöbe-Buglé;Ngobe-Bugle;"indigenous region";NB;15919
+Panama;PA;PAN;175;Panamá;Panama;province;8;15916
+Panama;PA;PAN;174;"Kuna Yala";"Kuna Yala";"indigenous region";KY;48238
+Panama;PA;PAN;175;Veraguas;Veraguas;province;9;15927
+"Papua New Guinea";PG;PNG;176;Bougainville;Bougainville;"autonomous region";NSB;48706
+"Papua New Guinea";PG;PNG;176;Central;Central;province;CPM;15935
+"Papua New Guinea";PG;PNG;176;Chimbu;Chimbu;province;CPK;15931
+"Papua New Guinea";PG;PNG;176;"East New Britain";"East New Britain";province;EBR;15946
+"Papua New Guinea";PG;PNG;176;"East Sepik";"East Sepik";province;ESW;15937
+"Papua New Guinea";PG;PNG;176;"Eastern Highlands";"Eastern Highlands";province;EHG;15936
+"Papua New Guinea";PG;PNG;176;Enga;Enga;province;EPW;15934
+"Papua New Guinea";PG;PNG;176;Gulf;Gulf;province;GPK;15947
+"Papua New Guinea";PG;PNG;176;Madang;Madang;province;MPM;15939
+"Papua New Guinea";PG;PNG;176;Manus;Manus;province;MRL;15933
+"Papua New Guinea";PG;PNG;176;"Milne Bay";"Milne Bay";province;MBA;15940
+"Papua New Guinea";PG;PNG;176;Morobe;Morobe;province;MPL;15941
+"Papua New Guinea";PG;PNG;176;"National Capital District (Port Moresby)";"National Capital District (Port Moresby)";district;NCD;15948
+"Papua New Guinea";PG;PNG;176;"New Ireland";"New Ireland";province;NIK;15932
+"Papua New Guinea";PG;PNG;176;"North Solomons";"North Solomons";province;NSA;15942
+"Papua New Guinea";PG;PNG;176;Northern;Northern;province;NPP;15949
+"Papua New Guinea";PG;PNG;176;"Sandaun (West Sepik)";"Sandaun (West Sepik)";province;SAN;15943
+"Papua New Guinea";PG;PNG;176;"Southern Highlands";"Southern Highlands";province;SHM;15944
+"Papua New Guinea";PG;PNG;176;"West New Britain";"West New Britain";province;WBK;15945
+"Papua New Guinea";PG;PNG;176;Western;Western;province;WPD;15938
+"Papua New Guinea";PG;PNG;176;"Western Highlands";"Western Highlands";province;WHM;15950
+Paraguay;PY;PRY;177;"Alto Paraguay";"Alto Paraguay";department;16;15963
+Paraguay;PY;PRY;177;"Alto Paraná";"Alto Parana";department;10;15964
+Paraguay;PY;PRY;177;Amambay;Amambay;department;13;15965
+Paraguay;PY;PRY;177;Asunción;Asuncion;capital;ASU;15954
+Paraguay;PY;PRY;177;Boquerón;Boqueron;department;19;15953
+Paraguay;PY;PRY;177;Caaguazú;Caaguazu;department;5;15955
+Paraguay;PY;PRY;177;Caazapá;Caazapa;department;6;15966
+Paraguay;PY;PRY;177;Canindeyú;Canindeyu;department;14;15956
+Paraguay;PY;PRY;177;Central;Central;department;11;15952
+Paraguay;PY;PRY;177;Concepción;Concepcion;department;1;15957
+Paraguay;PY;PRY;177;Cordillera;Cordillera;department;3;15958
+Paraguay;PY;PRY;177;Guairá;Guaira;department;4;15967
+Paraguay;PY;PRY;177;Itapúa;Itapua;department;7;15959
+Paraguay;PY;PRY;177;Misiones;Misiones;department;8;15968
+Paraguay;PY;PRY;177;Paraguarí;Paraguari;department;9;15951
+Paraguay;PY;PRY;177;"Presidente Hayes";"Presidente Hayes";department;15;15961
+Paraguay;PY;PRY;177;"San Pedro";"San Pedro";department;2;15962
+Paraguay;PY;PRY;177;Ñeembucú;Neembucu;department;12;15960
+Peru;PE;PER;178;Amazonas;Amazonas;department;AMA;15982
+Peru;PE;PER;178;Ancash;Ancash;department;ANC;15981
+Peru;PE;PER;178;Apurímac;Apurimac;department;APU;15983
+Peru;PE;PER;178;Arequipa;Arequipa;department;ARE;15972
+Peru;PE;PER;178;Ayacucho;Ayacucho;department;AYA;15984
+Peru;PE;PER;178;Cajamarca;Cajamarca;department;CAJ;15985
+Peru;PE;PER;178;"Cusco (Cuzco)";"Cusco (Cuzco)";department;CUS;15989
+Peru;PE;PER;178;"El Callao";"El Callao";"constitutional province";CAL;15992
+Peru;PE;PER;178;Huancavelica;Huancavelica;department;HUV;15986
+Peru;PE;PER;178;Huánuco;Huanuco;department;HUC;15987
+Peru;PE;PER;178;Ica;Ica;department;ICA;15971
+Peru;PE;PER;178;Junín;Junin;department;JUN;15988
+Peru;PE;PER;178;"La Libertad";"La Libertad";department;LAL;15990
+Peru;PE;PER;178;Lambayeque;Lambayeque;department;LAM;15973
+Peru;PE;PER;178;Lima;Lima;department;LIM;15969
+Peru;PE;PER;178;Loreto;Loreto;department;LOR;15974
+Peru;PE;PER;178;"Madre de Dios";"Madre de Dios";department;MDD;15970
+Peru;PE;PER;178;Moquegua;Moquegua;department;MOQ;15975
+Peru;PE;PER;178;"Municipalidad Metropolitana de Lima";"Municipalidad Metropolitana de Lima";municipality;LMA;42646
+Peru;PE;PER;178;"Municipalidad Metropolitana de Lima";"Municipalidad Metropolitana de Lima";municipality;X1~;48136
+Peru;PE;PER;178;Pasco;Pasco;department;PAS;15991
+Peru;PE;PER;178;Piura;Piura;department;PIU;15976
+Peru;PE;PER;178;Puno;Puno;department;PUN;15977
+Peru;PE;PER;178;"San Martín";"San Martin";department;SAM;15994
+Peru;PE;PER;178;Tacna;Tacna;department;TAC;15978
+Peru;PE;PER;178;Tumbes;Tumbes;department;TUM;15979
+Peru;PE;PER;178;Ucayali;Ucayali;department;UCA;15993
+Philippines;PH;PHL;180;Abra;Abra;province;ABR;17214
+Philippines;PH;PHL;180;"Agusan del Norte";"Agusan del Norte";province;AGN;16310
+Philippines;PH;PHL;180;"Agusan del Sur";"Agusan del Sur";province;AGS;17293
+Philippines;PH;PHL;180;Aklan;Aklan;province;AKL;16347
+Philippines;PH;PHL;180;Albay;Albay;province;ALB;16303
+Philippines;PH;PHL;180;Antique;Antique;province;ANT;16348
+Philippines;PH;PHL;180;Apayao;Apayao;province;APA;17215
+Philippines;PH;PHL;180;Aurora;Aurora;province;AUR;17115
+Philippines;PH;PHL;180;"Autonomous Region in Muslim Mindanao (ARMM)";"Autonomous Region in Muslim Mindanao (ARMM)";region;14;17207
+Philippines;PH;PHL;180;Basilan;Basilan;province;BAS;17237
+Philippines;PH;PHL;180;Bataan;Bataan;province;BAN;16312
+Philippines;PH;PHL;180;Batanes;Batanes;province;BTN;16307
+Philippines;PH;PHL;180;Batangas;Batangas;province;BTG;17233
+Philippines;PH;PHL;180;Benguet;Benguet;province;BEN;16315
+Philippines;PH;PHL;180;"Bicol (Region V)";"Bicol (Region V)";region;05;17201
+Philippines;PH;PHL;180;Biliran;Biliran;province;BIL;17217
+Philippines;PH;PHL;180;Bohol;Bohol;province;BOH;17303
+Philippines;PH;PHL;180;Bukidnon;Bukidnon;province;BUK;16333
+Philippines;PH;PHL;180;Bulacan;Bulacan;province;BUL;17295
+Philippines;PH;PHL;180;Cagayan;Cagayan;province;CAG;17291
+Philippines;PH;PHL;180;"Cagayan Valley (Region II)";"Cagayan Valley (Region II)";region;02;16298
+Philippines;PH;PHL;180;"CALABARZON (Region IV-A)";"CALABARZON (Region IV-A)";region;40;48239
+Philippines;PH;PHL;180;"Camarines Norte";"Camarines Norte";province;CAN;16304
+Philippines;PH;PHL;180;"Camarines Sur";"Camarines Sur";province;CAS;17289
+Philippines;PH;PHL;180;Camiguin;Camiguin;province;CAM;16334
+Philippines;PH;PHL;180;Capiz;Capiz;province;CAP;17239
+Philippines;PH;PHL;180;"Caraga (Region XIII)";"Caraga (Region XIII)";region;13;16299
+Philippines;PH;PHL;180;Catanduanes;Catanduanes;province;CAT;16305
+Philippines;PH;PHL;180;Cavite;Cavite;province;CAV;16340
+Philippines;PH;PHL;180;Cebu;Cebu;province;CEB;17304
+Philippines;PH;PHL;180;"Central Luzon (Region III)";"Central Luzon (Region III)";region;03;17202
+Philippines;PH;PHL;180;"Central Visayas (Region VII)";"Central Visayas (Region VII)";region;07;17203
+Philippines;PH;PHL;180;"Compostela Valley";"Compostela Valley";province;COM;17230
+Philippines;PH;PHL;180;"Cordillera Administrative Region (CAR)";"Cordillera Administrative Region (CAR)";region;15;17204
+Philippines;PH;PHL;180;Cotabato;Cotabato;province;NCO;17298
+Philippines;PH;PHL;180;"Davao (Region XI)";"Davao (Region XI)";region;11;48240
+Philippines;PH;PHL;180;"Davao del Norte";"Davao del Norte";province;DAV;16336
+Philippines;PH;PHL;180;"Davao del Sur";"Davao del Sur";province;DAS;17231
+Philippines;PH;PHL;180;"Davao Oriental";"Davao Oriental";province;DAO;16337
+Philippines;PH;PHL;180;"Dinagat Islands";"Dinagat Islands";province;DIN;16521
+Philippines;PH;PHL;180;"Dinagat Islands";"Dinagat Islands";;X1~;48135
+Philippines;PH;PHL;180;"Eastern Samar";"Eastern Samar";province;EAS;16318
+Philippines;PH;PHL;180;"Eastern Visayas (Region VIII)";"Eastern Visayas (Region VIII)";region;08;17205
+Philippines;PH;PHL;180;Guimaras;Guimaras;province;GUI;16349
+Philippines;PH;PHL;180;Ifugao;Ifugao;province;IFU;16316
+Philippines;PH;PHL;180;"Ilocos (Region I)";"Ilocos (Region I)";region;01;17206
+Philippines;PH;PHL;180;"Ilocos Norte";"Ilocos Norte";province;ILN;16321
+Philippines;PH;PHL;180;"Ilocos Sur";"Ilocos Sur";province;ILS;17220
+Philippines;PH;PHL;180;Iloilo;Iloilo;province;ILI;17240
+Philippines;PH;PHL;180;Isabela;Isabela;province;ISA;16308
+Philippines;PH;PHL;180;Kalinga;Kalinga;province;KAL;17216
+Philippines;PH;PHL;180;"La Union";"La Union";province;LUN;16322
+Philippines;PH;PHL;180;Laguna;Laguna;province;LAG;16341
+Philippines;PH;PHL;180;"Lanao del Norte";"Lanao del Norte";province;LAN;17300
+Philippines;PH;PHL;180;"Lanao del Sur";"Lanao del Sur";province;LAS;16301
+Philippines;PH;PHL;180;Leyte;Leyte;province;LEY;16765
+Philippines;PH;PHL;180;Maguindanao;Maguindanao;province;MAG;17287
+Philippines;PH;PHL;180;Marinduque;Marinduque;province;MAD;17234
+Philippines;PH;PHL;180;Masbate;Masbate;province;MAS;17290
+Philippines;PH;PHL;180;"MIMAROPA (Region IV-B)";"MIMAROPA (Region IV-B)";region;41;48241
+Philippines;PH;PHL;180;"Mindoro Occidental";"Mindoro Occidental";province;MDC;16342
+Philippines;PH;PHL;180;"Mindoro Oriental";"Mindoro Oriental";province;MDR;17235
+Philippines;PH;PHL;180;"Misamis Occidental";"Misamis Occidental";province;MSC;17229
+Philippines;PH;PHL;180;"Misamis Oriental";"Misamis Oriental";province;MSR;16335
+Philippines;PH;PHL;180;"Mountain Province";"Mountain Province";province;MOU;16317
+Philippines;PH;PHL;180;"National Capital Region";"National Capital Region";region;00;17208
+Philippines;PH;PHL;180;"Negros Occidental";"Negros Occidental";province;NEC;16350
+Philippines;PH;PHL;180;"Negros Oriental";"Negros Oriental";province;NER;17305
+Philippines;PH;PHL;180;"Northern Mindanao (Region X)";"Northern Mindanao (Region X)";region;10;17209
+Philippines;PH;PHL;180;"Northern Samar";"Northern Samar";province;NSA;17218
+Philippines;PH;PHL;180;"Nueva Ecija";"Nueva Ecija";province;NUE;16313
+Philippines;PH;PHL;180;"Nueva Vizcaya";"Nueva Vizcaya";province;NUV;17292
+Philippines;PH;PHL;180;Palawan;Palawan;province;PLW;16343
+Philippines;PH;PHL;180;Pampanga;Pampanga;province;PAM;16314
+Philippines;PH;PHL;180;Pangasinan;Pangasinan;province;PAN;16323
+Philippines;PH;PHL;180;Quezon;Quezon;province;QUE;17595
+Philippines;PH;PHL;180;Quirino;Quirino;province;QUI;16144
+Philippines;PH;PHL;180;Rizal;Rizal;province;RIZ;17583
+Philippines;PH;PHL;180;Romblon;Romblon;province;ROM;17082
+Philippines;PH;PHL;180;Sarangani;Sarangani;province;SAR;17232
+Philippines;PH;PHL;180;"Shariff Kabunsuan";"Shariff Kabunsuan";;X2~;21362
+Philippines;PH;PHL;180;Siquijor;Siquijor;province;SIG;17306
+Philippines;PH;PHL;180;"Soccsksargen (Region XII)";"Soccsksargen (Region XII)";region;12;48242
+Philippines;PH;PHL;180;Sorsogon;Sorsogon;province;SOR;16306
+Philippines;PH;PHL;180;"South Cotabato";"South Cotabato";province;SCO;16338
+Philippines;PH;PHL;180;"Southern Leyte";"Southern Leyte";province;SLE;17219
+Philippines;PH;PHL;180;"Sultan Kudarat";"Sultan Kudarat";province;SUK;17302
+Philippines;PH;PHL;180;Sulu;Sulu;province;SLU;16302
+Philippines;PH;PHL;180;"Surigao del Norte";"Surigao del Norte";province;SUN;16311
+Philippines;PH;PHL;180;"Surigao del Sur";"Surigao del Sur";province;SUR;17294
+Philippines;PH;PHL;180;Tarlac;Tarlac;province;TAR;17296
+Philippines;PH;PHL;180;Tawi-Tawi;Tawi-Tawi;province;TAW;17288
+Philippines;PH;PHL;180;"Western Samar";"Western Samar";province;WSA;16320
+Philippines;PH;PHL;180;"Western Visayas (Region VI)";"Western Visayas (Region VI)";region;06;17213
+Philippines;PH;PHL;180;Zambales;Zambales;province;ZMB;17297
+Philippines;PH;PHL;180;"Zamboanga del Norte";"Zamboanga del Norte";province;ZAN;16346
+Philippines;PH;PHL;180;"Zamboanga del Sur";"Zamboanga del Sur";province;ZAS;17238
+Philippines;PH;PHL;180;"Zamboanga Peninsula (Region IX)";"Zamboanga Peninsula (Region IX)";region;09;48243
+Philippines;PH;PHL;180;"Zamboanga Sibuguey (Zamboanga Sibugay)";"Zamboanga Sibuguey (Zamboanga Sibugay)";province;ZSI;17672
+Philippines;PH;PHL;180;;;;48079
+Poland;PL;POL;183;Dolnoslaskie;Dolnoslaskie;voivodeship;DS;17731
+Poland;PL;POL;183;Kujawsko-pomorskie;Kujawsko-pomorskie;voivodeship;KP;17732
+Poland;PL;POL;183;Lubelskie;Lubelskie;voivodeship;LU;17733
+Poland;PL;POL;183;Lubuskie;Lubuskie;voivodeship;LB;17740
+Poland;PL;POL;183;Lódzkie;Lodzkie;voivodeship;LD;17734
+Poland;PL;POL;183;Malopolskie;Malopolskie;voivodeship;MA;17744
+Poland;PL;POL;183;Mazowieckie;Mazowieckie;voivodeship;MZ;17735
+Poland;PL;POL;183;Opolskie;Opolskie;voivodeship;OP;17743
+Poland;PL;POL;183;Podkarpackie;Podkarpackie;voivodeship;PK;17736
+Poland;PL;POL;183;Podlaskie;Podlaskie;voivodeship;PD;17742
+Poland;PL;POL;183;Pomorskie;Pomorskie;voivodeship;PM;17737
+Poland;PL;POL;183;Slaskie;Slaskie;voivodeship;SL;17745
+Poland;PL;POL;183;Swietokrzyskie;Swietokrzyskie;voivodeship;SK;17738
+Poland;PL;POL;183;Warminsko-mazurskie;Warminsko-mazurskie;voivodeship;WN;17741
+Poland;PL;POL;183;Wielkopolskie;Wielkopolskie;voivodeship;WP;17739
+Poland;PL;POL;183;Zachodniopomorskie;Zachodniopomorskie;voivodeship;ZP;17730
+Portugal;PT;PRT;184;Aveiro;Aveiro;district;01;19045
+Portugal;PT;PRT;184;Beja;Beja;district;02;19046
+Portugal;PT;PRT;184;Braga;Braga;district;03;19047
+Portugal;PT;PRT;184;Bragança;Braganca;district;04;19048
+Portugal;PT;PRT;184;"Castelo Branco";"Castelo Branco";district;05;19049
+Portugal;PT;PRT;184;Coimbra;Coimbra;district;06;19050
+Portugal;PT;PRT;184;Faro;Faro;district;08;19052
+Portugal;PT;PRT;184;Guarda;Guarda;district;09;19053
+Portugal;PT;PRT;184;Leiria;Leiria;district;10;19054
+Portugal;PT;PRT;184;Lisboa;Lisboa;district;11;19055
+Portugal;PT;PRT;184;Portalegre;Portalegre;district;12;19056
+Portugal;PT;PRT;184;Porto;Porto;district;13;19057
+Portugal;PT;PRT;184;"Região Autónoma da Madeira";"Regiao Autonoma da Madeira";"autonomous region";30;17751
+Portugal;PT;PRT;184;"Região Autónoma dos Açores";"Regiao Autonoma dos Acores";"autonomous region";20;17748
+Portugal;PT;PRT;184;Santarém;Santarem;district;14;19058
+Portugal;PT;PRT;184;Setúbal;Setubal;district;15;19059
+Portugal;PT;PRT;184;"Viana do Castelo";"Viana do Castelo";district;16;19060
+Portugal;PT;PRT;184;"Vila Real";"Vila Real";district;17;19061
+Portugal;PT;PRT;184;Viseu;Viseu;district;18;19062
+Portugal;PT;PRT;184;Évora;Evora;district;07;19051
+Qatar;QA;QAT;186;"Ad Dawhah";"Ad Dawhah";municipality;DA;17769
+Qatar;QA;QAT;186;"Al Ghuwayriyah";"Al Ghuwayriyah";municipality;GH;17770
+Qatar;QA;QAT;186;"Al Jumayliyah";"Al Jumayliyah";municipality;JU;17764
+Qatar;QA;QAT;186;"Al Khawr wa adh Dhakhīrah";"Al Khawr wa adh Dhakhirah";municipality;KH;17765
+Qatar;QA;QAT;186;"Al Wakrah";"Al Wakrah";municipality;WA;17763
+Qatar;QA;QAT;186;"Ar Rayyan";"Ar Rayyan";municipality;RA;17771
+Qatar;QA;QAT;186;"Az̧ Z̧a‘āyin";"Az Za'ayin";municipality;ZA;48710
+Qatar;QA;QAT;186;"Jariyan al Batnah";"Jariyan al Batnah";municipality;JB;17768
+Qatar;QA;QAT;186;"Madinat ash Shamal";"Madinat ash Shamal";municipality;MS;17766
+Qatar;QA;QAT;186;"Umm Sa'id";"Umm Sa'id";municipality;X1~;17767
+Qatar;QA;QAT;186;"Umm Salal";"Umm Salal";municipality;US;17762
+Romania;RO;ROU;189;Alba;Alba;county;AB;17794
+Romania;RO;ROU;189;Arad;Arad;county;AR;17795
+Romania;RO;ROU;189;Arges;Arges;county;AG;17796
+Romania;RO;ROU;189;Bacau;Bacau;county;BC;17797
+Romania;RO;ROU;189;Bihor;Bihor;county;BH;17798
+Romania;RO;ROU;189;Bistrita-Nasaud;Bistrita-Nasaud;county;BN;17799
+Romania;RO;ROU;189;Botosani;Botosani;county;BT;17800
+Romania;RO;ROU;189;Braila;Braila;county;BR;17801
+Romania;RO;ROU;189;Brasov;Brasov;county;BV;17783
+Romania;RO;ROU;189;Bucuresti;Bucuresti;city;B;17802
+Romania;RO;ROU;189;Buzau;Buzau;county;BZ;17784
+Romania;RO;ROU;189;Calarasi;Calarasi;county;CL;17803
+Romania;RO;ROU;189;Caras-Severin;Caras-Severin;county;CS;17785
+Romania;RO;ROU;189;Cluj;Cluj;county;CJ;17804
+Romania;RO;ROU;189;Constanta;Constanta;county;CT;17786
+Romania;RO;ROU;189;Covasna;Covasna;county;CV;17805
+Romania;RO;ROU;189;Dolj;Dolj;county;DJ;17788
+Romania;RO;ROU;189;Dâmbovita;Dambovita;county;DB;17787
+Romania;RO;ROU;189;Galati;Galati;county;GL;17806
+Romania;RO;ROU;189;Giurgiu;Giurgiu;county;GR;17789
+Romania;RO;ROU;189;Gorj;Gorj;county;GJ;17790
+Romania;RO;ROU;189;Harghita;Harghita;county;HR;17807
+Romania;RO;ROU;189;Hunedoara;Hunedoara;county;HD;17791
+Romania;RO;ROU;189;Ialomita;Ialomita;county;IL;17782
+Romania;RO;ROU;189;Iasi;Iasi;county;IS;17792
+Romania;RO;ROU;189;Ilfov;Ilfov;county;IF;17817
+Romania;RO;ROU;189;Maramures;Maramures;county;MM;17793
+Romania;RO;ROU;189;Mehedinti;Mehedinti;county;MH;17808
+Romania;RO;ROU;189;Mures;Mures;county;MS;17821
+Romania;RO;ROU;189;Neamt;Neamt;county;NT;17809
+Romania;RO;ROU;189;Olt;Olt;county;OT;17820
+Romania;RO;ROU;189;Prahova;Prahova;county;PH;17810
+Romania;RO;ROU;189;Salaj;Salaj;county;SJ;17811
+Romania;RO;ROU;189;"Satu Mare";"Satu Mare";county;SM;17819
+Romania;RO;ROU;189;Sibiu;Sibiu;county;SB;17812
+Romania;RO;ROU;189;Suceava;Suceava;county;SV;17813
+Romania;RO;ROU;189;Teleorman;Teleorman;county;TR;17822
+Romania;RO;ROU;189;Timis;Timis;county;TM;17814
+Romania;RO;ROU;189;Tulcea;Tulcea;county;TL;17815
+Romania;RO;ROU;189;Vaslui;Vaslui;county;VS;17816
+Romania;RO;ROU;189;Vrancea;Vrancea;county;VN;17781
+Romania;RO;ROU;189;Vâlcea;Valcea;county;VL;17818
+"Russian Federation";RU;RUS;190;"Respublika Adygeya";"Respublika Adygeya";republic;AD;17879
+"Russian Federation";RU;RUS;190;"Aginskiy Buryatskiy avtonomnyy okrug";"Aginskiy Buryatskiy avtonomnyy okrug";"autonomous district";AGB;17880
+"Russian Federation";RU;RUS;190;"Respublika Altay";"Respublika Altay";republic;AL;17857
+"Russian Federation";RU;RUS;190;"Altayskiy kray";"Altayskiy kray";"administrative territory";ALT;17881
+"Russian Federation";RU;RUS;190;"Amurskaya oblast'";"Amurskaya oblast'";"administrative region";AMU;17882
+"Russian Federation";RU;RUS;190;"Arkhangel'skaya oblast'";"Arkhangel'skaya oblast'";"administrative region";ARK;17853
+"Russian Federation";RU;RUS;190;"Astrakhanskaya oblast'";"Astrakhanskaya oblast'";"administrative region";AST;17883
+"Russian Federation";RU;RUS;190;"Respublika Bashkortostan";"Respublika Bashkortostan";republic;BA;17884
+"Russian Federation";RU;RUS;190;"Belgorodskaya oblast'";"Belgorodskaya oblast'";"administrative region";BEL;17854
+"Russian Federation";RU;RUS;190;"Bryanskaya oblast'";"Bryanskaya oblast'";"administrative region";BRY;17885
+"Russian Federation";RU;RUS;190;"Respublika Buryatiya";"Respublika Buryatiya";republic;BU;17886
+"Russian Federation";RU;RUS;190;"Chechenskaya Respublika";"Chechenskaya Respublika";republic;CE;17855
+"Russian Federation";RU;RUS;190;"Chelyabinskaya oblast'";"Chelyabinskaya oblast'";"administrative region";CHE;17887
+"Russian Federation";RU;RUS;190;"Chitinskaya oblast'";"Chitinskaya oblast'";"administrative region";CHI;17888
+"Russian Federation";RU;RUS;190;"Chukotskiy avtonomnyy okrug";"Chukotskiy avtonomnyy okrug";"autonomous district";CHU;17889
+"Russian Federation";RU;RUS;190;"Chuvashskaya Respublika";"Chuvashskaya Respublika";republic;CU;17856
+"Russian Federation";RU;RUS;190;"Respublika Dagestan";"Respublika Dagestan";republic;DA;17890
+"Russian Federation";RU;RUS;190;"Evenkiyskiy avtonomnyy okrug";"Evenkiyskiy avtonomnyy okrug";"autonomous district";EVE;17891
+"Russian Federation";RU;RUS;190;"Ingushskaya Respublika (Respublika Ingushetiya)";"Ingushskaya Respublika (Respublika Ingushetiya)";republic;IN;17894
+"Russian Federation";RU;RUS;190;"Irkutskaya oblast'";"Irkutskaya oblast'";"administrative region";IRK;17895
+"Russian Federation";RU;RUS;190;"Ivanovskaya oblast'";"Ivanovskaya oblast'";"administrative region";IVA;17859
+"Russian Federation";RU;RUS;190;"Kabardino-Balkarskaya Respublika";"Kabardino-Balkarskaya Respublika";republic;KB;17899
+"Russian Federation";RU;RUS;190;"Kaliningradskaya oblast'";"Kaliningradskaya oblast'";"administrative region";KGD;17900
+"Russian Federation";RU;RUS;190;"Respublika Kalmykiya";"Respublika Kalmykiya";republic;KL;17901
+"Russian Federation";RU;RUS;190;"Kaluzhskaya oblast'";"Kaluzhskaya oblast'";"administrative region";KLU;17902
+"Russian Federation";RU;RUS;190;"Kamchatskaya oblast'";"Kamchatskaya oblast'";"administrative territory";KAM;17903
+"Russian Federation";RU;RUS;190;"Karachayevo-Cherkesskaya Respublika";"Karachayevo-Cherkesskaya Respublika";republic;KC;17904
+"Russian Federation";RU;RUS;190;"Respublika Kareliya";"Respublika Kareliya";republic;KR;17905
+"Russian Federation";RU;RUS;190;"Kemerovskaya oblast'";"Kemerovskaya oblast'";"administrative region";KEM;17843
+"Russian Federation";RU;RUS;190;"Khabarovskiy kray";"Khabarovskiy kray";"administrative territory";KHA;17892
+"Russian Federation";RU;RUS;190;"Respublika Khakasiya";"Respublika Khakasiya";republic;KK;17893
+"Russian Federation";RU;RUS;190;"Khanty-Mansiyskiy avtonomnyy okrug (Yugra)";"Khanty-Mansiyskiy avtonomnyy okrug (Yugra)";"autonomous district";KHM;17858
+"Russian Federation";RU;RUS;190;"Kirovskaya oblast'";"Kirovskaya oblast'";"administrative region";KIR;17844
+"Russian Federation";RU;RUS;190;"Respublika Komi";"Respublika Komi";republic;KO;17845
+"Russian Federation";RU;RUS;190;Komi-Permyak;Komi-Permyak;;X1~;17846
+"Russian Federation";RU;RUS;190;"Koryakskiy avtonomnyy okrug";"Koryakskiy avtonomnyy okrug";"autonomous district";KOR;17860
+"Russian Federation";RU;RUS;190;"Kostromskaya oblast'";"Kostromskaya oblast'";"administrative region";KOS;17847
+"Russian Federation";RU;RUS;190;"Krasnodarskiy kray";"Krasnodarskiy kray";"administrative territory";KDA;17861
+"Russian Federation";RU;RUS;190;"Krasnoyarskiy kray";"Krasnoyarskiy kray";"administrative territory";KYA;17848
+"Russian Federation";RU;RUS;190;"Kurganskaya oblast'";"Kurganskaya oblast'";"administrative region";KGN;17849
+"Russian Federation";RU;RUS;190;"Kurskaya oblast'";"Kurskaya oblast'";"administrative region";KRS;17862
+"Russian Federation";RU;RUS;190;"Leningradskaya oblast'";"Leningradskaya oblast'";"administrative region";LEN;17850
+"Russian Federation";RU;RUS;190;"Lipetskaya oblast'";"Lipetskaya oblast'";"administrative region";LIP;17863
+"Russian Federation";RU;RUS;190;"Magadanskaya oblast'";"Magadanskaya oblast'";"administrative region";MAG;17851
+"Russian Federation";RU;RUS;190;"Respublika Mariy El";"Respublika Mariy El";republic;ME;17834
+"Russian Federation";RU;RUS;190;"Respublika Mordoviya";"Respublika Mordoviya";republic;MO;17864
+"Russian Federation";RU;RUS;190;"Moskovskaya oblast'";"Moskovskaya oblast'";"administrative region";MOS;17836
+"Russian Federation";RU;RUS;190;Moskva;Moskva;"autonomous city";MOW;17835
+"Russian Federation";RU;RUS;190;"Murmanskaya oblast'";"Murmanskaya oblast'";"administrative region";MUR;17865
+"Russian Federation";RU;RUS;190;"Nenetskiy avtonomnyy okrug";"Nenetskiy avtonomnyy okrug";"autonomous district";NEN;17837
+"Russian Federation";RU;RUS;190;"Nizhegorodskaya oblast'";"Nizhegorodskaya oblast'";"administrative region";NIZ;17838
+"Russian Federation";RU;RUS;190;"Novgorodskaya oblast'";"Novgorodskaya oblast'";"administrative region";NGR;17866
+"Russian Federation";RU;RUS;190;"Novosibirskaya oblast'";"Novosibirskaya oblast'";"administrative region";NVS;17839
+"Russian Federation";RU;RUS;190;"Omskaya oblast'";"Omskaya oblast'";"administrative region";OMS;17867
+"Russian Federation";RU;RUS;190;"Orenburgskaya oblast'";"Orenburgskaya oblast'";"administrative region";ORE;17840
+"Russian Federation";RU;RUS;190;"Orlovskaya oblast'";"Orlovskaya oblast'";"administrative region";ORL;17841
+"Russian Federation";RU;RUS;190;"Penzenskaya oblast'";"Penzenskaya oblast'";"administrative region";PNZ;17868
+"Russian Federation";RU;RUS;190;Perm;Perm;"administrative territory";PER;17842
+"Russian Federation";RU;RUS;190;"Primorskiy kray";"Primorskiy kray";"administrative territory";PRI;17825
+"Russian Federation";RU;RUS;190;"Pskovskaya oblast'";"Pskovskaya oblast'";"administrative region";PSK;17869
+"Russian Federation";RU;RUS;190;"Rostovskaya oblast'";"Rostovskaya oblast'";"administrative region";ROS;17870
+"Russian Federation";RU;RUS;190;"Ryazanskaya oblast'";"Ryazanskaya oblast'";"administrative region";RYA;17826
+"Russian Federation";RU;RUS;190;"Respublika (Yakutiya) Sakha";"Respublika (Yakutiya) Sakha";republic;SA;17827
+"Russian Federation";RU;RUS;190;"Sakhalinskaya oblast'";"Sakhalinskaya oblast'";"administrative region";SAK;17828
+"Russian Federation";RU;RUS;190;"Samarskaya oblast'";"Samarskaya oblast'";"administrative region";SAM;17871
+"Russian Federation";RU;RUS;190;Sankt-Peterburg;Sankt-Peterburg;"autonomous city";SPE;17829
+"Russian Federation";RU;RUS;190;"Saratovskaya oblast'";"Saratovskaya oblast'";"administrative region";SAR;17872
+"Russian Federation";RU;RUS;190;"Respublika (Alaniya) (Respublika Severnaya Osetiya-Alaniya) Severnaya Osetiya";"Respublika (Alaniya) (Respublika Severnaya Osetiya-Alaniya) Severnaya Osetiya";republic;SE;17852
+"Russian Federation";RU;RUS;190;"Smolenskaya oblast'";"Smolenskaya oblast'";"administrative region";SMO;17830
+"Russian Federation";RU;RUS;190;"Stavropol'skiy kray";"Stavropol'skiy kray";"administrative territory";STA;17831
+"Russian Federation";RU;RUS;190;"Sverdlovskaya oblast'";"Sverdlovskaya oblast'";"administrative region";SVE;17832
+"Russian Federation";RU;RUS;190;"Tambovskaya oblast'";"Tambovskaya oblast'";"administrative region";TAM;17833
+"Russian Federation";RU;RUS;190;"Respublika Tatarstan";"Respublika Tatarstan";republic;TA;17824
+"Russian Federation";RU;RUS;190;"Taymyrskiy (Dolgano-Nenetskiy) avtonomnyy okrug";"Taymyrskiy (Dolgano-Nenetskiy) avtonomnyy okrug";"autonomous district";TAY;17873
+"Russian Federation";RU;RUS;190;"Tomskaya oblast'";"Tomskaya oblast'";"administrative region";TOM;17906
+"Russian Federation";RU;RUS;190;"Tul'skaya oblast'";"Tul'skaya oblast'";"administrative region";TUL;17875
+"Russian Federation";RU;RUS;190;"Tverskaya oblast'";"Tverskaya oblast'";"administrative region";TVE;17910
+"Russian Federation";RU;RUS;190;"Tyumenskaya oblast'";"Tyumenskaya oblast'";"administrative region";TYU;17874
+"Russian Federation";RU;RUS;190;"Respublika (Tuva) Tyva";"Respublika (Tuva) Tyva";republic;TY;17909
+"Russian Federation";RU;RUS;190;"Udmurtskaya Respublika";"Udmurtskaya Respublika";republic;UD;17876
+"Russian Federation";RU;RUS;190;"Ul'yanovskaya oblast'";"Ul'yanovskaya oblast'";"administrative region";ULY;17908
+"Russian Federation";RU;RUS;190;"Ust'-Ordynskiy Buryatskiy avtonomnyy okrug";"Ust'-Ordynskiy Buryatskiy avtonomnyy okrug";"autonomous district";UOB;17911
+"Russian Federation";RU;RUS;190;"Vladimirskaya oblast'";"Vladimirskaya oblast'";"administrative region";VLA;17877
+"Russian Federation";RU;RUS;190;"Volgogradskaya oblast'";"Volgogradskaya oblast'";"administrative region";VGG;17907
+"Russian Federation";RU;RUS;190;"Vologodskaya oblast'";"Vologodskaya oblast'";"administrative region";VLG;17823
+"Russian Federation";RU;RUS;190;"Voronezhskaya oblast'";"Voronezhskaya oblast'";"administrative region";VOR;17878
+"Russian Federation";RU;RUS;190;"Yamalo-Nenetskiy avtonomnyy okrug";"Yamalo-Nenetskiy avtonomnyy okrug";"autonomous district";YAN;17896
+"Russian Federation";RU;RUS;190;"Yaroslavskaya oblast'";"Yaroslavskaya oblast'";"administrative region";YAR;17897
+"Russian Federation";RU;RUS;190;"Yevreyskaya avtonomnaya oblast'";"Yevreyskaya avtonomnaya oblast'";"autonomous region";YEV;17898
+"Russian Federation";RU;RUS;190;"Zabajkal'skij kraj";"Zabajkal'skij kraj";"administrative territory";ZAB;48221
+Rwanda;RW;RWA;191;Est;Est;province;02;19063
+Rwanda;RW;RWA;191;Nord;Nord;province;03;19064
+Rwanda;RW;RWA;191;Ouest;Ouest;province;04;19065
+Rwanda;RW;RWA;191;Sud;Sud;province;05;17912
+Rwanda;RW;RWA;191;"Ville de Kigali";"Ville de Kigali";province;01;17923
+"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;Ascension;Ascension;dependency;AC;17926
+"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;Ascension;Ascension;"geographical entity";AC;48879
+"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Saint Helena";"Saint Helena";"geographical entity";HL;48880
+"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Saint Helena";"Saint Helena";"administrative area";SH;17930
+"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Tristan da Cunha";"Tristan da Cunha";"geographical entity";TA;48881
+"Ascension and Tristan Da Cunha Saint Helena";SH;SHN;192;"Tristan da Cunha";"Tristan da Cunha";dependency;TA;17925
+"Saint Kitts And Nevis";KN;KNA;193;"Christ Church Nichola Town";"Christ Church Nichola Town";parish;01;17933
+"Saint Kitts And Nevis";KN;KNA;193;Nevis;Nevis;state;N;48461
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Anne Sandy Point";"Saint Anne Sandy Point";parish;02;17940
+"Saint Kitts And Nevis";KN;KNA;193;"Saint George Basseterre";"Saint George Basseterre";parish;03;17934
+"Saint Kitts And Nevis";KN;KNA;193;"Saint George Gingerland";"Saint George Gingerland";parish;04;17941
+"Saint Kitts And Nevis";KN;KNA;193;"Saint James Windward";"Saint James Windward";parish;05;17935
+"Saint Kitts And Nevis";KN;KNA;193;"Saint John Capisterre";"Saint John Capisterre";parish;06;17932
+"Saint Kitts And Nevis";KN;KNA;193;"Saint John Figtree";"Saint John Figtree";parish;07;17936
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Kitts";"Saint Kitts";state;K;48460
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Mary Cayon";"Saint Mary Cayon";parish;08;17942
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Paul Capisterre";"Saint Paul Capisterre";parish;09;17937
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Paul Charlestown";"Saint Paul Charlestown";parish;10;17944
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Peter Basseterre";"Saint Peter Basseterre";parish;11;17938
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Thomas Lowland";"Saint Thomas Lowland";parish;12;17943
+"Saint Kitts And Nevis";KN;KNA;193;"Saint Thomas Middle Island";"Saint Thomas Middle Island";parish;13;17939
+"Saint Kitts And Nevis";KN;KNA;193;"Trinity Palmetto Point";"Trinity Palmetto Point";parish;15;17931
+"Saint Vincent And The Grenadines";VC;VCT;195;Charlotte;Charlotte;parish;01;17963
+"Saint Vincent And The Grenadines";VC;VCT;195;Grenadines;Grenadines;parish;06;17958
+"Saint Vincent And The Grenadines";VC;VCT;195;"Saint Andrew";"Saint Andrew";parish;02;17962
+"Saint Vincent And The Grenadines";VC;VCT;195;"Saint David";"Saint David";parish;03;17959
+"Saint Vincent And The Grenadines";VC;VCT;195;"Saint George";"Saint George";parish;04;17957
+"Saint Vincent And The Grenadines";VC;VCT;195;"Saint Patrick";"Saint Patrick";parish;05;17960
+Samoa;WS;WSM;196;A'ana;A'ana;district;AA;20647
+Samoa;WS;WSM;196;Aiga-i-le-Tai;Aiga-i-le-Tai;district;AL;20648
+Samoa;WS;WSM;196;Atua;Atua;district;AT;20649
+Samoa;WS;WSM;196;Fa'asaleleaga;Fa'asaleleaga;district;FA;20650
+Samoa;WS;WSM;196;Gaga'emauga;Gaga'emauga;district;GE;20651
+Samoa;WS;WSM;196;Gagaifomauga;Gagaifomauga;district;GI;20652
+Samoa;WS;WSM;196;Palauli;Palauli;district;PA;20653
+Samoa;WS;WSM;196;Satupa'itea;Satupa'itea;district;SA;20654
+Samoa;WS;WSM;196;Tuamasaga;Tuamasaga;district;TU;20655
+Samoa;WS;WSM;196;Va'a-o-Fonoti;Va'a-o-Fonoti;district;VF;20656
+Samoa;WS;WSM;196;Vaisigano;Vaisigano;district;VS;20657
+"San Marino";SM;SMR;197;Acquaviva;Acquaviva;municipality;01;17972
+"San Marino";SM;SMR;197;"Borgo Maggiore";"Borgo Maggiore";municipality;06;17971
+"San Marino";SM;SMR;197;Chiesanuova;Chiesanuova;municipality;02;17973
+"San Marino";SM;SMR;197;Domagnano;Domagnano;municipality;03;17970
+"San Marino";SM;SMR;197;Faetano;Faetano;municipality;04;17974
+"San Marino";SM;SMR;197;Fiorentino;Fiorentino;municipality;05;17969
+"San Marino";SM;SMR;197;Montegiardino;Montegiardino;municipality;08;17975
+"San Marino";SM;SMR;197;"San Marino";"San Marino";municipality;07;17976
+"San Marino";SM;SMR;197;Serravalle;Serravalle;municipality;09;17968
+"Sao Tome and Principe";ST;STP;198;Príncipe;Principe;municipality;P;20324
+"Sao Tome and Principe";ST;STP;198;"São Tomé";"Sao Tome";municipality;S;20325
+"Saudi Arabia";SA;SAU;199;?a'il;a'il;region;06;17981
+"Saudi Arabia";SA;SAU;199;?Asir;Asir;region;14;17984
+"Saudi Arabia";SA;SAU;199;"Al Bāḩah";"Al Bahah";region;11;17980
+"Saudi Arabia";SA;SAU;199;"Al Jawf";"Al Jawf";region;12;17982
+"Saudi Arabia";SA;SAU;199;"Al Madinah";"Al Madinah";region;03;17979
+"Saudi Arabia";SA;SAU;199;"Al Qasim";"Al Qasim";region;05;17988
+"Saudi Arabia";SA;SAU;199;"Al Ḩudūd ash Shamālīyah";"Al Hudud ash Shamaliyah";region;08;17985
+"Saudi Arabia";SA;SAU;199;"Ar Riyāḑ";"Ar Riyad";region;01;17978
+"Saudi Arabia";SA;SAU;199;"Ash Sharqiyah";"Ash Sharqiyah";region;04;17989
+"Saudi Arabia";SA;SAU;199;Jizan;Jizan;region;09;17986
+"Saudi Arabia";SA;SAU;199;Makkah;Makkah;region;02;17987
+"Saudi Arabia";SA;SAU;199;Najran;Najran;region;10;17983
+"Saudi Arabia";SA;SAU;199;Tabuk;Tabuk;region;07;17977
+Senegal;SN;SEN;200;Dakar;Dakar;region;DK;17998
+Senegal;SN;SEN;200;Diourbel;Diourbel;region;DB;17991
+Senegal;SN;SEN;200;Fatick;Fatick;region;FK;17997
+Senegal;SN;SEN;200;Kaffrine;Kaffrine;region;KA;48218
+Senegal;SN;SEN;200;Kaolack;Kaolack;region;KL;17999
+Senegal;SN;SEN;200;Kolda;Kolda;region;KD;17993
+Senegal;SN;SEN;200;Kédougou;Kedougou;region;KE;48219
+Senegal;SN;SEN;200;Louga;Louga;region;LG;17996
+Senegal;SN;SEN;200;Matam;Matam;region;MT;17994
+Senegal;SN;SEN;200;Saint-Louis;Saint-Louis;region;SL;17992
+Senegal;SN;SEN;200;Sédhiou;Sedhiou;region;SE;48220
+Senegal;SN;SEN;200;Tambacounda;Tambacounda;region;TC;18000
+Senegal;SN;SEN;200;Thiès;Thies;region;TH;17995
+Senegal;SN;SEN;200;Ziguinchor;Ziguinchor;region;ZG;17990
+Serbia;RS;SRB;201;Belgrade;Belgrade;city;00;47890
+Serbia;RS;SRB;201;"Borski okrug";"Borski okrug";district;14;19066
+Serbia;RS;SRB;201;"Braničevski okrug";"Branicevski okrug";district;11;19067
+Serbia;RS;SRB;201;"Jablanički okrug";"Jablanicki okrug";district;23;19068
+Serbia;RS;SRB;201;"Južnobanatski okrug";"Juznobanatski okrug";district;06;19069
+Serbia;RS;SRB;201;"Južnobanatski okrug";"Juznobanatski okrug";district;04;19070
+Serbia;RS;SRB;201;"Kolubarski okrug";"Kolubarski okrug";district;09;19071
+Serbia;RS;SRB;201;"Kosovski okrug";"Kosovski okrug";district;25;18004
+Serbia;RS;SRB;201;"Kosovsko-Mitrovački okrug";"Kosovsko-Mitrovacki okrug";district;28;19074
+Serbia;RS;SRB;201;"Kosovsko-Pomoravski okrug";"Kosovsko-Pomoravski okrug";district;29;19073
+Serbia;RS;SRB;201;"Mačvanski okrug";"Macvanski okrug";district;08;19075
+Serbia;RS;SRB;201;"Moravički okrug";"Moravicki okrug";district;17;19076
+Serbia;RS;SRB;201;"Nišavski okrug";"Nisavski okrug";district;20;19077
+Serbia;RS;SRB;201;"Pećki okrug";"Pecki okrug";district;26;19079
+Serbia;RS;SRB;201;"Pirotski okrug";"Pirotski okrug";district;22;19080
+Serbia;RS;SRB;201;"Podunavski okrug";"Podunavski okrug";district;10;19081
+Serbia;RS;SRB;201;"Pomoravski okrug";"Pomoravski okrug";district;13;19082
+Serbia;RS;SRB;201;"Prizrenski okrug";"Prizrenski okrug";district;27;19083
+Serbia;RS;SRB;201;"Pčinjski okrug";"Pcinjski okrug";district;24;19078
+Serbia;RS;SRB;201;"Rasinski okrug";"Rasinski okrug";district;19;19084
+Serbia;RS;SRB;201;"Raška okrug";"Raska okrug";district;18;19085
+Serbia;RS;SRB;201;"Severnobanatski okrug";"Severnobanatski okrug";district;03;19087
+Serbia;RS;SRB;201;"Severnobački okrug";"Severnobacki okrug";district;01;19086
+Serbia;RS;SRB;201;"Srednjebanatski okrug";"Srednjebanatski okrug";district;02;19088
+Serbia;RS;SRB;201;"Sremski okrug";"Sremski okrug";district;07;19089
+Serbia;RS;SRB;201;"Toplièki okrug";"Toplieki okrug";district;21;19091
+Serbia;RS;SRB;201;"Zajeèarski okrug";"Zajeearski okrug";district;15;19092
+Serbia;RS;SRB;201;"Zapadnobaèki okrug";"Zapadnobaeki okrug";district;05;19093
+Serbia;RS;SRB;201;"Zlatiborski okrug";"Zlatiborski okrug";district;16;19094
+Serbia;RS;SRB;201;"Šumadijski okrug";"Sumadijski okrug";district;12;19090
+Seychelles;SC;SYC;202;"Anse aux Pins";"Anse aux Pins";district;01;18014
+Seychelles;SC;SYC;202;"Anse Boileau";"Anse Boileau";district;02;18017
+Seychelles;SC;SYC;202;"Anse Royale";"Anse Royale";district;05;18015
+Seychelles;SC;SYC;202;"Anse Étoile";"Anse Etoile";district;03;18018
+Seychelles;SC;SYC;202;"Au Cap";"Au Cap";district;04;18019
+Seychelles;SC;SYC;202;"Baie Lazare";"Baie Lazare";district;06;18006
+Seychelles;SC;SYC;202;"Baie Sainte Anne";"Baie Sainte Anne";district;07;18020
+Seychelles;SC;SYC;202;"Beau Vallon";"Beau Vallon";district;08;18021
+Seychelles;SC;SYC;202;"Bel Air";"Bel Air";district;09;18025
+Seychelles;SC;SYC;202;"Bel Ombre";"Bel Ombre";district;10;18022
+Seychelles;SC;SYC;202;Cascade;Cascade;district;11;18029
+Seychelles;SC;SYC;202;"English River";"English River";district;16;18023
+Seychelles;SC;SYC;202;Glacis;Glacis;district;12;18024
+Seychelles;SC;SYC;202;"Grand Anse Mahe";"Grand Anse Mahe";district;13;18028
+Seychelles;SC;SYC;202;"Grand Anse Praslin";"Grand Anse Praslin";district;14;18007
+Seychelles;SC;SYC;202;"La Digue";"La Digue";district;15;18027
+Seychelles;SC;SYC;202;"Les Mamelles";"Les Mamelles";district;24;48216
+Seychelles;SC;SYC;202;"Mont Buxton";"Mont Buxton";district;17;18009
+Seychelles;SC;SYC;202;"Mont Fleuri";"Mont Fleuri";district;18;18030
+Seychelles;SC;SYC;202;Plaisance;Plaisance;district;19;18026
+Seychelles;SC;SYC;202;"Pointe La Rue";"Pointe La Rue";district;20;18011
+Seychelles;SC;SYC;202;"Port Glaud";"Port Glaud";district;21;18012
+Seychelles;SC;SYC;202;"Roche Caiman";"Roche Caiman";district;25;48217
+Seychelles;SC;SYC;202;"Saint Louis";"Saint Louis";district;22;18013
+Seychelles;SC;SYC;202;Takamaka;Takamaka;district;23;18005
+"Sierra Leone";SL;SLE;203;Eastern;Eastern;province;E;18044
+"Sierra Leone";SL;SLE;203;Northern;Northern;province;N;18033
+"Sierra Leone";SL;SLE;203;Southern;Southern;province;S;18045
+"Sierra Leone";SL;SLE;203;"Western Area (Freetown)";"Western Area (Freetown)";area;W;18034
+Singapore;SG;SGP;205;"Central Singapore";"Central Singapore";district;01;48250
+Singapore;SG;SGP;205;"North East";"North East";district;02;48251
+Singapore;SG;SGP;205;"North West";"North West";district;03;48252
+Singapore;SG;SGP;205;"Singapore - No State";"Singapore - No State";;X1~;48078
+Singapore;SG;SGP;205;"South East";"South East";district;04;48253
+Singapore;SG;SGP;205;"South West";"South West";district;05;48254
+Slovakia;SK;SVK;206;"Banskobystrický kraj";"Banskobystricky kraj";region;BC;18060
+Slovakia;SK;SVK;206;"Bratislavský kraj";"Bratislavsky kraj";region;BL;18053
+Slovakia;SK;SVK;206;"Košický kraj";"Kosicky kraj";region;KI;18059
+Slovakia;SK;SVK;206;"Nitriansky kraj";"Nitriansky kraj";region;NI;18054
+Slovakia;SK;SVK;206;"Prešovský kraj";"Presovsky kraj";region;PV;18055
+Slovakia;SK;SVK;206;"Trenciansky kraj";"Trenciansky kraj";region;TC;18052
+Slovakia;SK;SVK;206;"Trnavský kraj";"Trnavsky kraj";region;TA;18056
+Slovakia;SK;SVK;206;"Žilinský kraj";"Zilinsky kraj";region;ZI;18057
+Slovenia;SI;SVN;207;Ajdovšcina;Ajdovscina;;001;20197
+Slovenia;SI;SVN;207;Apače;Apace;commune;195;48197
+Slovenia;SI;SVN;207;Beltinci;Beltinci;;002;20198
+Slovenia;SI;SVN;207;Benedikt;Benedikt;;148;20199
+Slovenia;SI;SVN;207;"Bistrica ob Sotli";"Bistrica ob Sotli";;149;20200
+Slovenia;SI;SVN;207;Bled;Bled;;003;20201
+Slovenia;SI;SVN;207;Bloke;Bloke;;150;20202
+Slovenia;SI;SVN;207;Bohinj;Bohinj;;004;20203
+Slovenia;SI;SVN;207;Borovnica;Borovnica;;005;20204
+Slovenia;SI;SVN;207;Bovec;Bovec;;006;20205
+Slovenia;SI;SVN;207;Braslovce;Braslovce;;151;20206
+Slovenia;SI;SVN;207;Brda;Brda;;007;20207
+Slovenia;SI;SVN;207;Brezovica;Brezovica;;008;20208
+Slovenia;SI;SVN;207;Brežice;Brezice;;009;19899
+Slovenia;SI;SVN;207;Cankova;Cankova;;152;19900
+Slovenia;SI;SVN;207;Celje;Celje;;011;19901
+Slovenia;SI;SVN;207;"Cerklje na Gorenjskem";"Cerklje na Gorenjskem";;012;19902
+Slovenia;SI;SVN;207;Cerknica;Cerknica;;013;19903
+Slovenia;SI;SVN;207;Cerkno;Cerkno;;014;19904
+Slovenia;SI;SVN;207;Cerkvenjak;Cerkvenjak;;153;19905
+Slovenia;SI;SVN;207;Cirkulane;Cirkulane;commune;197;48198
+Slovenia;SI;SVN;207;Crenšovci;Crensovci;;015;19906
+Slovenia;SI;SVN;207;"Crna na Koroškem";"Crna na Koroskem";;016;19907
+Slovenia;SI;SVN;207;Crnomelj;Crnomelj;;017;19908
+Slovenia;SI;SVN;207;Destrnik;Destrnik;;018;19909
+Slovenia;SI;SVN;207;Divaca;Divaca;;019;19910
+Slovenia;SI;SVN;207;Dobje;Dobje;;154;19911
+Slovenia;SI;SVN;207;Dobrepolje;Dobrepolje;;020;19912
+Slovenia;SI;SVN;207;Dobrna;Dobrna;;155;19913
+Slovenia;SI;SVN;207;"Dobrova-Polhov Gradec";"Dobrova-Polhov Gradec";;021;19914
+Slovenia;SI;SVN;207;Dobrovnik/Dobronak;Dobrovnik/Dobronak;;156;19915
+Slovenia;SI;SVN;207;"Dol pri Ljubljani";"Dol pri Ljubljani";;022;19916
+Slovenia;SI;SVN;207;"Dolenjske Toplice";"Dolenjske Toplice";;157;19917
+Slovenia;SI;SVN;207;Domžale;Domzale;;023;19918
+Slovenia;SI;SVN;207;Dornava;Dornava;;024;19919
+Slovenia;SI;SVN;207;Dravograd;Dravograd;;025;19920
+Slovenia;SI;SVN;207;Duplek;Duplek;;026;19921
+Slovenia;SI;SVN;207;"Gorenja vas-Poljane";"Gorenja vas-Poljane";;027;19922
+Slovenia;SI;SVN;207;Gorišnica;Gorisnica;;028;19923
+Slovenia;SI;SVN;207;Gorje;Gorje;commune;207;48212
+Slovenia;SI;SVN;207;"Gornja Radgona";"Gornja Radgona";;029;19924
+Slovenia;SI;SVN;207;"Gornji Grad";"Gornji Grad";;030;19925
+Slovenia;SI;SVN;207;"Gornji Petrovci";"Gornji Petrovci";;031;19926
+Slovenia;SI;SVN;207;Grad;Grad;;158;19927
+Slovenia;SI;SVN;207;Grosuplje;Grosuplje;;032;19928
+Slovenia;SI;SVN;207;Hajdina;Hajdina;;159;19929
+Slovenia;SI;SVN;207;Hoce-Slivnica;Hoce-Slivnica;;160;19930
+Slovenia;SI;SVN;207;Hodoš/Hodos;Hodos/Hodos;;161;19931
+Slovenia;SI;SVN;207;Horjul;Horjul;;162;19932
+Slovenia;SI;SVN;207;Hrastnik;Hrastnik;;034;19933
+Slovenia;SI;SVN;207;Hrpelje-Kozina;Hrpelje-Kozina;;035;19934
+Slovenia;SI;SVN;207;Idrija;Idrija;;036;19935
+Slovenia;SI;SVN;207;Ig;Ig;;037;19936
+Slovenia;SI;SVN;207;"Ilirska Bistrica";"Ilirska Bistrica";;038;19937
+Slovenia;SI;SVN;207;"Ivancna Gorica";"Ivancna Gorica";;039;19938
+Slovenia;SI;SVN;207;Izola/Isola;Izola/Isola;;040;19939
+Slovenia;SI;SVN;207;Jesenice;Jesenice;;041;19940
+Slovenia;SI;SVN;207;Jezersko;Jezersko;;163;19941
+Slovenia;SI;SVN;207;Juršinci;Jursinci;;042;19942
+Slovenia;SI;SVN;207;Kamnik;Kamnik;;043;19943
+Slovenia;SI;SVN;207;Kanal;Kanal;;044;19944
+Slovenia;SI;SVN;207;Kidricevo;Kidricevo;;045;19945
+Slovenia;SI;SVN;207;Kobarid;Kobarid;;046;19946
+Slovenia;SI;SVN;207;Kobilje;Kobilje;;047;19947
+Slovenia;SI;SVN;207;Kocevje;Kocevje;;048;19948
+Slovenia;SI;SVN;207;Komen;Komen;;049;19949
+Slovenia;SI;SVN;207;Komenda;Komenda;;164;19950
+Slovenia;SI;SVN;207;Koper/Capodistria;Koper/Capodistria;;050;19951
+Slovenia;SI;SVN;207;"Kosanjevica na Krki";"Kosanjevica na Krki";commune;196;48199
+Slovenia;SI;SVN;207;Kostel;Kostel;;165;19952
+Slovenia;SI;SVN;207;Kozje;Kozje;;051;19953
+Slovenia;SI;SVN;207;Kranj;Kranj;;052;19954
+Slovenia;SI;SVN;207;"Kranjska Gora";"Kranjska Gora";;053;19955
+Slovenia;SI;SVN;207;Križevci;Krizevci;;166;19956
+Slovenia;SI;SVN;207;Krško;Krsko;;054;19957
+Slovenia;SI;SVN;207;Kungota;Kungota;;055;19958
+Slovenia;SI;SVN;207;Kuzma;Kuzma;;056;19959
+Slovenia;SI;SVN;207;Laško;Lasko;;057;19960
+Slovenia;SI;SVN;207;Lenart;Lenart;;058;19961
+Slovenia;SI;SVN;207;Lendava/Lendva;Lendava/Lendva;;059;19962
+Slovenia;SI;SVN;207;Litija;Litija;;060;19963
+Slovenia;SI;SVN;207;Ljubljana;Ljubljana;;061;19964
+Slovenia;SI;SVN;207;Ljubno;Ljubno;;062;19965
+Slovenia;SI;SVN;207;Ljutomer;Ljutomer;;063;19966
+Slovenia;SI;SVN;207;Log-Dragomer;Log-Dragomer;commune;208;48213
+Slovenia;SI;SVN;207;Logatec;Logatec;;064;19967
+Slovenia;SI;SVN;207;"Lovrenc na Pohorju";"Lovrenc na Pohorju";;167;19970
+Slovenia;SI;SVN;207;"Loška dolina";"Loska dolina";;065;19968
+Slovenia;SI;SVN;207;"Loški Potok";"Loski Potok";;066;19969
+Slovenia;SI;SVN;207;Luce;Luce;;067;19971
+Slovenia;SI;SVN;207;Lukovica;Lukovica;;068;19972
+Slovenia;SI;SVN;207;Majšperk;Majsperk;;069;19973
+Slovenia;SI;SVN;207;Makole;Makole;commune;198;48200
+Slovenia;SI;SVN;207;Maribor;Maribor;;070;19974
+Slovenia;SI;SVN;207;Markovci;Markovci;;168;19975
+Slovenia;SI;SVN;207;Medvode;Medvode;;071;19976
+Slovenia;SI;SVN;207;Mengeš;Menges;;072;19977
+Slovenia;SI;SVN;207;Metlika;Metlika;;073;19978
+Slovenia;SI;SVN;207;Mežica;Mezica;;074;19979
+Slovenia;SI;SVN;207;"Miklavž na Dravskem polju";"Miklavz na Dravskem polju";;169;19980
+Slovenia;SI;SVN;207;Miren-Kostanjevica;Miren-Kostanjevica;;075;19981
+Slovenia;SI;SVN;207;"Mirna Pec";"Mirna Pec";;170;19982
+Slovenia;SI;SVN;207;Mislinja;Mislinja;;076;19983
+Slovenia;SI;SVN;207;Mokronog-Trebelno;Mokronog-Trebelno;commune;199;48201
+Slovenia;SI;SVN;207;Moravce;Moravce;;077;19984
+Slovenia;SI;SVN;207;"Moravske Toplice";"Moravske Toplice";;078;19985
+Slovenia;SI;SVN;207;Mozirje;Mozirje;;079;19986
+Slovenia;SI;SVN;207;"Murska Sobota";"Murska Sobota";;080;19987
+Slovenia;SI;SVN;207;Muta;Muta;;081;19988
+Slovenia;SI;SVN;207;Naklo;Naklo;;082;19989
+Slovenia;SI;SVN;207;Nazarje;Nazarje;;083;19990
+Slovenia;SI;SVN;207;"Nova Gorica";"Nova Gorica";;084;19991
+Slovenia;SI;SVN;207;"Novo mesto";"Novo mesto";;085;19992
+Slovenia;SI;SVN;207;Odranci;Odranci;;086;19993
+Slovenia;SI;SVN;207;Oplotnica;Oplotnica;;171;19994
+Slovenia;SI;SVN;207;Ormož;Ormoz;;087;19995
+Slovenia;SI;SVN;207;Osilnica;Osilnica;;088;19996
+Slovenia;SI;SVN;207;Pesnica;Pesnica;;089;19997
+Slovenia;SI;SVN;207;Piran/Pirano;Piran/Pirano;;090;19998
+Slovenia;SI;SVN;207;Pivka;Pivka;;091;19999
+Slovenia;SI;SVN;207;Podcetrtek;Podcetrtek;;092;20000
+Slovenia;SI;SVN;207;Podlehnik;Podlehnik;;172;20001
+Slovenia;SI;SVN;207;Podvelka;Podvelka;;093;20002
+Slovenia;SI;SVN;207;Poljčane;Poljcane;commune;200;48202
+Slovenia;SI;SVN;207;Polzela;Polzela;;173;20003
+Slovenia;SI;SVN;207;Postojna;Postojna;;094;20004
+Slovenia;SI;SVN;207;Prebold;Prebold;;174;20005
+Slovenia;SI;SVN;207;Preddvor;Preddvor;;095;20006
+Slovenia;SI;SVN;207;Prevalje;Prevalje;;175;20007
+Slovenia;SI;SVN;207;Ptuj;Ptuj;;096;20008
+Slovenia;SI;SVN;207;Puconci;Puconci;;097;20009
+Slovenia;SI;SVN;207;Race-Fram;Race-Fram;;098;20010
+Slovenia;SI;SVN;207;Radece;Radece;;099;20011
+Slovenia;SI;SVN;207;Radenci;Radenci;;100;20012
+Slovenia;SI;SVN;207;"Radlje ob Dravi";"Radlje ob Dravi";;101;20013
+Slovenia;SI;SVN;207;Radovljica;Radovljica;;102;20014
+Slovenia;SI;SVN;207;"Ravne na Koroškem";"Ravne na Koroskem";;103;20015
+Slovenia;SI;SVN;207;Razkrižje;Razkrizje;;176;20016
+Slovenia;SI;SVN;207;Renče-Vogrsko;Rence-Vogrsko;commune;201;48203
+Slovenia;SI;SVN;207;"Rečica ob Savinji";"Recica ob Savinji";commune;209;48204
+Slovenia;SI;SVN;207;Ribnica;Ribnica;;104;20017
+Slovenia;SI;SVN;207;"Ribnica na Pohorju";"Ribnica na Pohorju";;177;20018
+Slovenia;SI;SVN;207;Rogatec;Rogatec;;107;20021
+Slovenia;SI;SVN;207;"Rogaška Slatina";"Rogaska Slatina";;106;20019
+Slovenia;SI;SVN;207;Rogašovci;Rogasovci;;105;20020
+Slovenia;SI;SVN;207;Ruše;Ruse;;108;20022
+Slovenia;SI;SVN;207;"Selnica ob Dravi";"Selnica ob Dravi";;178;20023
+Slovenia;SI;SVN;207;Semic;Semic;;109;20024
+Slovenia;SI;SVN;207;Sevnica;Sevnica;;110;20025
+Slovenia;SI;SVN;207;Sežana;Sezana;;111;20026
+Slovenia;SI;SVN;207;"Slovenj Gradec";"Slovenj Gradec";;112;20027
+Slovenia;SI;SVN;207;"Slovenska Bistrica";"Slovenska Bistrica";;113;20028
+Slovenia;SI;SVN;207;"Slovenske Konjice";"Slovenske Konjice";;114;20029
+Slovenia;SI;SVN;207;Sodražica;Sodrazica;;179;20030
+Slovenia;SI;SVN;207;Solcava;Solcava;;180;20031
+Slovenia;SI;SVN;207;"Središče ob Dravi";"Sredisce ob Dravi";commune;202;48206
+Slovenia;SI;SVN;207;Starše;Starse;;115;20032
+Slovenia;SI;SVN;207;Straža;Straza;commune;203;48207
+Slovenia;SI;SVN;207;"Sveta Ana";"Sveta Ana";;181;20033
+Slovenia;SI;SVN;207;"Sveta Trojica v Slovenskih Goricah";"Sveta Trojica v Slovenskih Goricah";commune;204;48208
+Slovenia;SI;SVN;207;"Sveti Andraž v Slovenskih goricah";"Sveti Andraz v Slovenskih goricah";;182;20034
+Slovenia;SI;SVN;207;"Sveti Jurij";"Sveti Jurij";;116;20035
+Slovenia;SI;SVN;207;"Sveti Jurij v Slovenskih Goricah";"Sveti Jurij v Slovenskih Goricah";commune;210;48205
+Slovenia;SI;SVN;207;"Sveti Tomaž";"Sveti Tomaz";commune;205;48209
+Slovenia;SI;SVN;207;Tabor;Tabor;;184;20050
+Slovenia;SI;SVN;207;Tišina;Tisina;;010;20051
+Slovenia;SI;SVN;207;Tolmin;Tolmin;;128;20052
+Slovenia;SI;SVN;207;Trbovlje;Trbovlje;;129;20053
+Slovenia;SI;SVN;207;Trebnje;Trebnje;;130;20054
+Slovenia;SI;SVN;207;"Trnovska vas";"Trnovska vas";;185;20055
+Slovenia;SI;SVN;207;Trzin;Trzin;;186;20057
+Slovenia;SI;SVN;207;Tržic;Trzic;;131;20056
+Slovenia;SI;SVN;207;Turnišce;Turnisce;;132;20058
+Slovenia;SI;SVN;207;Velenje;Velenje;;133;20059
+Slovenia;SI;SVN;207;"Velika Polana";"Velika Polana";;187;20060
+Slovenia;SI;SVN;207;"Velike Lašce";"Velike Lasce";;134;20061
+Slovenia;SI;SVN;207;Veržej;Verzej;;188;20062
+Slovenia;SI;SVN;207;Videm;Videm;;135;20063
+Slovenia;SI;SVN;207;Vipava;Vipava;;136;20064
+Slovenia;SI;SVN;207;Vitanje;Vitanje;;137;20065
+Slovenia;SI;SVN;207;Vodice;Vodice;;138;20066
+Slovenia;SI;SVN;207;Vojnik;Vojnik;;139;20067
+Slovenia;SI;SVN;207;Vransko;Vransko;;189;20068
+Slovenia;SI;SVN;207;Vrhnika;Vrhnika;;140;20069
+Slovenia;SI;SVN;207;Vuzenica;Vuzenica;;141;20070
+Slovenia;SI;SVN;207;"Zagorje ob Savi";"Zagorje ob Savi";;142;20071
+Slovenia;SI;SVN;207;Zavrc;Zavrc;;143;20072
+Slovenia;SI;SVN;207;Zrece;Zrece;;144;20073
+Slovenia;SI;SVN;207;Šalovci;Salovci;;033;20036
+Slovenia;SI;SVN;207;Šempeter-Vrtojba;Sempeter-Vrtojba;;183;20037
+Slovenia;SI;SVN;207;Šencur;Sencur;;117;20038
+Slovenia;SI;SVN;207;Šentilj;Sentilj;;118;20039
+Slovenia;SI;SVN;207;Šentjernej;Sentjernej;;119;20040
+Slovenia;SI;SVN;207;"Šentjur pri Celju";"Sentjur pri Celju";;120;20041
+Slovenia;SI;SVN;207;Šentrupert;Sentrupert;commune;211;48210
+Slovenia;SI;SVN;207;Škocjan;Skocjan;;121;20042
+Slovenia;SI;SVN;207;"Škofja Loka";"Skofja Loka";;122;20043
+Slovenia;SI;SVN;207;Škofljica;Skofljica;;123;20044
+Slovenia;SI;SVN;207;"Šmarje pri Jelšah";"Smarje pri Jelsah";;124;20045
+Slovenia;SI;SVN;207;"Šmarješke Toplice";"Smarjeske Toplice";commune;206;48211
+Slovenia;SI;SVN;207;"Šmartno ob Paki";"Smartno ob Paki";;125;20046
+Slovenia;SI;SVN;207;"Šmartno pri Litiji";"Smartno pri Litiji";;194;20047
+Slovenia;SI;SVN;207;"Šmartno pri Litiji";"Smartno pri Litiji";commune;194;48196
+Slovenia;SI;SVN;207;Šoštanj;Sostanj;;126;20048
+Slovenia;SI;SVN;207;Štore;Store;;127;20049
+Slovenia;SI;SVN;207;Žalec;Zalec;;190;20074
+Slovenia;SI;SVN;207;Železniki;Zelezniki;;146;20075
+Slovenia;SI;SVN;207;Žetale;Zetale;;191;20076
+Slovenia;SI;SVN;207;Žiri;Ziri;;147;20077
+Slovenia;SI;SVN;207;Žirovnica;Zirovnica;;192;20078
+Slovenia;SI;SVN;207;Žužemberk;Zuzemberk;;193;20079
+"Solomon Islands";SB;SLB;208;"Capital Territory (Honiara)";"Capital Territory (Honiara)";"capital territory";CT;18079
+"Solomon Islands";SB;SLB;208;Central;Central;province;CE;18074
+"Solomon Islands";SB;SLB;208;Choiseul;Choiseul;province;CH;18075
+"Solomon Islands";SB;SLB;208;Guadalcanal;Guadalcanal;province;GU;18076
+"Solomon Islands";SB;SLB;208;Isabel;Isabel;province;IS;18081
+"Solomon Islands";SB;SLB;208;Makira;Makira;province;MK;18080
+"Solomon Islands";SB;SLB;208;Malaita;Malaita;province;ML;18082
+"Solomon Islands";SB;SLB;208;"Rennell and Bellona";"Rennell and Bellona";province;RB;18078
+"Solomon Islands";SB;SLB;208;Temotu;Temotu;province;TE;18073
+"Solomon Islands";SB;SLB;208;Western;Western;province;WE;18077
+Somalia;SO;SOM;209;Awdal;Awdal;region;AW;18093
+Somalia;SO;SOM;209;Bakool;Bakool;region;BK;18094
+Somalia;SO;SOM;209;Banaadir;Banaadir;region;BN;18098
+Somalia;SO;SOM;209;Bari;Bari;region;BR;18095
+Somalia;SO;SOM;209;Bay;Bay;region;BY;18097
+Somalia;SO;SOM;209;Galguduud;Galguduud;region;GA;18084
+Somalia;SO;SOM;209;Gedo;Gedo;region;GE;18085
+Somalia;SO;SOM;209;Hiiraan;Hiiraan;region;HI;18099
+Somalia;SO;SOM;209;"Jubbada Dhexe";"Jubbada Dhexe";region;JD;18086
+Somalia;SO;SOM;209;"Jubbada Hoose";"Jubbada Hoose";region;JH;18087
+Somalia;SO;SOM;209;Mudug;Mudug;region;MU;18096
+Somalia;SO;SOM;209;Nugaal;Nugaal;region;NU;18088
+Somalia;SO;SOM;209;Sanaag;Sanaag;region;SA;18090
+Somalia;SO;SOM;209;"Shabeellaha Dhexe";"Shabeellaha Dhexe";region;SD;18100
+Somalia;SO;SOM;209;"Shabeellaha Hoose";"Shabeellaha Hoose";region;SH;18089
+Somalia;SO;SOM;209;Sool;Sool;region;SO;18083
+Somalia;SO;SOM;209;Togdheer;Togdheer;region;TO;18091
+Somalia;SO;SOM;209;"Woqooyi Galbeed";"Woqooyi Galbeed";region;WO;18092
+"South Africa";ZA;ZAF;210;"Eastern Cape";"Eastern Cape";province;EC;18103
+"South Africa";ZA;ZAF;210;"Free State";"Free State";province;FS;18104
+"South Africa";ZA;ZAF;210;Gauteng;Gauteng;province;GT;18109
+"South Africa";ZA;ZAF;210;Kwazulu-Natal;Kwazulu-Natal;province;NL;18105
+"South Africa";ZA;ZAF;210;Limpopo;Limpopo;province;LP;18106
+"South Africa";ZA;ZAF;210;Mpumalanga;Mpumalanga;province;MP;18102
+"South Africa";ZA;ZAF;210;North-West;North-West;province;NW;18101
+"South Africa";ZA;ZAF;210;"Northern Cape";"Northern Cape";province;NC;18107
+"South Africa";ZA;ZAF;210;"Western Cape";"Western Cape";province;WC;18108
+"South Sudan";SS;SSD;703;"Central Equatoria";"Central Equatoria";state;EC;48882
+"South Sudan";SS;SSD;703;"Eastern Equatoria";"Eastern Equatoria";state;EE;48883
+"South Sudan";SS;SSD;703;Jonglei;Jonglei;state;JG;48884
+"South Sudan";SS;SSD;703;Lakes;Lakes;state;LK;48885
+"South Sudan";SS;SSD;703;"Northern Bahr el-Ghazal";"Northern Bahr el-Ghazal";state;BN;48886
+"South Sudan";SS;SSD;703;Unity;Unity;state;UY;48887
+"South Sudan";SS;SSD;703;"Upper Nile";"Upper Nile";state;NU;48888
+"South Sudan";SS;SSD;703;Warrap;Warrap;state;WR;48889
+"South Sudan";SS;SSD;703;"Western Bahr el-Ghazal";"Western Bahr el-Ghazal";state;BW;48890
+"South Sudan";SS;SSD;703;"Western Equatoria";"Western Equatoria";state;EW;48891
+Spain;ES;ESP;212;"A Coruña";"A Coruna";province;C;18135
+Spain;ES;ESP;212;Albacete;Albacete;province;AB;18137
+Spain;ES;ESP;212;Alicante;Alicante;province;A;18136
+Spain;ES;ESP;212;Almería;Almeria;province;AL;18138
+Spain;ES;ESP;212;Andalucía;Andalucia;;AN;19572
+Spain;ES;ESP;212;Asturias;Asturias;province;O;18122
+Spain;ES;ESP;212;"Principado de Asturias";"Principado de Asturias";"autonomous community";AS;47901
+Spain;ES;ESP;212;Badajoz;Badajoz;province;BA;18140
+Spain;ES;ESP;212;Baleares;Baleares;province;PM;18123
+Spain;ES;ESP;212;Barcelona;Barcelona;province;B;18141
+Spain;ES;ESP;212;Burgos;Burgos;province;BU;18124
+Spain;ES;ESP;212;Canarias;Canarias;;CN;19574
+Spain;ES;ESP;212;Cantabria;Cantabria;"autonomous community";CB;47898
+Spain;ES;ESP;212;Cantabria;Cantabria;province;S;18125
+Spain;ES;ESP;212;Castellón;Castellon;province;CS;18144
+Spain;ES;ESP;212;"Castilla y León";"Castilla y Leon";"autonomous community";CL;19575
+Spain;ES;ESP;212;"Castilla-La Mancha";"Castilla-La Mancha";"autonomous community";CM;19576
+Spain;ES;ESP;212;Catalunya;Catalunya;"autonomous community";CT;19577
+Spain;ES;ESP;212;Ceuta;Ceuta;"autonomous city";CE;42631
+Spain;ES;ESP;212;"Ciudad Real";"Ciudad Real";province;CR;18126
+Spain;ES;ESP;212;Cuenca;Cuenca;province;CU;18154
+Spain;ES;ESP;212;Cáceres;Caceres;province;CC;18142
+Spain;ES;ESP;212;Cádiz;Cadiz;province;CA;18143
+Spain;ES;ESP;212;Córdoba;Cordoba;province;CO;18127
+Spain;ES;ESP;212;Extremadura;Extremadura;"autonomous community";EX;19578
+Spain;ES;ESP;212;Galicia;Galicia;"autonomous community";GA;19579
+Spain;ES;ESP;212;Girona;Girona;province;GI;18128
+Spain;ES;ESP;212;Granada;Granada;province;GR;18129
+Spain;ES;ESP;212;Guadalajara;Guadalajara;province;GU;18155
+Spain;ES;ESP;212;Guipúzcoa;Guipuzcoa;province;SS;18130
+Spain;ES;ESP;212;Huelva;Huelva;province;H;18156
+Spain;ES;ESP;212;Huesca;Huesca;province;HU;18131
+Spain;ES;ESP;212;"Illes Balears";"Illes Balears";"autonomous community";IB;48287
+Spain;ES;ESP;212;Jaén;Jaen;province;J;18132
+Spain;ES;ESP;212;"La Rioja";"La Rioja";province;LO;18157
+Spain;ES;ESP;212;"Las Palmas";"Las Palmas";province;GC;18133
+Spain;ES;ESP;212;León;Leon;province;LE;18158
+Spain;ES;ESP;212;Lleida;Lleida;province;L;18134
+Spain;ES;ESP;212;Lugo;Lugo;province;LU;18145
+Spain;ES;ESP;212;Madrid;Madrid;province;M;18159
+Spain;ES;ESP;212;"Comunidad de Madrid";"Comunidad de Madrid";"autonomous community";MD;42628
+Spain;ES;ESP;212;Melilla;Melilla;"autonomous city";ML;42627
+Spain;ES;ESP;212;Murcia;Murcia;province;MU;18160
+Spain;ES;ESP;212;"Región de Murcia";"Region de Murcia";"autonomous community";MC;47866
+Spain;ES;ESP;212;Málaga;Malaga;province;MA;18146
+Spain;ES;ESP;212;Navarra;Navarra;province;NA;18148
+Spain;ES;ESP;212;"Comunidad Foral de Navarra";"Comunidad Foral de Navarra";"autonomous community";NC;42626
+Spain;ES;ESP;212;Ourense;Ourense;province;OR;18116
+Spain;ES;ESP;212;Palencia;Palencia;province;P;18149
+Spain;ES;ESP;212;"País Vasco";"Pais Vasco";"autonomous community";PV;19580
+Spain;ES;ESP;212;Pontevedra;Pontevedra;province;PO;18150
+Spain;ES;ESP;212;Salamanca;Salamanca;province;SA;18161
+Spain;ES;ESP;212;"Santa Cruz de Tenerife";"Santa Cruz de Tenerife";province;TF;18151
+Spain;ES;ESP;212;Segovia;Segovia;province;SG;18115
+Spain;ES;ESP;212;Sevilla;Sevilla;province;SE;18152
+Spain;ES;ESP;212;Soria;Soria;province;SO;18117
+Spain;ES;ESP;212;Tarragona;Tarragona;province;T;18112
+Spain;ES;ESP;212;Teruel;Teruel;province;TE;18118
+Spain;ES;ESP;212;Toledo;Toledo;province;TO;18119
+Spain;ES;ESP;212;Valencia;Valencia;province;V;18111
+Spain;ES;ESP;212;"Comunidad Valenciana";"Comunidad Valenciana";"autonomous community";VC;42625
+Spain;ES;ESP;212;Valladolid;Valladolid;province;VA;18120
+Spain;ES;ESP;212;Vizcaya;Vizcaya;province;BI;18113
+Spain;ES;ESP;212;Zamora;Zamora;province;ZA;18114
+Spain;ES;ESP;212;Zaragoza;Zaragoza;province;Z;18110
+Spain;ES;ESP;212;Álava;Alava;province;VI;18121
+Spain;ES;ESP;212;Ávila;Avila;province;AV;18139
+Spain;ES;ESP;212;;;;19573
+Spain;ES;ESP;212;;"autonomous community";"autonomous community";42629
+"Sri Lanka";LK;LKA;213;Ampāra;Ampara;district;52;18178
+"Sri Lanka";LK;LKA;213;Anurādhapura;Anuradhapura;district;71;18175
+"Sri Lanka";LK;LKA;213;Badulla;Badulla;district;81;18179
+"Sri Lanka";LK;LKA;213;"Basnāhira paḷāta";"Basnahira palata";province;1;48278
+"Sri Lanka";LK;LKA;213;"Dakuṇu paḷāta";"Dakunu palata";province;3;48279
+"Sri Lanka";LK;LKA;213;Gampaha;Gampaha;district;12;18176
+"Sri Lanka";LK;LKA;213;Gālla;Galla;district;31;18180
+"Sri Lanka";LK;LKA;213;Hambantŏṭa;Hambantota;district;33;18181
+"Sri Lanka";LK;LKA;213;Kalutara;Kalutara;district;13;18177
+"Sri Lanka";LK;LKA;213;Kegalla;Kegalla;district;92;18182
+"Sri Lanka";LK;LKA;213;Kilinŏchchi;Kilinochchi;district;42;18168
+"Sri Lanka";LK;LKA;213;Kuruṇægala;Kurunaegala;district;61;18186
+"Sri Lanka";LK;LKA;213;Kŏḷamba;Kolamba;district;11;18183
+"Sri Lanka";LK;LKA;213;Madakalapuva;Madakalapuva;district;51;18184
+"Sri Lanka";LK;LKA;213;"Madhyama paḷāta";"Madhyama palata";province;2;48280
+"Sri Lanka";LK;LKA;213;Mahanuvara;Mahanuvara;district;21;18167
+"Sri Lanka";LK;LKA;213;Mannārama;Mannarama;district;43;18185
+"Sri Lanka";LK;LKA;213;"Mattiya mākāṇam";"Mattiya makanam";province;5;48281
+"Sri Lanka";LK;LKA;213;Mulativ;Mulativ;district;45;18163
+"Sri Lanka";LK;LKA;213;Mātale;Matale;district;22;18169
+"Sri Lanka";LK;LKA;213;Mātara;Matara;district;32;18164
+"Sri Lanka";LK;LKA;213;Mŏṇarāgala;Monaragala;district;82;18170
+"Sri Lanka";LK;LKA;213;"Nuvara Ĕliya";"Nuvara Eliya";district;23;18171
+"Sri Lanka";LK;LKA;213;Puttalama;Puttalama;district;62;18172
+"Sri Lanka";LK;LKA;213;Pŏḷŏnnaruva;Polonnaruva;district;72;18165
+"Sri Lanka";LK;LKA;213;Ratnapura;Ratnapura;district;91;18166
+"Sri Lanka";LK;LKA;213;"Sabaragamuva paḷāta";"Sabaragamuva palata";province;9;48282
+"Sri Lanka";LK;LKA;213;Trikuṇāmalaya;Trikunamalaya;district;53;18173
+"Sri Lanka";LK;LKA;213;"Uturu paḷāta";"Uturu palata";province;4;48284
+"Sri Lanka";LK;LKA;213;"Uturumæ̆da paḷāta";"Uturumaeda palata";province;7;48283
+"Sri Lanka";LK;LKA;213;Vavuniyāva;Vavuniyava;district;44;18162
+"Sri Lanka";LK;LKA;213;"Vayamba paḷāta";"Vayamba palata";province;6;48286
+"Sri Lanka";LK;LKA;213;Yāpanaya;Yapanaya;district;41;18174
+"Sri Lanka";LK;LKA;213;"Ūva paḷāta";"Uva palata";province;8;48285
+Sudan;SD;SDN;214;"A?ali an Nil";"Aali an Nil";state;23;18194
+Sudan;SD;SDN;214;"Al Ba?r al A?mar";"Al Bar al Amar";state;26;48711
+Sudan;SD;SDN;214;"Al Bah¸r al Ah¸mar";"Al Bah,r al Ah,mar";state;RS;18206
+Sudan;SD;SDN;214;"Al Bu?ayrat";"Al Buayrat";state;18;18207
+Sudan;SD;SDN;214;"Al Jazirah";"Al Jazirah";state;07;48712
+Sudan;SD;SDN;214;"Al Jazirah";"Al Jazirah";state;GZ;18193
+Sudan;SD;SDN;214;"Al Khartum";"Al Khartum";state;KH;18197
+Sudan;SD;SDN;214;"Al Khartum";"Al Khartum";state;03;48713
+Sudan;SD;SDN;214;"Al Qa?arif";"Al Qaarif";state;06;48714
+Sudan;SD;SDN;214;"Al Qaḑārif";"Al Qadarif";state;GD;18189
+Sudan;SD;SDN;214;"Al Wa?dah";"Al Wadah";state;22;18187
+Sudan;SD;SDN;214;"An Nil";"An Nil";state;04;48715
+Sudan;SD;SDN;214;"An Nil";"An Nil";state;NR;18200
+Sudan;SD;SDN;214;"An Nil al Azraq";"An Nil al Azraq";state;NB;18201
+Sudan;SD;SDN;214;"An Nil al Azraq";"An Nil al Azraq";state;24;48717
+Sudan;SD;SDN;214;"An Nīl al Abyaḑ";"An Nil al Abyad";state;NW;18192
+Sudan;SD;SDN;214;"An Nīl al Abyaḑ";"An Nil al Abyad";state;08;48716
+Sudan;SD;SDN;214;"Ash Shamaliyah";"Ash Shamaliyah";state;01;48718
+Sudan;SD;SDN;214;"Ash Shamaliyah";"Ash Shamaliyah";state;NO;18190
+Sudan;SD;SDN;214;"Bahr al Jabal";"Bahr al Jabal";state;17;18195
+Sudan;SD;SDN;214;"Gharb al Istiwa'iyah";"Gharb al Istiwa'iyah";state;16;18208
+Sudan;SD;SDN;214;"Gharb Ba?r al Ghazal";"Gharb Bar al Ghazal";state;14;18196
+Sudan;SD;SDN;214;"Gharb Darfur";"Gharb Darfur";state;DW;18209
+Sudan;SD;SDN;214;"Gharb Darfur";"Gharb Darfur";state;12;48719
+Sudan;SD;SDN;214;"Gharb Kurdufan";"Gharb Kurdufan";;10;18210
+Sudan;SD;SDN;214;"Janub Darfur";"Janub Darfur";state;11;48720
+Sudan;SD;SDN;214;"Janub Darfur";"Janub Darfur";state;DS;18211
+Sudan;SD;SDN;214;"Janub Kurdufan";"Janub Kurdufan";state;KS;18198
+Sudan;SD;SDN;214;"Janub Kurdufan";"Janub Kurdufan";state;13;48721
+Sudan;SD;SDN;214;Junqali;Junqali;state;20;18199
+Sudan;SD;SDN;214;Kassala;Kassala;state;KA;18212
+Sudan;SD;SDN;214;Kassala;Kassala;state;05;48722
+Sudan;SD;SDN;214;"Shamal Ba?r al Ghazal";"Shamal Bar al Ghazal";state;15;18188
+Sudan;SD;SDN;214;"Shamal Darfur";"Shamal Darfur";state;DN;18202
+Sudan;SD;SDN;214;"Shamal Darfur";"Shamal Darfur";state;02;48723
+Sudan;SD;SDN;214;"Shamal Kurdufan";"Shamal Kurdufan";state;09;48724
+Sudan;SD;SDN;214;"Shamal Kurdufan";"Shamal Kurdufan";state;KN;18203
+Sudan;SD;SDN;214;"Sharq al Istiwa'iyah";"Sharq al Istiwa'iyah";state;19;18191
+Sudan;SD;SDN;214;"Sharq Dārfūr";"Sharq Darfur";;DE;48726
+Sudan;SD;SDN;214;Sinnar;Sinnar;state;25;48725
+Sudan;SD;SDN;214;Sinnar;Sinnar;state;SI;18204
+Sudan;SD;SDN;214;Warab;Warab;state;21;18205
+Sudan;SD;SDN;214;Zalingei;Zalingei;;DC;48727
+Suriname;SR;SUR;215;Brokopondo;Brokopondo;district;BR;18220
+Suriname;SR;SUR;215;Commewijne;Commewijne;district;CM;18214
+Suriname;SR;SUR;215;Coronie;Coronie;district;CR;18215
+Suriname;SR;SUR;215;Marowijne;Marowijne;district;MA;18221
+Suriname;SR;SUR;215;Nickerie;Nickerie;district;NI;18216
+Suriname;SR;SUR;215;Para;Para;district;PR;18222
+Suriname;SR;SUR;215;Paramaribo;Paramaribo;district;PM;18217
+Suriname;SR;SUR;215;Saramacca;Saramacca;district;SA;18218
+Suriname;SR;SUR;215;Sipaliwini;Sipaliwini;district;SI;18213
+Suriname;SR;SUR;215;Wanica;Wanica;district;WA;18219
+Swaziland;SZ;SWZ;217;Hhohho;Hhohho;district;HH;18226
+Swaziland;SZ;SWZ;217;Lubombo;Lubombo;district;LU;18228
+Swaziland;SZ;SWZ;217;Manzini;Manzini;district;MA;18225
+Swaziland;SZ;SWZ;217;Shiselweni;Shiselweni;district;SH;18227
+Sweden;SE;SWE;218;"Blekinge län (SE-10)";"Blekinge lan (SE-10)";county;K;18240
+Sweden;SE;SWE;218;"Dalarnas län (SE-20)";"Dalarnas lan (SE-20)";county;W;18248
+Sweden;SE;SWE;218;"Gotlands län (SE-09)";"Gotlands lan (SE-09)";county;I;18249
+Sweden;SE;SWE;218;"Gävleborgs län (SE-21)";"Gavleborgs lan (SE-21)";county;X;18241
+Sweden;SE;SWE;218;"Hallands län (SE-13)";"Hallands lan (SE-13)";county;N;18242
+Sweden;SE;SWE;218;"Jämtlands län (SE-23)";"Jamtlands lan (SE-23)";county;Z;18243
+Sweden;SE;SWE;218;"Jönköpings län (SE-06)";"Jonkopings lan (SE-06)";county;F;18250
+Sweden;SE;SWE;218;"Kalmar län (SE-08)";"Kalmar lan (SE-08)";county;H;18244
+Sweden;SE;SWE;218;"Kronobergs län (SE-07)";"Kronobergs lan (SE-07)";county;G;18245
+Sweden;SE;SWE;218;"Norrbottens län (SE-25)";"Norrbottens lan (SE-25)";county;BD;18251
+Sweden;SE;SWE;218;"Skåne län (SE-12)";"Skane lan (SE-12)";county;M;18247
+Sweden;SE;SWE;218;"Stockholms län (SE-01)";"Stockholms lan (SE-01)";county;AB;18252
+Sweden;SE;SWE;218;"Södermanlands län (SE-04)";"Sodermanlands lan (SE-04)";county;D;18231
+Sweden;SE;SWE;218;"Uppsala län (SE-03)";"Uppsala lan (SE-03)";county;C;18232
+Sweden;SE;SWE;218;"Värmlands län (SE-17)";"Varmlands lan (SE-17)";county;S;18233
+Sweden;SE;SWE;218;"Västerbottens län (SE-24)";"Vasterbottens lan (SE-24)";county;AC;18254
+Sweden;SE;SWE;218;"Västernorrlands län (SE-22)";"Vasternorrlands lan (SE-22)";county;Y;18234
+Sweden;SE;SWE;218;"Västmanlands län (SE-19)";"Vastmanlands lan (SE-19)";county;U;18253
+Sweden;SE;SWE;218;"Västra Götalands län (SE-14)";"Vastra Gotalands lan (SE-14)";county;O;18235
+Sweden;SE;SWE;218;"Örebro län (SE-18)";"Orebro lan (SE-18)";county;T;18246
+Sweden;SE;SWE;218;"Östergötlands län (SE-05)";"Ostergotlands lan (SE-05)";county;E;18230
+Switzerland;CH;CHE;219;"Aargau (de)";"Aargau (de)";canton;AG;18257
+Switzerland;CH;CHE;219;"Appenzell Ausserrhoden (de)";"Appenzell Ausserrhoden (de)";canton;AR;18274
+Switzerland;CH;CHE;219;"Appenzell Innerrhoden (de)";"Appenzell Innerrhoden (de)";canton;AI;18258
+Switzerland;CH;CHE;219;"Basel-Landschaft (de)";"Basel-Landschaft (de)";canton;BL;18275
+Switzerland;CH;CHE;219;"Basel-Stadt (de)";"Basel-Stadt (de)";canton;BS;18259
+Switzerland;CH;CHE;219;"Bern (de)";"Bern (de)";canton;BE;18276
+Switzerland;CH;CHE;219;"Fribourg (fr)";"Fribourg (fr)";canton;FR;18260
+Switzerland;CH;CHE;219;"Genève (fr)";"Geneve (fr)";canton;GE;18277
+Switzerland;CH;CHE;219;"Glarus (de)";"Glarus (de)";canton;GL;18261
+Switzerland;CH;CHE;219;"Graubünden (de)";"Graubunden (de)";canton;GR;18265
+Switzerland;CH;CHE;219;"Jura (fr)";"Jura (fr)";canton;JU;18262
+Switzerland;CH;CHE;219;"Luzern (de)";"Luzern (de)";canton;LU;18266
+Switzerland;CH;CHE;219;"Neuchâtel (fr)";"Neuchatel (fr)";canton;NE;18263
+Switzerland;CH;CHE;219;"Nidwalden (de)";"Nidwalden (de)";canton;NW;18267
+Switzerland;CH;CHE;219;"Obwalden (de)";"Obwalden (de)";canton;OW;18264
+Switzerland;CH;CHE;219;"Sankt Gallen (de)";"Sankt Gallen (de)";canton;SG;18268
+Switzerland;CH;CHE;219;"Schaffhausen (de)";"Schaffhausen (de)";canton;SH;18279
+Switzerland;CH;CHE;219;"Schwyz (de)";"Schwyz (de)";canton;SZ;18269
+Switzerland;CH;CHE;219;"Solothurn (de)";"Solothurn (de)";canton;SO;18270
+Switzerland;CH;CHE;219;"Thurgau (de)";"Thurgau (de)";canton;TG;18280
+Switzerland;CH;CHE;219;"Ticino (it)";"Ticino (it)";canton;TI;18271
+Switzerland;CH;CHE;219;"Uri (de)";"Uri (de)";canton;UR;18278
+Switzerland;CH;CHE;219;"Valais (fr)";"Valais (fr)";canton;VS;18272
+Switzerland;CH;CHE;219;"Vaud (fr)";"Vaud (fr)";canton;VD;18255
+Switzerland;CH;CHE;219;"Zug (de)";"Zug (de)";canton;ZG;18273
+Switzerland;CH;CHE;219;"Zürich (de)";"Zurich (de)";canton;ZH;18256
+"Syrian Arab Republic";SY;SYR;220;?alab;alab;province;HL;18285
+"Syrian Arab Republic";SY;SYR;220;?amah;amah;province;HM;18293
+"Syrian Arab Republic";SY;SYR;220;?ims;ims;province;HI;18284
+"Syrian Arab Republic";SY;SYR;220;"Al ?asakah";"Al asakah";province;HA;18288
+"Syrian Arab Republic";SY;SYR;220;"Al Ladhiqiyah";"Al Ladhiqiyah";province;LA;18289
+"Syrian Arab Republic";SY;SYR;220;"Al Qunaytirah";"Al Qunaytirah";province;QU;18290
+"Syrian Arab Republic";SY;SYR;220;"Ar Raqqah";"Ar Raqqah";province;RA;18282
+"Syrian Arab Republic";SY;SYR;220;"As Suwayda'";"As Suwayda'";province;SU;18291
+"Syrian Arab Republic";SY;SYR;220;Dar?a;Dara;province;DR;18286
+"Syrian Arab Republic";SY;SYR;220;"Dayr az Zawr";"Dayr az Zawr";province;DY;18292
+"Syrian Arab Republic";SY;SYR;220;Dimashq;Dimashq;province;DI;18283
+"Syrian Arab Republic";SY;SYR;220;Idlib;Idlib;province;ID;18294
+"Syrian Arab Republic";SY;SYR;220;"Rif Dimashq";"Rif Dimashq";province;RD;18287
+"Syrian Arab Republic";SY;SYR;220;Tartus;Tartus;province;TA;18281
+"Province Of China Taiwan";TW;TWN;221;Changhua;Changhua;district;CHA;18312
+"Province Of China Taiwan";TW;TWN;221;Chiayi;Chiayi;district;CYQ;18313
+"Province Of China Taiwan";TW;TWN;221;"Chiayi Municipality";"Chiayi Municipality";municipality;CYI;18308
+"Province Of China Taiwan";TW;TWN;221;Hsinchu;Hsinchu;district;HSQ;18310
+"Province Of China Taiwan";TW;TWN;221;"Hsinchu Municipality";"Hsinchu Municipality";municipality;HSZ;18309
+"Province Of China Taiwan";TW;TWN;221;Hualien;Hualien;district;HUA;18314
+"Province Of China Taiwan";TW;TWN;221;Ilan;Ilan;district;ILA;18311
+"Province Of China Taiwan";TW;TWN;221;Kaohsiung;Kaohsiung;district;KHQ;18315
+"Province Of China Taiwan";TW;TWN;221;"Kaohsiung Special Municipality";"Kaohsiung Special Municipality";"special municipality";KHH;18320
+"Province Of China Taiwan";TW;TWN;221;"Keelung Municipality";"Keelung Municipality";municipality;KEE;18316
+"Province Of China Taiwan";TW;TWN;221;Miaoli;Miaoli;district;MIA;18317
+"Province Of China Taiwan";TW;TWN;221;Nantou;Nantou;district;NAN;18323
+"Province Of China Taiwan";TW;TWN;221;Penghu;Penghu;district;PEN;18324
+"Province Of China Taiwan";TW;TWN;221;Pingtung;Pingtung;district;PIF;18318
+"Province Of China Taiwan";TW;TWN;221;Taichung;Taichung;district;TXQ;18307
+"Province Of China Taiwan";TW;TWN;221;"Taichung Municipality";"Taichung Municipality";municipality;TXG;18325
+"Province Of China Taiwan";TW;TWN;221;Tainan;Tainan;district;TNQ;18306
+"Province Of China Taiwan";TW;TWN;221;"Tainan Municipality";"Tainan Municipality";municipality;TNN;18319
+"Province Of China Taiwan";TW;TWN;221;Taipei;Taipei;district;TPQ;18305
+"Province Of China Taiwan";TW;TWN;221;"Taipei Special Municipality";"Taipei Special Municipality";"special municipality";TPE;18326
+"Province Of China Taiwan";TW;TWN;221;Taitung;Taitung;district;TTT;18304
+"Province Of China Taiwan";TW;TWN;221;Taoyuan;Taoyuan;district;TAO;18303
+"Province Of China Taiwan";TW;TWN;221;Yunlin;Yunlin;district;YUN;18302
+Tajikistan;TJ;TJK;222;Gorno-Badakhshan;Gorno-Badakhshan;"autonomous region";GB;18331
+Tajikistan;TJ;TJK;222;Khatlon;Khatlon;region;KT;18327
+Tajikistan;TJ;TJK;222;Sughd;Sughd;region;SU;18330
+Tajikistan;TJ;TJK;222;;city;city;18329
+"United Republic of Tanzania";TZ;TZA;223;Arusha;Arusha;region;01;18349
+"United Republic of Tanzania";TZ;TZA;223;"Dar es Salaam";"Dar es Salaam";region;02;18350
+"United Republic of Tanzania";TZ;TZA;223;Dodoma;Dodoma;region;03;18351
+"United Republic of Tanzania";TZ;TZA;223;Iringa;Iringa;region;04;18352
+"United Republic of Tanzania";TZ;TZA;223;Kagera;Kagera;region;05;18338
+"United Republic of Tanzania";TZ;TZA;223;"Kaskazini Pemba";"Kaskazini Pemba";region;06;18333
+"United Republic of Tanzania";TZ;TZA;223;"Kaskazini Unguja";"Kaskazini Unguja";region;07;19095
+"United Republic of Tanzania";TZ;TZA;223;Kigoma;Kigoma;region;08;18339
+"United Republic of Tanzania";TZ;TZA;223;Kilimanjaro;Kilimanjaro;region;09;18340
+"United Republic of Tanzania";TZ;TZA;223;"Kusini Pemba";"Kusini Pemba";region;10;19096
+"United Republic of Tanzania";TZ;TZA;223;"Kusini Unguja";"Kusini Unguja";region;11;19097
+"United Republic of Tanzania";TZ;TZA;223;Lindi;Lindi;region;12;18353
+"United Republic of Tanzania";TZ;TZA;223;Manyara;Manyara;region;26;18341
+"United Republic of Tanzania";TZ;TZA;223;Mara;Mara;region;13;18342
+"United Republic of Tanzania";TZ;TZA;223;Mbeya;Mbeya;region;14;18337
+"United Republic of Tanzania";TZ;TZA;223;"Mjini Magharibi";"Mjini Magharibi";region;15;19098
+"United Republic of Tanzania";TZ;TZA;223;Morogoro;Morogoro;region;16;18343
+"United Republic of Tanzania";TZ;TZA;223;Mtwara;Mtwara;region;17;18354
+"United Republic of Tanzania";TZ;TZA;223;Mwanza;Mwanza;region;18;18344
+"United Republic of Tanzania";TZ;TZA;223;Pwani;Pwani;region;19;18345
+"United Republic of Tanzania";TZ;TZA;223;Rukwa;Rukwa;region;20;18336
+"United Republic of Tanzania";TZ;TZA;223;Ruvuma;Ruvuma;region;21;18346
+"United Republic of Tanzania";TZ;TZA;223;Shinyanga;Shinyanga;region;22;18347
+"United Republic of Tanzania";TZ;TZA;223;Singida;Singida;region;23;18335
+"United Republic of Tanzania";TZ;TZA;223;Tabora;Tabora;region;24;18348
+"United Republic of Tanzania";TZ;TZA;223;Tanga;Tanga;region;25;18334
+Thailand;TH;THA;224;"Amnat Charoen";"Amnat Charoen";province;37;18402
+Thailand;TH;THA;224;"Ang Thong";"Ang Thong";province;15;18403
+Thailand;TH;THA;224;"Buri Ram";"Buri Ram";province;31;18421
+Thailand;TH;THA;224;Chachoengsao;Chachoengsao;province;24;18404
+Thailand;TH;THA;224;"Chai Nat";"Chai Nat";province;18;18422
+Thailand;TH;THA;224;Chaiyaphum;Chaiyaphum;province;36;18393
+Thailand;TH;THA;224;Chanthaburi;Chanthaburi;province;22;18394
+Thailand;TH;THA;224;"Chiang Mai";"Chiang Mai";province;50;18423
+Thailand;TH;THA;224;"Chiang Rai";"Chiang Rai";province;57;18395
+Thailand;TH;THA;224;"Chon Buri";"Chon Buri";province;20;18424
+Thailand;TH;THA;224;Chumphon;Chumphon;province;86;18396
+Thailand;TH;THA;224;Kalasin;Kalasin;province;46;18425
+Thailand;TH;THA;224;"Kamphaeng Phet";"Kamphaeng Phet";province;62;18397
+Thailand;TH;THA;224;Kanchanaburi;Kanchanaburi;province;71;18398
+Thailand;TH;THA;224;"Khon Kaen";"Khon Kaen";province;40;18426
+Thailand;TH;THA;224;Krabi;Krabi;province;81;18399
+Thailand;TH;THA;224;"Krung Thep Maha Nakhon (Bangkok)";"Krung Thep Maha Nakhon (Bangkok)";"metropolitan administration";10;18427
+Thailand;TH;THA;224;Lampang;Lampang;province;52;18400
+Thailand;TH;THA;224;Lamphun;Lamphun;province;51;18401
+Thailand;TH;THA;224;Loei;Loei;province;42;18366
+Thailand;TH;THA;224;"Lop Buri";"Lop Buri";province;16;18405
+Thailand;TH;THA;224;"Mae Hong Son";"Mae Hong Son";province;58;18406
+Thailand;TH;THA;224;"Maha Sarakham";"Maha Sarakham";province;44;18367
+Thailand;TH;THA;224;Mukdahan;Mukdahan;province;49;18407
+Thailand;TH;THA;224;"Nakhon Nayok";"Nakhon Nayok";province;26;18368
+Thailand;TH;THA;224;"Nakhon Pathom";"Nakhon Pathom";province;73;18408
+Thailand;TH;THA;224;"Nakhon Phanom";"Nakhon Phanom";province;48;18409
+Thailand;TH;THA;224;"Nakhon Ratchasima";"Nakhon Ratchasima";province;30;18369
+Thailand;TH;THA;224;"Nakhon Sawan";"Nakhon Sawan";province;60;18410
+Thailand;TH;THA;224;"Nakhon Si Thammarat";"Nakhon Si Thammarat";province;80;18370
+Thailand;TH;THA;224;Nan;Nan;province;55;18411
+Thailand;TH;THA;224;Narathiwat;Narathiwat;province;96;18412
+Thailand;TH;THA;224;"Nong Bua Lam Phu";"Nong Bua Lam Phu";province;39;18371
+Thailand;TH;THA;224;"Nong Khai";"Nong Khai";province;43;18384
+Thailand;TH;THA;224;Nonthaburi;Nonthaburi;province;12;18372
+Thailand;TH;THA;224;"Pathum Thani";"Pathum Thani";province;13;18385
+Thailand;TH;THA;224;Pattani;Pattani;province;94;18386
+Thailand;TH;THA;224;Phangnga;Phangnga;province;82;18373
+Thailand;TH;THA;224;Phatthalung;Phatthalung;province;93;18387
+Thailand;TH;THA;224;Phatthaya;Phatthaya;"special administrative city";S;20407
+Thailand;TH;THA;224;Phayao;Phayao;province;56;18374
+Thailand;TH;THA;224;Phetchabun;Phetchabun;province;67;18388
+Thailand;TH;THA;224;Phetchaburi;Phetchaburi;province;76;18389
+Thailand;TH;THA;224;Phichit;Phichit;province;66;18357
+Thailand;TH;THA;224;Phitsanulok;Phitsanulok;province;65;18390
+Thailand;TH;THA;224;"Phra Nakhon Si Ayutthaya";"Phra Nakhon Si Ayutthaya";province;14;18358
+Thailand;TH;THA;224;Phrae;Phrae;province;54;18391
+Thailand;TH;THA;224;Phuket;Phuket;province;83;18392
+Thailand;TH;THA;224;"Prachin Buri";"Prachin Buri";province;25;18359
+Thailand;TH;THA;224;"Prachuap Khiri Khan";"Prachuap Khiri Khan";province;77;18413
+Thailand;TH;THA;224;Ranong;Ranong;province;85;18414
+Thailand;TH;THA;224;Ratchaburi;Ratchaburi;province;70;18360
+Thailand;TH;THA;224;Rayong;Rayong;province;21;18415
+Thailand;TH;THA;224;"Roi Et";"Roi Et";province;45;18361
+Thailand;TH;THA;224;"Sa Kaeo";"Sa Kaeo";province;27;18416
+Thailand;TH;THA;224;"Sakon Nakhon";"Sakon Nakhon";province;47;18417
+Thailand;TH;THA;224;"Samut Prakan";"Samut Prakan";province;11;18362
+Thailand;TH;THA;224;"Samut Sakhon";"Samut Sakhon";province;74;18418
+Thailand;TH;THA;224;"Samut Songkhram";"Samut Songkhram";province;75;18363
+Thailand;TH;THA;224;Saraburi;Saraburi;province;19;18419
+Thailand;TH;THA;224;Satun;Satun;province;91;18420
+Thailand;TH;THA;224;"Si Sa Ket";"Si Sa Ket";province;33;18375
+Thailand;TH;THA;224;"Sing Buri";"Sing Buri";province;17;18364
+Thailand;TH;THA;224;Songkhla;Songkhla;province;90;18376
+Thailand;TH;THA;224;Sukhothai;Sukhothai;province;64;18365
+Thailand;TH;THA;224;"Suphan Buri";"Suphan Buri";province;72;18377
+Thailand;TH;THA;224;"Surat Thani";"Surat Thani";province;84;18356
+Thailand;TH;THA;224;Surin;Surin;province;32;18378
+Thailand;TH;THA;224;Tak;Tak;province;63;18379
+Thailand;TH;THA;224;Trang;Trang;province;92;18428
+Thailand;TH;THA;224;Trat;Trat;province;23;18380
+Thailand;TH;THA;224;"Ubon Ratchathani";"Ubon Ratchathani";province;34;18381
+Thailand;TH;THA;224;"Udon Thani";"Udon Thani";province;41;18430
+Thailand;TH;THA;224;"Uthai Thani";"Uthai Thani";province;61;18382
+Thailand;TH;THA;224;Uttaradit;Uttaradit;province;53;18429
+Thailand;TH;THA;224;Yala;Yala;province;95;18383
+Thailand;TH;THA;224;Yasothon;Yasothon;province;35;18355
+Timor-Leste;TL;TLS;226;Aileu;Aileu;district;AL;13554
+Timor-Leste;TL;TLS;226;Ainaro;Ainaro;district;AN;13553
+Timor-Leste;TL;TLS;226;Baucau;Baucau;district;BA;13562
+Timor-Leste;TL;TLS;226;Bobonaro;Bobonaro;district;BO;13556
+Timor-Leste;TL;TLS;226;"Cova Lima";"Cova Lima";district;CO;13557
+Timor-Leste;TL;TLS;226;Díli;Dili;district;DI;13564
+Timor-Leste;TL;TLS;226;Ermera;Ermera;district;ER;13558
+Timor-Leste;TL;TLS;226;Lautem;Lautem;district;LA;13563
+Timor-Leste;TL;TLS;226;Liquiça;Liquica;district;LI;13559
+Timor-Leste;TL;TLS;226;Manatuto;Manatuto;district;MT;13560
+Timor-Leste;TL;TLS;226;Manufahi;Manufahi;district;MF;13552
+Timor-Leste;TL;TLS;226;Oecussi;Oecussi;district;OE;13555
+Timor-Leste;TL;TLS;226;Viqueque;Viqueque;district;VI;13561
+Togo;TG;TGO;227;Centre;Centre;region;C;18433
+Togo;TG;TGO;227;Kara;Kara;region;K;18432
+Togo;TG;TGO;227;"Maritime (Région)";"Maritime (Region)";region;M;18435
+Togo;TG;TGO;227;Plateaux;Plateaux;region;P;18434
+Togo;TG;TGO;227;Savannes;Savannes;region;S;18431
+Tonga;TO;TON;229;'Eua;'Eua;"island group";01;18442
+Tonga;TO;TON;229;Ha'apai;Ha'apai;"island group";02;18440
+Tonga;TO;TON;229;Niuas;Niuas;"island group";03;18443
+Tonga;TO;TON;229;Tongatapu;Tongatapu;"island group";04;18441
+Tonga;TO;TON;229;Vava'u;Vava'u;"island group";05;18439
+"Trinidad and Tobago";TT;TTO;230;Arima;Arima;municipality;ARI;18446
+"Trinidad and Tobago";TT;TTO;230;Chaguanas;Chaguanas;municipality;CHA;18456
+"Trinidad and Tobago";TT;TTO;230;Couva-Tabaquite-Talparo;Couva-Tabaquite-Talparo;region;CTT;18447
+"Trinidad and Tobago";TT;TTO;230;"Diego Martin";"Diego Martin";region;DMN;18448
+"Trinidad and Tobago";TT;TTO;230;"Eastern Tobago";"Eastern Tobago";region;ETO;20483
+"Trinidad and Tobago";TT;TTO;230;Penal-Debe;Penal-Debe;region;PED;18449
+"Trinidad and Tobago";TT;TTO;230;"Point Fortin";"Point Fortin";municipality;PTF;18457
+"Trinidad and Tobago";TT;TTO;230;"Port of Spain";"Port of Spain";municipality;POS;18450
+"Trinidad and Tobago";TT;TTO;230;"Princes Town";"Princes Town";region;PRT;18445
+"Trinidad and Tobago";TT;TTO;230;"Rio Claro-Mayaro";"Rio Claro-Mayaro";region;RCM;18455
+"Trinidad and Tobago";TT;TTO;230;"San Fernando";"San Fernando";municipality;SFO;18451
+"Trinidad and Tobago";TT;TTO;230;"San Juan-Laventille";"San Juan-Laventille";region;SJL;18452
+"Trinidad and Tobago";TT;TTO;230;"Sangre Grande";"Sangre Grande";region;SGE;18458
+"Trinidad and Tobago";TT;TTO;230;Siparia;Siparia;region;SIP;18453
+"Trinidad and Tobago";TT;TTO;230;Tunapuna-Piarco;Tunapuna-Piarco;region;TUP;18454
+"Trinidad and Tobago";TT;TTO;230;"Western Tobago";"Western Tobago";region;WTO;20488
+Tunisia;TN;TUN;231;Ariana;Ariana;governorate;12;18463
+Tunisia;TN;TUN;231;"Ben Arous";"Ben Arous";governorate;13;18464
+Tunisia;TN;TUN;231;Bizerte;Bizerte;governorate;23;18470
+Tunisia;TN;TUN;231;Béja;Beja;governorate;31;18469
+Tunisia;TN;TUN;231;Gabès;Gabes;governorate;81;18474
+Tunisia;TN;TUN;231;Gafsa;Gafsa;governorate;71;18475
+Tunisia;TN;TUN;231;Jendouba;Jendouba;governorate;32;18465
+Tunisia;TN;TUN;231;Kairouan;Kairouan;governorate;41;18477
+Tunisia;TN;TUN;231;Kasserine;Kasserine;governorate;42;18476
+Tunisia;TN;TUN;231;Kebili;Kebili;governorate;73;18478
+Tunisia;TN;TUN;231;"La Manouba";"La Manouba";governorate;14;18467
+Tunisia;TN;TUN;231;"Le Kef";"Le Kef";governorate;33;18471
+Tunisia;TN;TUN;231;Mahdia;Mahdia;governorate;53;18472
+Tunisia;TN;TUN;231;Medenine;Medenine;governorate;82;18466
+Tunisia;TN;TUN;231;Monastir;Monastir;governorate;52;18473
+Tunisia;TN;TUN;231;Nabeul;Nabeul;governorate;21;18468
+Tunisia;TN;TUN;231;Sfax;Sfax;governorate;61;18462
+Tunisia;TN;TUN;231;"Sidi Bouzid";"Sidi Bouzid";governorate;43;18479
+Tunisia;TN;TUN;231;Siliana;Siliana;governorate;34;18461
+Tunisia;TN;TUN;231;Sousse;Sousse;governorate;51;18480
+Tunisia;TN;TUN;231;Tataouine;Tataouine;governorate;83;18460
+Tunisia;TN;TUN;231;Tozeur;Tozeur;governorate;72;18481
+Tunisia;TN;TUN;231;Tunis;Tunis;governorate;11;18482
+Tunisia;TN;TUN;231;Zaghouan;Zaghouan;governorate;22;18459
+Turkey;TR;TUR;232;Adana;Adana;province;01;18551
+Turkey;TR;TUR;232;Adiyaman;Adiyaman;province;02;18523
+Turkey;TR;TUR;232;Afyonkarahisar;Afyonkarahisar;province;03;18524
+Turkey;TR;TUR;232;Agri;Agri;province;04;18552
+Turkey;TR;TUR;232;Aksaray;Aksaray;province;68;18514
+Turkey;TR;TUR;232;Amasya;Amasya;province;05;18515
+Turkey;TR;TUR;232;Ankara;Ankara;province;06;18553
+Turkey;TR;TUR;232;Antalya;Antalya;province;07;18516
+Turkey;TR;TUR;232;Ardahan;Ardahan;province;75;18517
+Turkey;TR;TUR;232;Artvin;Artvin;province;08;18554
+Turkey;TR;TUR;232;Aydin;Aydin;province;09;18518
+Turkey;TR;TUR;232;Balikesir;Balikesir;province;10;18519
+Turkey;TR;TUR;232;Bartin;Bartin;province;74;18555
+Turkey;TR;TUR;232;Batman;Batman;province;72;18520
+Turkey;TR;TUR;232;Bayburt;Bayburt;province;69;18521
+Turkey;TR;TUR;232;Bilecik;Bilecik;province;11;18556
+Turkey;TR;TUR;232;Bingöl;Bingol;province;12;18522
+Turkey;TR;TUR;232;Bitlis;Bitlis;province;13;18525
+Turkey;TR;TUR;232;Bolu;Bolu;province;14;18526
+Turkey;TR;TUR;232;Burdur;Burdur;province;15;18557
+Turkey;TR;TUR;232;Bursa;Bursa;province;16;18527
+Turkey;TR;TUR;232;Denizli;Denizli;province;20;18530
+Turkey;TR;TUR;232;Diyarbakir;Diyarbakir;province;21;18495
+Turkey;TR;TUR;232;Düzce;Duzce;province;81;18531
+Turkey;TR;TUR;232;Edirne;Edirne;province;22;18532
+Turkey;TR;TUR;232;Elazig;Elazig;province;23;18541
+Turkey;TR;TUR;232;Erzincan;Erzincan;province;24;18505
+Turkey;TR;TUR;232;Erzurum;Erzurum;province;25;18506
+Turkey;TR;TUR;232;Eskisehir;Eskisehir;province;26;18542
+Turkey;TR;TUR;232;Gaziantep;Gaziantep;province;27;18507
+Turkey;TR;TUR;232;Giresun;Giresun;province;28;18543
+Turkey;TR;TUR;232;Gümüshane;Gumushane;province;29;18508
+Turkey;TR;TUR;232;Hakkâri;Hakkari;province;30;18509
+Turkey;TR;TUR;232;Hatay;Hatay;province;31;18510
+Turkey;TR;TUR;232;Igdir;Igdir;province;76;18511
+Turkey;TR;TUR;232;Isparta;Isparta;province;32;18545
+Turkey;TR;TUR;232;Istanbul;Istanbul;province;34;18512
+Turkey;TR;TUR;232;Izmir;Izmir;province;35;18513
+Turkey;TR;TUR;232;Kahramanmaras;Kahramanmaras;province;46;18546
+Turkey;TR;TUR;232;Karabük;Karabuk;province;78;18533
+Turkey;TR;TUR;232;Karaman;Karaman;province;70;18534
+Turkey;TR;TUR;232;Kars;Kars;province;36;18547
+Turkey;TR;TUR;232;Kastamonu;Kastamonu;province;37;18535
+Turkey;TR;TUR;232;Kayseri;Kayseri;province;38;18536
+Turkey;TR;TUR;232;Kilis;Kilis;province;79;18548
+Turkey;TR;TUR;232;Kirikkale;Kirikkale;province;71;18537
+Turkey;TR;TUR;232;Kirklareli;Kirklareli;province;39;18486
+Turkey;TR;TUR;232;Kirsehir;Kirsehir;province;40;18538
+Turkey;TR;TUR;232;Kocaeli;Kocaeli;province;41;18539
+Turkey;TR;TUR;232;Konya;Konya;province;42;18540
+Turkey;TR;TUR;232;Kütahya;Kutahya;province;43;18559
+Turkey;TR;TUR;232;Malatya;Malatya;province;44;18496
+Turkey;TR;TUR;232;Manisa;Manisa;province;45;18497
+Turkey;TR;TUR;232;Mardin;Mardin;province;47;18485
+Turkey;TR;TUR;232;Mersin;Mersin;province;33;18544
+Turkey;TR;TUR;232;Mugla;Mugla;province;48;18498
+Turkey;TR;TUR;232;Mus;Mus;province;49;18499
+Turkey;TR;TUR;232;Nevsehir;Nevsehir;province;50;18560
+Turkey;TR;TUR;232;Nigde;Nigde;province;51;18500
+Turkey;TR;TUR;232;Ordu;Ordu;province;52;18501
+Turkey;TR;TUR;232;Osmaniye;Osmaniye;province;80;18484
+Turkey;TR;TUR;232;Rize;Rize;province;53;18502
+Turkey;TR;TUR;232;Sakarya;Sakarya;province;54;18503
+Turkey;TR;TUR;232;Samsun;Samsun;province;55;18561
+Turkey;TR;TUR;232;Sanliurfa;Sanliurfa;province;63;18504
+Turkey;TR;TUR;232;Siirt;Siirt;province;56;18487
+Turkey;TR;TUR;232;Sinop;Sinop;province;57;18564
+Turkey;TR;TUR;232;Sirnak;Sirnak;province;73;18488
+Turkey;TR;TUR;232;Sivas;Sivas;province;58;18563
+Turkey;TR;TUR;232;Tekirdag;Tekirdag;province;59;18489
+Turkey;TR;TUR;232;Tokat;Tokat;province;60;18490
+Turkey;TR;TUR;232;Trabzon;Trabzon;province;61;18491
+Turkey;TR;TUR;232;Tunceli;Tunceli;province;62;18562
+Turkey;TR;TUR;232;Usak;Usak;province;64;18492
+Turkey;TR;TUR;232;Van;Van;province;65;18493
+Turkey;TR;TUR;232;Yalova;Yalova;province;77;18565
+Turkey;TR;TUR;232;Yozgat;Yozgat;province;66;18494
+Turkey;TR;TUR;232;Zonguldak;Zonguldak;province;67;18483
+Turkey;TR;TUR;232;Çanakkale;Canakkale;province;17;18558
+Turkey;TR;TUR;232;Çankiri;Cankiri;province;18;18528
+Turkey;TR;TUR;232;Çorum;Corum;province;19;18529
+Turkmenistan;TM;TKM;233;Ahal;Ahal;region;A;18569
+Turkmenistan;TM;TKM;233;Balkan;Balkan;region;B;18568
+Turkmenistan;TM;TKM;233;Dasoguz;Dasoguz;region;D;18571
+Turkmenistan;TM;TKM;233;Lebap;Lebap;region;L;18572
+Turkmenistan;TM;TKM;233;Mary;Mary;region;M;18566
+Turkmenistan;TM;TKM;233;;City;city;18567
+Turkmenistan;TM;TKM;233;;City;city;48134
+Tuvalu;TV;TUV;235;Funafuti;Funafuti;"island council";FUN;18586
+Tuvalu;TV;TUV;235;Nanumanga;Nanumanga;"island council";NMG;18580
+Tuvalu;TV;TUV;235;Nanumea;Nanumea;"island council";NMA;18581
+Tuvalu;TV;TUV;235;Niutao;Niutao;"island council";NIT;18582
+Tuvalu;TV;TUV;235;Nui;Nui;"island council";NIU;18583
+Tuvalu;TV;TUV;235;Nukufetau;Nukufetau;"island council";NKF;18579
+Tuvalu;TV;TUV;235;Nukulaelae;Nukulaelae;"island council";NKL;18584
+Tuvalu;TV;TUV;235;Vaitupu;Vaitupu;"island council";VAI;18585
+Uganda;UG;UGA;236;Abim;Abim;district;317;48102
+Uganda;UG;UGA;236;Adjumani;Adjumani;district;301;20547
+Uganda;UG;UGA;236;Amolatar;Amolatar;district;314;48103
+Uganda;UG;UGA;236;Amuria;Amuria;district;216;48104
+Uganda;UG;UGA;236;Amuru;Amuru;district;319;48105
+Uganda;UG;UGA;236;Apac;Apac;district;302;20548
+Uganda;UG;UGA;236;Arua;Arua;district;303;20549
+Uganda;UG;UGA;236;Budaka;Budaka;district;217;48106
+Uganda;UG;UGA;236;Bududa;Bududa;district;223;48122
+Uganda;UG;UGA;236;Bugiri;Bugiri;district;201;20532
+Uganda;UG;UGA;236;Bukedea;Bukedea;district;224;48121
+Uganda;UG;UGA;236;Bukwa;Bukwa;district;218;48107
+Uganda;UG;UGA;236;Buliisa;Buliisa;district;419;48124
+Uganda;UG;UGA;236;Bundibugyo;Bundibugyo;district;401;20560
+Uganda;UG;UGA;236;Bushenyi;Bushenyi;district;402;20561
+Uganda;UG;UGA;236;Busia;Busia;district;202;20533
+Uganda;UG;UGA;236;Butaleja;Butaleja;district;219;48108
+Uganda;UG;UGA;236;Central;Central;"geographic region";C;48541
+Uganda;UG;UGA;236;Dokolo;Dokolo;district;318;48109
+Uganda;UG;UGA;236;Eastern;Eastern;"geographic region";E;48542
+Uganda;UG;UGA;236;Gulu;Gulu;district;304;20550
+Uganda;UG;UGA;236;Hoima;Hoima;district;403;20562
+Uganda;UG;UGA;236;Ibanda;Ibanda;district;416;48110
+Uganda;UG;UGA;236;Iganga;Iganga;district;203;20534
+Uganda;UG;UGA;236;Isingiro;Isingiro;district;417;48111
+Uganda;UG;UGA;236;Jinja;Jinja;district;204;20535
+Uganda;UG;UGA;236;Kaabong;Kaabong;district;315;48112
+Uganda;UG;UGA;236;Kabale;Kabale;district;404;20563
+Uganda;UG;UGA;236;Kabarole;Kabarole;district;405;20564
+Uganda;UG;UGA;236;Kaberamaido;Kaberamaido;district;213;20544
+Uganda;UG;UGA;236;Kalangala;Kalangala;district;101;20519
+Uganda;UG;UGA;236;Kaliro;Kaliro;district;220;48113
+Uganda;UG;UGA;236;Kampala;Kampala;district;102;20520
+Uganda;UG;UGA;236;Kamuli;Kamuli;district;205;20536
+Uganda;UG;UGA;236;Kamwenge;Kamwenge;district;413;20572
+Uganda;UG;UGA;236;Kanungu;Kanungu;district;414;20573
+Uganda;UG;UGA;236;Kapchorwa;Kapchorwa;district;206;20537
+Uganda;UG;UGA;236;Kasese;Kasese;district;406;20565
+Uganda;UG;UGA;236;Katakwi;Katakwi;district;207;20538
+Uganda;UG;UGA;236;Kayunga;Kayunga;district;112;20530
+Uganda;UG;UGA;236;Kibaale;Kibaale;district;407;20566
+Uganda;UG;UGA;236;Kiboga;Kiboga;district;103;20521
+Uganda;UG;UGA;236;Kiruhura;Kiruhura;district;418;48114
+Uganda;UG;UGA;236;Kisoro;Kisoro;district;408;20567
+Uganda;UG;UGA;236;Kitgum;Kitgum;district;305;20551
+Uganda;UG;UGA;236;Koboko;Koboko;district;316;48115
+Uganda;UG;UGA;236;Kotido;Kotido;district;306;20552
+Uganda;UG;UGA;236;Kumi;Kumi;district;208;20539
+Uganda;UG;UGA;236;Kyenjojo;Kyenjojo;district;415;20574
+Uganda;UG;UGA;236;Lira;Lira;district;307;20553
+Uganda;UG;UGA;236;Luwero;Luwero;district;104;20522
+Uganda;UG;UGA;236;Lyantonde;Lyantonde;district;116;48123
+Uganda;UG;UGA;236;Manafwa;Manafwa;district;221;48116
+Uganda;UG;UGA;236;Maracha;Maracha;district;320;48117
+Uganda;UG;UGA;236;Masaka;Masaka;district;105;20523
+Uganda;UG;UGA;236;Masindi;Masindi;district;409;20568
+Uganda;UG;UGA;236;Mayuge;Mayuge;district;214;20545
+Uganda;UG;UGA;236;Mbale;Mbale;district;209;20540
+Uganda;UG;UGA;236;Mbarara;Mbarara;district;410;20569
+Uganda;UG;UGA;236;Mityana;Mityana;district;114;48125
+Uganda;UG;UGA;236;Moroto;Moroto;district;308;20554
+Uganda;UG;UGA;236;Moyo;Moyo;district;309;20555
+Uganda;UG;UGA;236;Mpigi;Mpigi;district;106;20524
+Uganda;UG;UGA;236;Mubende;Mubende;district;107;20525
+Uganda;UG;UGA;236;Mukono;Mukono;district;108;20526
+Uganda;UG;UGA;236;Nakapiripirit;Nakapiripirit;district;311;20557
+Uganda;UG;UGA;236;Nakaseke;Nakaseke;district;115;48118
+Uganda;UG;UGA;236;Nakasongola;Nakasongola;district;109;20527
+Uganda;UG;UGA;236;Namutumba;Namutumba;district;222;48119
+Uganda;UG;UGA;236;Nebbi;Nebbi;district;310;20556
+Uganda;UG;UGA;236;Northern;Northern;"geographic region";N;48543
+Uganda;UG;UGA;236;Ntungamo;Ntungamo;district;411;20570
+Uganda;UG;UGA;236;Oyam;Oyam;district;321;48126
+Uganda;UG;UGA;236;Pader;Pader;district;312;20558
+Uganda;UG;UGA;236;Pallisa;Pallisa;district;210;20541
+Uganda;UG;UGA;236;Rakai;Rakai;district;110;20528
+Uganda;UG;UGA;236;Rukungiri;Rukungiri;district;412;20571
+Uganda;UG;UGA;236;Sembabule;Sembabule;district;111;20529
+Uganda;UG;UGA;236;Sironko;Sironko;district;215;20546
+Uganda;UG;UGA;236;Soroti;Soroti;district;211;20542
+Uganda;UG;UGA;236;Tororo;Tororo;district;212;20543
+Uganda;UG;UGA;236;Wakiso;Wakiso;district;113;20531
+Uganda;UG;UGA;236;Western;Western;"geographic region";W;48544
+Uganda;UG;UGA;236;Yumbe;Yumbe;district;313;20559
+Ukraine;UA;UKR;237;"Cherkas'ka Oblast'";"Cherkas'ka Oblast'";region;71;18594
+Ukraine;UA;UKR;237;"Chernihivs'ka Oblast'";"Chernihivs'ka Oblast'";region;74;18595
+Ukraine;UA;UKR;237;"Chernivets'ka Oblast'";"Chernivets'ka Oblast'";region;77;18596
+Ukraine;UA;UKR;237;"Dnipropetrovs'ka Oblast'";"Dnipropetrovs'ka Oblast'";region;12;18603
+Ukraine;UA;UKR;237;"Donets'ka Oblast'";"Donets'ka Oblast'";region;14;18597
+Ukraine;UA;UKR;237;"Ivano-Frankivs'ka Oblast'";"Ivano-Frankivs'ka Oblast'";region;26;18598
+Ukraine;UA;UKR;237;"Kharkivs'ka Oblast'";"Kharkivs'ka Oblast'";region;63;18599
+Ukraine;UA;UKR;237;"Khersons'ka Oblast'";"Khersons'ka Oblast'";region;65;18600
+Ukraine;UA;UKR;237;"Khmel'nyts'ka Oblast'";"Khmel'nyts'ka Oblast'";region;68;18604
+Ukraine;UA;UKR;237;"Kirovohrads'ka Oblast'";"Kirovohrads'ka Oblast'";region;35;18601
+Ukraine;UA;UKR;237;Kyïv;Kyiv;region;30;18607
+Ukraine;UA;UKR;237;"Kyïvs'ka Oblast'";"Kyivs'ka Oblast'";region;32;18608
+Ukraine;UA;UKR;237;"L'vivs'ka Oblast'";"L'vivs'ka Oblast'";region;46;18609
+Ukraine;UA;UKR;237;"Luhans'ka Oblast'";"Luhans'ka Oblast'";region;09;18605
+Ukraine;UA;UKR;237;"Mykolaïvs'ka Oblast'";"Mykolaivs'ka Oblast'";region;48;18610
+Ukraine;UA;UKR;237;"Odes'ka Oblast'";"Odes'ka Oblast'";region;51;18606
+Ukraine;UA;UKR;237;"Poltavs'ka Oblast'";"Poltavs'ka Oblast'";region;53;18611
+Ukraine;UA;UKR;237;"Respublika Krym";"Respublika Krym";"autonomous republic";43;18602
+Ukraine;UA;UKR;237;"Rivnens'ka Oblast'";"Rivnens'ka Oblast'";region;56;18612
+Ukraine;UA;UKR;237;Sevastopol';Sevastopol';region;40;18613
+Ukraine;UA;UKR;237;"Sums'ka Oblast'";"Sums'ka Oblast'";region;59;18614
+Ukraine;UA;UKR;237;"Ternopil's'ka Oblast'";"Ternopil's'ka Oblast'";region;61;18615
+Ukraine;UA;UKR;237;"Vinnyts'ka Oblast'";"Vinnyts'ka Oblast'";region;05;18593
+Ukraine;UA;UKR;237;"Volyns'ka Oblast'";"Volyns'ka Oblast'";region;07;18617
+Ukraine;UA;UKR;237;"Zakarpats'ka Oblast'";"Zakarpats'ka Oblast'";region;21;18618
+Ukraine;UA;UKR;237;"Zaporiz'ka Oblast'";"Zaporiz'ka Oblast'";region;23;18616
+Ukraine;UA;UKR;237;"Zhytomyrs'ka Oblast'";"Zhytomyrs'ka Oblast'";region;18;18592
+"United Arab Emirates";AE;ARE;238;"Abu Z¸aby (Abu Dhabi)";"Abu Z,aby (Abu Dhabi)";emirate;AZ;18622
+"United Arab Emirates";AE;ARE;238;Ajman;Ajman;emirate;AJ;20215
+"United Arab Emirates";AE;ARE;238;"Al Fujayrah";"Al Fujayrah";emirate;FU;20218
+"United Arab Emirates";AE;ARE;238;"Ash Shariqah (Sharjah)";"Ash Shariqah (Sharjah)";emirate;SH;20219
+"United Arab Emirates";AE;ARE;238;"Dubayy (Dubai)";"Dubayy (Dubai)";emirate;DU;20217
+"United Arab Emirates";AE;ARE;238;"Ra’s al Khaymah";"Ra's al Khaymah";emirate;RK;18620
+"United Arab Emirates";AE;ARE;238;"Umm al Qaywayn";"Umm al Qaywayn";emirate;UQ;20220
+"United Kingdom";GB;GBR;239;"Aberdeen City";"Aberdeen City";"council area";ABE;47989
+"United Kingdom";GB;GBR;239;Aberdeenshire;Aberdeenshire;"council area";ABD;47988
+"United Kingdom";GB;GBR;239;Angus;Angus;"council area";ANS;47987
+"United Kingdom";GB;GBR;239;Antrim;Antrim;"district council area";ANT;48015
+"United Kingdom";GB;GBR;239;Ards;Ards;"district council area";ARD;48014
+"United Kingdom";GB;GBR;239;"Argyll and Bute";"Argyll and Bute";"council area";AGB;47986
+"United Kingdom";GB;GBR;239;Armagh;Armagh;"district council area";ARM;48013
+"United Kingdom";GB;GBR;239;Ballymena;Ballymena;"district council area";BLA;48012
+"United Kingdom";GB;GBR;239;Ballymoney;Ballymoney;"district council area";BLY;48011
+"United Kingdom";GB;GBR;239;Banbridge;Banbridge;"district council area";BNB;48010
+"United Kingdom";GB;GBR;239;"Barking and Dagenham";"Barking and Dagenham";borough;BDG;19166
+"United Kingdom";GB;GBR;239;Barnet;Barnet;borough;BNE;19167
+"United Kingdom";GB;GBR;239;Barnsley;Barnsley;"metropolitan district";BNS;19168
+"United Kingdom";GB;GBR;239;"Bath and North East Somerset";"Bath and North East Somerset";"unitary authority";BAS;47935
+"United Kingdom";GB;GBR;239;Bedfordshire;Bedfordshire;"unitary authority";BDF;47934
+"United Kingdom";GB;GBR;239;Belfast;Belfast;"district council area";BFS;48009
+"United Kingdom";GB;GBR;239;Bexley;Bexley;borough;BEX;19172
+"United Kingdom";GB;GBR;239;Birmingham;Birmingham;"metropolitan district";BIR;19173
+"United Kingdom";GB;GBR;239;"Blackburn with Darwen";"Blackburn with Darwen";"unitary authority";BBD;47933
+"United Kingdom";GB;GBR;239;Blackpool;Blackpool;"unitary authority";BPL;47932
+"United Kingdom";GB;GBR;239;"Blaenau Gwent";"Blaenau Gwent";"unitary authority";BGW;47956
+"United Kingdom";GB;GBR;239;Bolton;Bolton;"metropolitan district";BOL;19177
+"United Kingdom";GB;GBR;239;Bournemouth;Bournemouth;"unitary authority";BMH;47931
+"United Kingdom";GB;GBR;239;"Bracknell Forest";"Bracknell Forest";"unitary authority";BRC;47930
+"United Kingdom";GB;GBR;239;Bradford;Bradford;"metropolitan district";BRD;19180
+"United Kingdom";GB;GBR;239;Brent;Brent;borough;BEN;19181
+"United Kingdom";GB;GBR;239;"Bridgend (Pen-y-bont ar Ogwr GB-POG)";"Bridgend (Pen-y-bont ar Ogwr GB-POG)";"unitary authority";BGE;47955
+"United Kingdom";GB;GBR;239;"Brighton and Hove";"Brighton and Hove";"unitary authority";BNH;47929
+"United Kingdom";GB;GBR;239;"City of Bristol";"City of Bristol";"unitary authority";BST;47928
+"United Kingdom";GB;GBR;239;Bromley;Bromley;borough;BRY;19185
+"United Kingdom";GB;GBR;239;Buckinghamshire;Buckinghamshire;"two-tier county";BKM;47927
+"United Kingdom";GB;GBR;239;Bury;Bury;"metropolitan district";BUR;19187
+"United Kingdom";GB;GBR;239;"Caerphilly (Caerffili GB-CAF)";"Caerphilly (Caerffili GB-CAF)";"unitary authority";CAY;47954
+"United Kingdom";GB;GBR;239;Calderdale;Calderdale;"metropolitan district";CLD;19189
+"United Kingdom";GB;GBR;239;Cambridgeshire;Cambridgeshire;"two-tier county";CAM;47926
+"United Kingdom";GB;GBR;239;Camden;Camden;borough;CMD;19191
+"United Kingdom";GB;GBR;239;"Cardiff (Caerdydd GB-CRD)";"Cardiff (Caerdydd GB-CRD)";"unitary authority";CRF;47953
+"United Kingdom";GB;GBR;239;"Carmarthenshire (Sir Gaerfyrddin GB-GFY)";"Carmarthenshire (Sir Gaerfyrddin GB-GFY)";"unitary authority";CMN;47952
+"United Kingdom";GB;GBR;239;Carrickfergus;Carrickfergus;"district council area";CKF;48008
+"United Kingdom";GB;GBR;239;Castlereagh;Castlereagh;"district council area";CSR;48007
+"United Kingdom";GB;GBR;239;"Ceredigion (Sir Ceredigion)";"Ceredigion (Sir Ceredigion)";"unitary authority";CGN;47951
+"United Kingdom";GB;GBR;239;Cheshire;Cheshire;;CHS;47925
+"United Kingdom";GB;GBR;239;Clackmannanshire;Clackmannanshire;"council area";CLK;47985
+"United Kingdom";GB;GBR;239;Coleraine;Coleraine;"district council area";CLR;48006
+"United Kingdom";GB;GBR;239;Conwy;Conwy;"unitary authority";CWY;47950
+"United Kingdom";GB;GBR;239;Cookstown;Cookstown;"district council area";CKT;48005
+"United Kingdom";GB;GBR;239;Cornwall;Cornwall;"unitary authority";CON;47924
+"United Kingdom";GB;GBR;239;Coventry;Coventry;"metropolitan district";COV;19203
+"United Kingdom";GB;GBR;239;Craigavon;Craigavon;"district council area";CGV;48004
+"United Kingdom";GB;GBR;239;Croydon;Croydon;borough;CRY;19205
+"United Kingdom";GB;GBR;239;Cumbria;Cumbria;"two-tier county";CMA;47923
+"United Kingdom";GB;GBR;239;Darlington;Darlington;"unitary authority";DAL;47922
+"United Kingdom";GB;GBR;239;"Denbighshire (Sir Ddinbych GB-DDB)";"Denbighshire (Sir Ddinbych GB-DDB)";"unitary authority";DEN;47949
+"United Kingdom";GB;GBR;239;Derby;Derby;"unitary authority";DER;47921
+"United Kingdom";GB;GBR;239;Derbyshire;Derbyshire;"two-tier county";DBY;47920
+"United Kingdom";GB;GBR;239;Derry;Derry;"district council area";DRY;47997
+"United Kingdom";GB;GBR;239;Devon;Devon;"two-tier county";DEV;47919
+"United Kingdom";GB;GBR;239;Doncaster;Doncaster;"metropolitan district";DNC;19213
+"United Kingdom";GB;GBR;239;Dorset;Dorset;"two-tier county";DOR;47918
+"United Kingdom";GB;GBR;239;Down;Down;"district council area";DOW;48003
+"United Kingdom";GB;GBR;239;Dudley;Dudley;"metropolitan district";DUD;19216
+"United Kingdom";GB;GBR;239;"Dumfries and Galloway";"Dumfries and Galloway";"council area";DGY;47984
+"United Kingdom";GB;GBR;239;"Dundee City";"Dundee City";"council area";DND;47983
+"United Kingdom";GB;GBR;239;"Dungannon and South Tyrone";"Dungannon and South Tyrone";"district council area";DGN;48002
+"United Kingdom";GB;GBR;239;Durham;Durham;"unitary authority";DUR;47917
+"United Kingdom";GB;GBR;239;Ealing;Ealing;borough;EAL;19221
+"United Kingdom";GB;GBR;239;"East Ayrshire";"East Ayrshire";"council area";EAY;47982
+"United Kingdom";GB;GBR;239;"East Dunbartonshire";"East Dunbartonshire";"council area";EDU;47981
+"United Kingdom";GB;GBR;239;"East Lothian";"East Lothian";"council area";ELN;47980
+"United Kingdom";GB;GBR;239;"East Renfrewshire";"East Renfrewshire";"council area";ERW;47979
+"United Kingdom";GB;GBR;239;"East Riding of Yorkshire";"East Riding of Yorkshire";"unitary authority";ERY;47916
+"United Kingdom";GB;GBR;239;"East Sussex";"East Sussex";"two-tier county";ESX;47915
+"United Kingdom";GB;GBR;239;"City of Edinburgh";"City of Edinburgh";"council area";EDH;47978
+"United Kingdom";GB;GBR;239;"Eilean Siar";"Eilean Siar";"council area";ELS;47977
+"United Kingdom";GB;GBR;239;Enfield;Enfield;borough;ENF;19230
+"United Kingdom";GB;GBR;239;Essex;Essex;"two-tier county";ESS;47914
+"United Kingdom";GB;GBR;239;Falkirk;Falkirk;"council area";FAL;47976
+"United Kingdom";GB;GBR;239;Fermanagh;Fermanagh;"district council area";FER;48001
+"United Kingdom";GB;GBR;239;Fife;Fife;"council area";FIF;47975
+"United Kingdom";GB;GBR;239;"Flintshire (Sir y Fflint GB-FFL)";"Flintshire (Sir y Fflint GB-FFL)";"unitary authority";FLN;47948
+"United Kingdom";GB;GBR;239;Gateshead;Gateshead;"metropolitan district";GAT;19236
+"United Kingdom";GB;GBR;239;"Glasgow City";"Glasgow City";"council area";GLG;47974
+"United Kingdom";GB;GBR;239;Gloucestershire;Gloucestershire;"two-tier county";GLS;47913
+"United Kingdom";GB;GBR;239;Greenwich;Greenwich;borough;GRE;19239
+"United Kingdom";GB;GBR;239;Gwynedd;Gwynedd;"unitary authority";GWN;47947
+"United Kingdom";GB;GBR;239;Hackney;Hackney;borough;HCK;19241
+"United Kingdom";GB;GBR;239;Halton;Halton;"unitary authority";HAL;47911
+"United Kingdom";GB;GBR;239;"Hammersmith and Fulham";"Hammersmith and Fulham";borough;HMF;19243
+"United Kingdom";GB;GBR;239;Hampshire;Hampshire;"two-tier county";HAM;47910
+"United Kingdom";GB;GBR;239;Haringey;Haringey;borough;HRY;19245
+"United Kingdom";GB;GBR;239;Harrow;Harrow;borough;HRW;19246
+"United Kingdom";GB;GBR;239;Hartlepool;Hartlepool;"unitary authority";HPL;47909
+"United Kingdom";GB;GBR;239;Havering;Havering;borough;HAV;19248
+"United Kingdom";GB;GBR;239;"County of Herefordshire";"County of Herefordshire";"unitary authority";HEF;47908
+"United Kingdom";GB;GBR;239;Hertfordshire;Hertfordshire;"two-tier county";HRT;47907
+"United Kingdom";GB;GBR;239;Highland;Highland;"council area";HLD;47973
+"United Kingdom";GB;GBR;239;Hillingdon;Hillingdon;borough;HIL;19252
+"United Kingdom";GB;GBR;239;Hounslow;Hounslow;borough;HNS;19253
+"United Kingdom";GB;GBR;239;Inverclyde;Inverclyde;"council area";IVC;47972
+"United Kingdom";GB;GBR;239;"Isle of Anglesey (Sir Ynys Môn GB-YNM)";"Isle of Anglesey (Sir Ynys Mon GB-YNM)";"unitary authority";AGY;47957
+"United Kingdom";GB;GBR;239;"Isle of Wight";"Isle of Wight";"unitary authority";IOW;47906
+"United Kingdom";GB;GBR;239;"Isles of Scilly";"Isles of Scilly";;IOS;19257
+"United Kingdom";GB;GBR;239;Islington;Islington;borough;ISL;19258
+"United Kingdom";GB;GBR;239;"Kensington and Chelsea";"Kensington and Chelsea";borough;KEC;19259
+"United Kingdom";GB;GBR;239;Kent;Kent;"two-tier county";KEN;47905
+"United Kingdom";GB;GBR;239;"City of Kingston upon Hull";"City of Kingston upon Hull";"unitary authority";KHL;47904
+"United Kingdom";GB;GBR;239;"Kingston upon Thames";"Kingston upon Thames";borough;KTT;19262
+"United Kingdom";GB;GBR;239;Kirklees;Kirklees;"metropolitan district";KIR;19263
+"United Kingdom";GB;GBR;239;Knowsley;Knowsley;"metropolitan district";KWL;19264
+"United Kingdom";GB;GBR;239;Lambeth;Lambeth;borough;LBH;19265
+"United Kingdom";GB;GBR;239;Lancashire;Lancashire;"two-tier county";LAN;48070
+"United Kingdom";GB;GBR;239;Larne;Larne;"district council area";LRN;48000
+"United Kingdom";GB;GBR;239;Leeds;Leeds;"metropolitan district";LDS;19268
+"United Kingdom";GB;GBR;239;Leicester;Leicester;"unitary authority";LCE;48069
+"United Kingdom";GB;GBR;239;Leicestershire;Leicestershire;"two-tier county";LEC;48068
+"United Kingdom";GB;GBR;239;Lewisham;Lewisham;borough;LEW;19271
+"United Kingdom";GB;GBR;239;Limavady;Limavady;"district council area";LMV;47999
+"United Kingdom";GB;GBR;239;Lincolnshire;Lincolnshire;"two-tier county";LIN;48067
+"United Kingdom";GB;GBR;239;Lisburn;Lisburn;"district council area";LSB;47998
+"United Kingdom";GB;GBR;239;Liverpool;Liverpool;"metropolitan district";LIV;19275
+"United Kingdom";GB;GBR;239;"City of London";"City of London";"city corporation";LND;47912
+"United Kingdom";GB;GBR;239;Luton;Luton;"unitary authority";LUT;48065
+"United Kingdom";GB;GBR;239;Magherafelt;Magherafelt;"district council area";MFT;47996
+"United Kingdom";GB;GBR;239;Manchester;Manchester;"metropolitan district";MAN;48066
+"United Kingdom";GB;GBR;239;Medway;Medway;"unitary authority";MDW;48064
+"United Kingdom";GB;GBR;239;"Merthyr Tydfil (Merthyr Tudful GB-MTU)";"Merthyr Tydfil (Merthyr Tudful GB-MTU)";"unitary authority";MTY;47946
+"United Kingdom";GB;GBR;239;Merton;Merton;borough;MRT;19282
+"United Kingdom";GB;GBR;239;Middlesbrough;Middlesbrough;"unitary authority";MDB;48062
+"United Kingdom";GB;GBR;239;Midlothian;Midlothian;"council area";MLN;47971
+"United Kingdom";GB;GBR;239;"Milton Keynes";"Milton Keynes";"unitary authority";MIK;48061
+"United Kingdom";GB;GBR;239;"Monmouthshire (Sir Fynwy GB-FYN)";"Monmouthshire (Sir Fynwy GB-FYN)";"unitary authority";MON;47945
+"United Kingdom";GB;GBR;239;Moray;Moray;"council area";MRY;47970
+"United Kingdom";GB;GBR;239;Moyle;Moyle;"district council area";MYL;47995
+"United Kingdom";GB;GBR;239;"Neath Port Talbot (Castell-nedd Port Talbot GB-CTL)";"Neath Port Talbot (Castell-nedd Port Talbot GB-CTL)";"unitary authority";NTL;47944
+"United Kingdom";GB;GBR;239;"Newcastle upon Tyne";"Newcastle upon Tyne";"metropolitan district";NET;19290
+"United Kingdom";GB;GBR;239;Newham;Newham;borough;NWM;19291
+"United Kingdom";GB;GBR;239;"Newport (Casnewydd GB-CNW)";"Newport (Casnewydd GB-CNW)";"unitary authority";NWP;47943
+"United Kingdom";GB;GBR;239;"Newry and Mourne";"Newry and Mourne";"district council area";NYM;47994
+"United Kingdom";GB;GBR;239;Newtownabbey;Newtownabbey;"district council area";NTA;47993
+"United Kingdom";GB;GBR;239;Norfolk;Norfolk;"two-tier county";NFK;48060
+"United Kingdom";GB;GBR;239;"North Ayrshire";"North Ayrshire";"council area";NAY;47969
+"United Kingdom";GB;GBR;239;"North Down";"North Down";"district council area";NDN;47992
+"United Kingdom";GB;GBR;239;"North East Lincolnshire";"North East Lincolnshire";"unitary authority";NEL;48059
+"United Kingdom";GB;GBR;239;"North Lanarkshire";"North Lanarkshire";"council area";NLK;47968
+"United Kingdom";GB;GBR;239;"North Lincolnshire";"North Lincolnshire";"unitary authority";NLN;48058
+"United Kingdom";GB;GBR;239;"North Somerset";"North Somerset";"unitary authority";NSM;48057
+"United Kingdom";GB;GBR;239;"North Tyneside";"North Tyneside";"metropolitan district";NTY;19302
+"United Kingdom";GB;GBR;239;"North Yorkshire";"North Yorkshire";"two-tier county";NYK;48056
+"United Kingdom";GB;GBR;239;Northamptonshire;Northamptonshire;"two-tier county";NTH;48055
+"United Kingdom";GB;GBR;239;Northumberland;Northumberland;"unitary authority";NBL;48054
+"United Kingdom";GB;GBR;239;Nottingham;Nottingham;"unitary authority";NGM;48053
+"United Kingdom";GB;GBR;239;Nottinghamshire;Nottinghamshire;"two-tier county";NTT;48052
+"United Kingdom";GB;GBR;239;Oldham;Oldham;"metropolitan district";OLD;19308
+"United Kingdom";GB;GBR;239;Omagh;Omagh;"district council area";OMH;47991
+"United Kingdom";GB;GBR;239;"Orkney Islands";"Orkney Islands";"council area";ORK;47967
+"United Kingdom";GB;GBR;239;Oxfordshire;Oxfordshire;"two-tier county";OXF;48051
+"United Kingdom";GB;GBR;239;"Pembrokeshire (Sir Benfro GB-BNF)";"Pembrokeshire (Sir Benfro GB-BNF)";"unitary authority";PEM;47942
+"United Kingdom";GB;GBR;239;"Perth and Kinross";"Perth and Kinross";"council area";PKN;47966
+"United Kingdom";GB;GBR;239;Peterborough;Peterborough;"unitary authority";PTE;48050
+"United Kingdom";GB;GBR;239;Plymouth;Plymouth;"unitary authority";PLY;48049
+"United Kingdom";GB;GBR;239;Poole;Poole;"unitary authority";POL;48048
+"United Kingdom";GB;GBR;239;Portsmouth;Portsmouth;"unitary authority";POR;48047
+"United Kingdom";GB;GBR;239;Powys;Powys;"unitary authority";POW;47941
+"United Kingdom";GB;GBR;239;Reading;Reading;"unitary authority";RDG;48046
+"United Kingdom";GB;GBR;239;Redbridge;Redbridge;borough;RDB;19320
+"United Kingdom";GB;GBR;239;"Redcar and Cleveland";"Redcar and Cleveland";"unitary authority";RCC;48045
+"United Kingdom";GB;GBR;239;Renfrewshire;Renfrewshire;"council area";RFW;47965
+"United Kingdom";GB;GBR;239;"Cynon Rhondda";"Cynon Rhondda";"unitary authority";RCT;47940
+"United Kingdom";GB;GBR;239;"Richmond upon Thames";"Richmond upon Thames";borough;RIC;19324
+"United Kingdom";GB;GBR;239;Rochdale;Rochdale;"metropolitan district";RCH;19325
+"United Kingdom";GB;GBR;239;Rotherham;Rotherham;"metropolitan district";ROT;19326
+"United Kingdom";GB;GBR;239;Rutland;Rutland;"unitary authority";RUT;48044
+"United Kingdom";GB;GBR;239;Salford;Salford;"metropolitan district";SLF;19328
+"United Kingdom";GB;GBR;239;Sandwell;Sandwell;"metropolitan district";SAW;19329
+"United Kingdom";GB;GBR;239;"The Scottish Borders";"The Scottish Borders";"council area";SCB;47964
+"United Kingdom";GB;GBR;239;Sefton;Sefton;"metropolitan district";SFT;19331
+"United Kingdom";GB;GBR;239;Sheffield;Sheffield;"metropolitan district";SHF;19332
+"United Kingdom";GB;GBR;239;"Shetland Islands";"Shetland Islands";"council area";ZET;47963
+"United Kingdom";GB;GBR;239;Shropshire;Shropshire;"unitary authority";SHR;48043
+"United Kingdom";GB;GBR;239;Slough;Slough;"unitary authority";SLG;48042
+"United Kingdom";GB;GBR;239;Solihull;Solihull;"metropolitan district";SOL;19336
+"United Kingdom";GB;GBR;239;Somerset;Somerset;"two-tier county";SOM;48041
+"United Kingdom";GB;GBR;239;"South Ayrshire";"South Ayrshire";"council area";SAY;47962
+"United Kingdom";GB;GBR;239;"South Gloucestershire";"South Gloucestershire";"unitary authority";SGC;48040
+"United Kingdom";GB;GBR;239;"South Lanarkshire";"South Lanarkshire";"council area";SLK;47961
+"United Kingdom";GB;GBR;239;"South Tyneside";"South Tyneside";"metropolitan district";STY;19341
+"United Kingdom";GB;GBR;239;Southampton;Southampton;"unitary authority";STH;48038
+"United Kingdom";GB;GBR;239;Southend-on-Sea;Southend-on-Sea;"unitary authority";SOS;48037
+"United Kingdom";GB;GBR;239;Southwark;Southwark;borough;SWK;19344
+"United Kingdom";GB;GBR;239;"St. Helens";"St. Helens";"metropolitan district";SHN;19345
+"United Kingdom";GB;GBR;239;Staffordshire;Staffordshire;"two-tier county";STS;48036
+"United Kingdom";GB;GBR;239;Stirling;Stirling;"council area";STG;47960
+"United Kingdom";GB;GBR;239;Stockport;Stockport;"metropolitan district";SKP;19348
+"United Kingdom";GB;GBR;239;Stockton-on-Tees;Stockton-on-Tees;"unitary authority";STT;48035
+"United Kingdom";GB;GBR;239;Stoke-on-Trent;Stoke-on-Trent;"unitary authority";STE;48034
+"United Kingdom";GB;GBR;239;Strabane;Strabane;"district council area";STB;47990
+"United Kingdom";GB;GBR;239;Suffolk;Suffolk;"two-tier county";SFK;48033
+"United Kingdom";GB;GBR;239;Sunderland;Sunderland;"metropolitan district";SND;19353
+"United Kingdom";GB;GBR;239;Surrey;Surrey;"two-tier county";SRY;48032
+"United Kingdom";GB;GBR;239;Sutton;Sutton;borough;STN;19355
+"United Kingdom";GB;GBR;239;"Swansea (Abertawe GB-ATA)";"Swansea (Abertawe GB-ATA)";"unitary authority";SWA;47939
+"United Kingdom";GB;GBR;239;Swindon;Swindon;"unitary authority";SWD;48031
+"United Kingdom";GB;GBR;239;Tameside;Tameside;"metropolitan district";TAM;19358
+"United Kingdom";GB;GBR;239;"Telford and Wrekin";"Telford and Wrekin";"unitary authority";TFW;48030
+"United Kingdom";GB;GBR;239;Thurrock;Thurrock;"unitary authority";THR;48029
+"United Kingdom";GB;GBR;239;Torbay;Torbay;"unitary authority";TOB;48028
+"United Kingdom";GB;GBR;239;"Torfaen (Tor-faen)";"Torfaen (Tor-faen)";"unitary authority";TOF;47938
+"United Kingdom";GB;GBR;239;"Tower Hamlets";"Tower Hamlets";borough;TWH;19363
+"United Kingdom";GB;GBR;239;Trafford;Trafford;"metropolitan district";TRF;19364
+"United Kingdom";GB;GBR;239;"The (Bro Morgannwg GB-BMG) Vale of Glamorgan";"The (Bro Morgannwg GB-BMG) Vale of Glamorgan";"unitary authority";VGL;47937
+"United Kingdom";GB;GBR;239;Wakefield;Wakefield;"metropolitan district";WKF;19366
+"United Kingdom";GB;GBR;239;Walsall;Walsall;"metropolitan district";WLL;19367
+"United Kingdom";GB;GBR;239;"Waltham Forest";"Waltham Forest";borough;WFT;19368
+"United Kingdom";GB;GBR;239;Wandsworth;Wandsworth;borough;WND;19369
+"United Kingdom";GB;GBR;239;Warrington;Warrington;"unitary authority";WRT;48026
+"United Kingdom";GB;GBR;239;Warwickshire;Warwickshire;"two-tier county";WAR;48025
+"United Kingdom";GB;GBR;239;"West Berkshire";"West Berkshire";"unitary authority";WBK;48024
+"United Kingdom";GB;GBR;239;"West Dunbartonshire";"West Dunbartonshire";"council area";WDU;47959
+"United Kingdom";GB;GBR;239;"West Lothian";"West Lothian";"council area";WLN;47958
+"United Kingdom";GB;GBR;239;"West Sussex";"West Sussex";"two-tier county";WSX;48022
+"United Kingdom";GB;GBR;239;Westminster;Westminster;borough;WSM;19376
+"United Kingdom";GB;GBR;239;Wigan;Wigan;"metropolitan district";WGN;19377
+"United Kingdom";GB;GBR;239;Wiltshire;Wiltshire;"unitary authority";WIL;48020
+"United Kingdom";GB;GBR;239;"Windsor and Maidenhead";"Windsor and Maidenhead";"unitary authority";WNM;48019
+"United Kingdom";GB;GBR;239;Wirral;Wirral;"metropolitan district";WRL;19380
+"United Kingdom";GB;GBR;239;Wokingham;Wokingham;"unitary authority";WOK;48018
+"United Kingdom";GB;GBR;239;Wolverhampton;Wolverhampton;"metropolitan district";WLV;19382
+"United Kingdom";GB;GBR;239;Worcestershire;Worcestershire;"two-tier county";WOR;48017
+"United Kingdom";GB;GBR;239;"Wrexham (Wrecsam GB-WRC)";"Wrexham (Wrecsam GB-WRC)";"unitary authority";WRX;47936
+"United Kingdom";GB;GBR;239;York;York;"unitary authority";YOR;48016
+"United States";US;USA;240;Alabama;Alabama;state;AL;18655
+"United States";US;USA;240;Alaska;Alaska;state;AK;18683
+"United States";US;USA;240;"American Samoa (see also separate entry under AS)";"American Samoa (see also separate entry under AS)";"outlying area";AS;19386
+"United States";US;USA;240;Arizona;Arizona;state;AZ;18656
+"United States";US;USA;240;Arkansas;Arkansas;state;AR;18684
+"United States";US;USA;240;California;California;state;CA;18657
+"United States";US;USA;240;Colorado;Colorado;state;CO;18685
+"United States";US;USA;240;Connecticut;Connecticut;state;CT;18658
+"United States";US;USA;240;Delaware;Delaware;state;DE;18686
+"United States";US;USA;240;"District of Columbia";"District of Columbia";district;DC;18659
+"United States";US;USA;240;Florida;Florida;state;FL;18687
+"United States";US;USA;240;Georgia;Georgia;state;GA;18660
+"United States";US;USA;240;"Guam (see also separate entry under GU)";"Guam (see also separate entry under GU)";"outlying area";GU;19388
+"United States";US;USA;240;Hawaii;Hawaii;state;HI;18688
+"United States";US;USA;240;Idaho;Idaho;state;ID;18661
+"United States";US;USA;240;Illinois;Illinois;state;IL;18674
+"United States";US;USA;240;Indiana;Indiana;state;IN;18662
+"United States";US;USA;240;Iowa;Iowa;state;IA;18663
+"United States";US;USA;240;Kansas;Kansas;state;KS;18675
+"United States";US;USA;240;Kentucky;Kentucky;state;KY;18664
+"United States";US;USA;240;Louisiana;Louisiana;state;LA;18676
+"United States";US;USA;240;Maine;Maine;state;ME;18665
+"United States";US;USA;240;Maryland;Maryland;state;MD;18677
+"United States";US;USA;240;Massachusetts;Massachusetts;state;MA;18666
+"United States";US;USA;240;Michigan;Michigan;state;MI;18678
+"United States";US;USA;240;Minnesota;Minnesota;state;MN;18646
+"United States";US;USA;240;Mississippi;Mississippi;state;MS;18679
+"United States";US;USA;240;Missouri;Missouri;state;MO;18647
+"United States";US;USA;240;Montana;Montana;state;MT;18648
+"United States";US;USA;240;Nebraska;Nebraska;state;NE;18680
+"United States";US;USA;240;Nevada;Nevada;state;NV;18649
+"United States";US;USA;240;"New Hampshire";"New Hampshire";state;NH;18681
+"United States";US;USA;240;"New Jersey";"New Jersey";state;NJ;18650
+"United States";US;USA;240;"New Mexico";"New Mexico";state;NM;18682
+"United States";US;USA;240;"New York";"New York";state;NY;18651
+"United States";US;USA;240;"North Carolina";"North Carolina";state;NC;18645
+"United States";US;USA;240;"North Dakota";"North Dakota";state;ND;18652
+"United States";US;USA;240;"Northern Mariana Islands (see also separate entry under MP)";"Northern Mariana Islands (see also separate entry under MP)";"outlying area";MP;19390
+"United States";US;USA;240;Ohio;Ohio;state;OH;18689
+"United States";US;USA;240;Oklahoma;Oklahoma;state;OK;18653
+"United States";US;USA;240;Oregon;Oregon;state;OR;18654
+"United States";US;USA;240;Pennsylvania;Pennsylvania;state;PA;18644
+"United States";US;USA;240;"Puerto Rico (see also separate entry under PR)";"Puerto Rico (see also separate entry under PR)";"outlying area";PR;19591
+"United States";US;USA;240;"Rhode Island";"Rhode Island";state;RI;18667
+"United States";US;USA;240;"South Carolina";"South Carolina";state;SC;18690
+"United States";US;USA;240;"South Dakota";"South Dakota";state;SD;18668
+"United States";US;USA;240;Tennessee;Tennessee;state;TN;18643
+"United States";US;USA;240;Texas;Texas;state;TX;18669
+"United States";US;USA;240;"United States Minor Outlying Islands (see also separate entry under UM)";"United States Minor Outlying Islands (see also separate entry under UM)";"outlying area";UM;19597
+"United States";US;USA;240;Utah;Utah;state;UT;18642
+"United States";US;USA;240;Vermont;Vermont;state;VT;18670
+"United States";US;USA;240;"U.S. (see also separate entry under VI) Virgin Islands";"U.S. (see also separate entry under VI) Virgin Islands";"outlying area";VI;19593
+"United States";US;USA;240;Virginia;Virginia;state;VA;18641
+"United States";US;USA;240;Washington;Washington;state;WA;18671
+"United States";US;USA;240;"West Virginia";"West Virginia";state;WV;18640
+"United States";US;USA;240;Wisconsin;Wisconsin;state;WI;18672
+"United States";US;USA;240;Wyoming;Wyoming;state;WY;18673
+"United States Minor Outlying Islands";UM;UMI;241;"Baker Island";"Baker Island";territory;81;18637
+"United States Minor Outlying Islands";UM;UMI;241;"Howland Island";"Howland Island";territory;84;18636
+"United States Minor Outlying Islands";UM;UMI;241;"Jarvis Island";"Jarvis Island";territory;86;18638
+"United States Minor Outlying Islands";UM;UMI;241;"Johnston Atoll";"Johnston Atoll";territory;67;18635
+"United States Minor Outlying Islands";UM;UMI;241;"Kingman Reef";"Kingman Reef";territory;89;18639
+"United States Minor Outlying Islands";UM;UMI;241;"Midway Islands";"Midway Islands";territory;71;18634
+"United States Minor Outlying Islands";UM;UMI;241;"Navassa Island";"Navassa Island";territory;76;18633
+"United States Minor Outlying Islands";UM;UMI;241;"Palmyra Atoll";"Palmyra Atoll";territory;95;18632
+"United States Minor Outlying Islands";UM;UMI;241;"Wake Island";"Wake Island";territory;79;18631
+Uruguay;UY;URY;242;Artigas;Artigas;department;AR;18696
+Uruguay;UY;URY;242;Durazno;Durazno;department;DU;18699
+Uruguay;UY;URY;242;Flores;Flores;department;FS;18695
+Uruguay;UY;URY;242;Florida;Florida;department;FD;18700
+Uruguay;UY;URY;242;Lavalleja;Lavalleja;department;LA;18709
+Uruguay;UY;URY;242;Maldonado;Maldonado;department;MA;18701
+Uruguay;UY;URY;242;Montevideo;Montevideo;department;MO;18702
+Uruguay;UY;URY;242;Paysandú;Paysandu;department;PA;18694
+Uruguay;UY;URY;242;Rivera;Rivera;department;RV;18693
+Uruguay;UY;URY;242;Rocha;Rocha;department;RO;18704
+Uruguay;UY;URY;242;"Río Negro";"Rio Negro";department;RN;18703
+Uruguay;UY;URY;242;Salto;Salto;department;SA;18705
+Uruguay;UY;URY;242;"San José";"San Jose";department;SJ;18692
+Uruguay;UY;URY;242;Soriano;Soriano;department;SO;18706
+Uruguay;UY;URY;242;Tacuarembó;Tacuarembo;department;TA;18691
+Uruguay;UY;URY;242;"Treinta y Tres";"Treinta y Tres";department;TT;18707
+Uruguay;UY;URY;242;;Department;department;18697
+Uruguay;UY;URY;242;;Department;department;18708
+Uruguay;UY;URY;242;;Department;department;18698
+Uzbekistan;UZ;UZB;243;Andijon;Andijon;region;AN;18715
+Uzbekistan;UZ;UZB;243;Buxoro;Buxoro;region;BU;18717
+Uzbekistan;UZ;UZB;243;Farg‘ona;Farg'ona;region;FA;18714
+Uzbekistan;UZ;UZB;243;Jizzax;Jizzax;region;JI;18723
+Uzbekistan;UZ;UZB;243;Namangan;Namangan;region;NG;18719
+Uzbekistan;UZ;UZB;243;Navoiy;Navoiy;region;NW;18712
+Uzbekistan;UZ;UZB;243;Qashqadaryo;Qashqadaryo;region;QA;18718
+Uzbekistan;UZ;UZB;243;"Qoraqalpog‘iston Respublikasi";"Qoraqalpog'iston Respublikasi";republic;QR;18713
+Uzbekistan;UZ;UZB;243;Samarqand;Samarqand;region;SA;18720
+Uzbekistan;UZ;UZB;243;Sirdaryo;Sirdaryo;region;SI;18711
+Uzbekistan;UZ;UZB;243;Surxondaryo;Surxondaryo;region;SU;18710
+Uzbekistan;UZ;UZB;243;Toshkent;Toshkent;region;TO;18721
+Uzbekistan;UZ;UZB;243;"Toshkent City";"Toshkent City";city;TK;20580
+Uzbekistan;UZ;UZB;243;Xorazm;Xorazm;region;XO;18724
+Vanuatu;VU;VUT;244;Malampa;Malampa;province;MAP;18726
+Vanuatu;VU;VUT;244;Pénama;Penama;province;PAM;18728
+Vanuatu;VU;VUT;244;Sanma;Sanma;province;SAM;18730
+Vanuatu;VU;VUT;244;Shéfa;Shefa;province;SEE;18727
+Vanuatu;VU;VUT;244;Taféa;Tafea;province;TAE;18725
+Vanuatu;VU;VUT;244;Torba;Torba;province;TOB;18729
+"Bolivarian Republic of Venezuela";VE;VEN;245;Amazonas;Amazonas;state;Z;18735
+"Bolivarian Republic of Venezuela";VE;VEN;245;Anzoátegui;Anzoategui;state;B;18745
+"Bolivarian Republic of Venezuela";VE;VEN;245;Apure;Apure;state;C;18746
+"Bolivarian Republic of Venezuela";VE;VEN;245;Aragua;Aragua;state;D;18736
+"Bolivarian Republic of Venezuela";VE;VEN;245;Barinas;Barinas;state;E;18747
+"Bolivarian Republic of Venezuela";VE;VEN;245;Bolívar;Bolivar;state;F;18737
+"Bolivarian Republic of Venezuela";VE;VEN;245;Carabobo;Carabobo;state;G;18748
+"Bolivarian Republic of Venezuela";VE;VEN;245;Cojedes;Cojedes;state;H;18749
+"Bolivarian Republic of Venezuela";VE;VEN;245;"Delta Amacuro";"Delta Amacuro";state;Y;18738
+"Bolivarian Republic of Venezuela";VE;VEN;245;"Dependencias Federales";"Dependencias Federales";"federal dependency";W;18750
+"Bolivarian Republic of Venezuela";VE;VEN;245;"Distrito Federal";"Distrito Federal";"federal district";A;18739
+"Bolivarian Republic of Venezuela";VE;VEN;245;Falcón;Falcon;state;I;18751
+"Bolivarian Republic of Venezuela";VE;VEN;245;Guárico;Guarico;state;J;18740
+"Bolivarian Republic of Venezuela";VE;VEN;245;Lara;Lara;state;K;18741
+"Bolivarian Republic of Venezuela";VE;VEN;245;Miranda;Miranda;state;M;18743
+"Bolivarian Republic of Venezuela";VE;VEN;245;Monagas;Monagas;state;N;18744
+"Bolivarian Republic of Venezuela";VE;VEN;245;Mérida;Merida;state;L;18742
+"Bolivarian Republic of Venezuela";VE;VEN;245;"Nueva Esparta";"Nueva Esparta";state;O;18734
+"Bolivarian Republic of Venezuela";VE;VEN;245;Portuguesa;Portuguesa;state;P;18752
+"Bolivarian Republic of Venezuela";VE;VEN;245;Sucre;Sucre;state;R;18733
+"Bolivarian Republic of Venezuela";VE;VEN;245;Trujillo;Trujillo;state;T;20682
+"Bolivarian Republic of Venezuela";VE;VEN;245;Táchira;Tachira;state;S;20681
+"Bolivarian Republic of Venezuela";VE;VEN;245;Vargas;Vargas;state;X;20683
+"Bolivarian Republic of Venezuela";VE;VEN;245;Yaracuy;Yaracuy;state;U;20680
+"Bolivarian Republic of Venezuela";VE;VEN;245;Zulia;Zulia;state;V;20684
+"Viet Nam";VN;VNM;247;"An Giang";"An Giang";province;44;18753
+"Viet Nam";VN;VNM;247;"Ba Ria-Vung Tau";"Ba Ria-Vung Tau";province;43;18756
+"Viet Nam";VN;VNM;247;"Bac Can";"Bac Can";province;53;18755
+"Viet Nam";VN;VNM;247;"Bac Giang";"Bac Giang";province;54;18754
+"Viet Nam";VN;VNM;247;"Bac Lieu";"Bac Lieu";province;55;18732
+"Viet Nam";VN;VNM;247;"Bac Ninh";"Bac Ninh";province;56;20625
+"Viet Nam";VN;VNM;247;"Ben Tre";"Ben Tre";province;50;20622
+"Viet Nam";VN;VNM;247;"Binh Dinh";"Binh Dinh";province;31;20607
+"Viet Nam";VN;VNM;247;"Binh Duong";"Binh Duong";province;57;20626
+"Viet Nam";VN;VNM;247;"Binh Phuoc";"Binh Phuoc";province;58;20627
+"Viet Nam";VN;VNM;247;"Binh Thuan";"Binh Thuan";province;40;20615
+"Viet Nam";VN;VNM;247;"Ca Mau";"Ca Mau";province;59;20628
+"Viet Nam";VN;VNM;247;"Can Tho";"Can Tho";municipality;CT;48708
+"Viet Nam";VN;VNM;247;"Can Tho";"Can Tho";province;48;20620
+"Viet Nam";VN;VNM;247;"Cao Bang";"Cao Bang";province;04;20587
+"Viet Nam";VN;VNM;247;"Da Nang";"Da Nang";municipality;DN;48892
+"Viet Nam";VN;VNM;247;"thanh pho Da Nang";"thanh pho Da Nang";province;60;20629
+"Viet Nam";VN;VNM;247;"Dac Lac";"Dac Lac";province;33;20609
+"Viet Nam";VN;VNM;247;"Dak Nong";"Dak Nong";province;72;20640
+"Viet Nam";VN;VNM;247;"Dien Bien";"Dien Bien";province;71;20639
+"Viet Nam";VN;VNM;247;"Dong Nai";"Dong Nai";province;39;20614
+"Viet Nam";VN;VNM;247;"Dong Thap";"Dong Thap";province;45;20617
+"Viet Nam";VN;VNM;247;"Gia Lai";"Gia Lai";province;30;20606
+"Viet Nam";VN;VNM;247;"Ha Giang";"Ha Giang";province;03;20586
+"Viet Nam";VN;VNM;247;"Ha Nam";"Ha Nam";province;63;20632
+"Viet Nam";VN;VNM;247;"Ha Noi";"Ha Noi";municipality;HN;48893
+"Viet Nam";VN;VNM;247;"thu do Ha Noi";"thu do Ha Noi";province;64;20633
+"Viet Nam";VN;VNM;247;"Ha Tay";"Ha Tay";province;15;20594
+"Viet Nam";VN;VNM;247;"Ha Tinh";"Ha Tinh";province;23;20599
+"Viet Nam";VN;VNM;247;"Hai Duong";"Hai Duong";province;61;20630
+"Viet Nam";VN;VNM;247;"Hai Phong";"Hai Phong";municipality;HP;48894
+"Viet Nam";VN;VNM;247;"thanh pho Hai Phong";"thanh pho Hai Phong";province;62;20631
+"Viet Nam";VN;VNM;247;"Hau Giang";"Hau Giang";province;73;20641
+"Viet Nam";VN;VNM;247;"Ho Chi Minh (Sai Gon)";"Ho Chi Minh (Sai Gon)";municipality;SG;48895
+"Viet Nam";VN;VNM;247;"thanh pho (Sai Gon) Ho Chi Minh";"thanh pho (Sai Gon) Ho Chi Minh";province;65;20634
+"Viet Nam";VN;VNM;247;"Hoa Binh";"Hoa Binh";province;14;20593
+"Viet Nam";VN;VNM;247;"Hung Yen";"Hung Yen";province;66;20635
+"Viet Nam";VN;VNM;247;"Khanh Hoa";"Khanh Hoa";province;34;20610
+"Viet Nam";VN;VNM;247;"Kien Giang";"Kien Giang";province;47;20619
+"Viet Nam";VN;VNM;247;"Kon Tum";"Kon Tum";province;28;20604
+"Viet Nam";VN;VNM;247;"Lai Chau";"Lai Chau";province;01;20584
+"Viet Nam";VN;VNM;247;"Lam Dong";"Lam Dong";province;35;20611
+"Viet Nam";VN;VNM;247;"Lang Son";"Lang Son";province;09;20591
+"Viet Nam";VN;VNM;247;"Lao Cai";"Lao Cai";province;02;20585
+"Viet Nam";VN;VNM;247;"Long An";"Long An";province;41;20616
+"Viet Nam";VN;VNM;247;"Nam Dinh";"Nam Dinh";province;67;20636
+"Viet Nam";VN;VNM;247;"Nghe An";"Nghe An";province;22;20598
+"Viet Nam";VN;VNM;247;"Ninh Binh";"Ninh Binh";province;18;20595
+"Viet Nam";VN;VNM;247;"Ninh Thuan";"Ninh Thuan";province;36;20612
+"Viet Nam";VN;VNM;247;"Phu Tho";"Phu Tho";province;68;20637
+"Viet Nam";VN;VNM;247;"Phu Yen";"Phu Yen";province;32;20608
+"Viet Nam";VN;VNM;247;"Quang Binh";"Quang Binh";province;24;20600
+"Viet Nam";VN;VNM;247;"Quang Nam";"Quang Nam";province;27;20603
+"Viet Nam";VN;VNM;247;"Quang Ngai";"Quang Ngai";province;29;20605
+"Viet Nam";VN;VNM;247;"Quang Ninh";"Quang Ninh";province;13;20592
+"Viet Nam";VN;VNM;247;"Quang Tri";"Quang Tri";province;25;20601
+"Viet Nam";VN;VNM;247;"Soc Trang";"Soc Trang";province;52;20624
+"Viet Nam";VN;VNM;247;"Son La";"Son La";province;05;20588
+"Viet Nam";VN;VNM;247;"Tay Ninh";"Tay Ninh";province;37;20613
+"Viet Nam";VN;VNM;247;"Thai Binh";"Thai Binh";province;20;20596
+"Viet Nam";VN;VNM;247;"Thai Nguyen";"Thai Nguyen";province;69;18763
+"Viet Nam";VN;VNM;247;"Thanh Hoa";"Thanh Hoa";province;21;20597
+"Viet Nam";VN;VNM;247;"Thua Thien-Hue";"Thua Thien-Hue";province;26;20602
+"Viet Nam";VN;VNM;247;"Tien Giang";"Tien Giang";province;46;20618
+"Viet Nam";VN;VNM;247;"Tra Vinh";"Tra Vinh";province;51;20623
+"Viet Nam";VN;VNM;247;"Tuyen Quang";"Tuyen Quang";province;07;20590
+"Viet Nam";VN;VNM;247;"Vinh Long";"Vinh Long";province;49;20621
+"Viet Nam";VN;VNM;247;"Vinh Phuc";"Vinh Phuc";province;70;20638
+"Viet Nam";VN;VNM;247;"Yen Bai";"Yen Bai";province;06;20589
+"Western Sahara";EH;ESH;251;Boujdour;Boujdour;province;BOD;18775
+"Western Sahara";EH;ESH;251;"Es Semara";"Es Semara";province;ESM;18777
+"Western Sahara";EH;ESH;251;Laayoune;Laayoune;province;LAA;18773
+"Western Sahara";EH;ESH;251;"Oued el Dahab";"Oued el Dahab";province;OUD;18774
+Yemen;YE;YEM;252;'Amran;'Amran;governorate;AM;20660
+Yemen;YE;YEM;252;Abyan;Abyan;governorate;AB;18787
+Yemen;YE;YEM;252;"Ad Dāli‘";"Ad Dali'";governorate;DA;20662
+Yemen;YE;YEM;252;"Al ?udaydah";"Al udaydah";governorate;HU;18790
+Yemen;YE;YEM;252;"Al Bay?a'";"Al Baya'";governorate;BA;18784
+Yemen;YE;YEM;252;"Al Jawf";"Al Jawf";governorate;JA;18792
+Yemen;YE;YEM;252;"Al Mahrah";"Al Mahrah";governorate;MR;18793
+Yemen;YE;YEM;252;"Al Mahwit";"Al Mahwit";governorate;MW;18781
+Yemen;YE;YEM;252;Dhamar;Dhamar;governorate;DH;18789
+Yemen;YE;YEM;252;Hadramawt;Hadramawt;governorate;HD;18785
+Yemen;YE;YEM;252;Hajjah;Hajjah;governorate;HJ;18786
+Yemen;YE;YEM;252;Ibb;Ibb;governorate;IB;18791
+Yemen;YE;YEM;252;La?ij;Laij;governorate;LA;18782
+Yemen;YE;YEM;252;Ma'rib;Ma'rib;governorate;MA;18794
+Yemen;YE;YEM;252;Raymah;Raymah;governorate;RA;42618
+Yemen;YE;YEM;252;Sa`dah;Sa'dah;governorate;SD;18795
+Yemen;YE;YEM;252;Sanʿā;San'a;governorate;SN;18779
+Yemen;YE;YEM;252;Shabwah;Shabwah;governorate;SH;18780
+Yemen;YE;YEM;252;Taʿizz;Ta'izz;governorate;TA;18778
+Yemen;YE;YEM;252;Şan‘ā;San'a;municipality;SA;48214
+Yemen;YE;YEM;252;ʿAdan;'Adan;governorate;AD;18783
+Zambia;ZM;ZMB;255;Central;Central;province;02;20690
+Zambia;ZM;ZMB;255;Copperbelt;Copperbelt;province;08;18800
+Zambia;ZM;ZMB;255;Eastern;Eastern;province;03;21381
+Zambia;ZM;ZMB;255;Luapula;Luapula;province;04;18803
+Zambia;ZM;ZMB;255;Lusaka;Lusaka;province;09;18801
+Zambia;ZM;ZMB;255;North-Western;North-Western;province;06;18804
+Zambia;ZM;ZMB;255;Northern;Northern;province;05;18798
+Zambia;ZM;ZMB;255;Southern;Southern;province;07;18802
+Zambia;ZM;ZMB;255;Western;Western;province;01;18796
+Zimbabwe;ZW;ZWE;256;Bulawayo;Bulawayo;city;BU;21380
+Zimbabwe;ZW;ZWE;256;Harare;Harare;city;HA;21379
+Zimbabwe;ZW;ZWE;256;Manicaland;Manicaland;province;MA;21280
+Zimbabwe;ZW;ZWE;256;"Mashonaland Central";"Mashonaland Central";province;MC;21282
+Zimbabwe;ZW;ZWE;256;"Mashonaland East";"Mashonaland East";province;ME;21283
+Zimbabwe;ZW;ZWE;256;"Mashonaland West";"Mashonaland West";province;MW;21284
+Zimbabwe;ZW;ZWE;256;Masvingo;Masvingo;province;MV;21287
+Zimbabwe;ZW;ZWE;256;"Matabeleland North";"Matabeleland North";province;MN;21285
+Zimbabwe;ZW;ZWE;256;"Matabeleland South";"Matabeleland South";province;MS;21286
+Zimbabwe;ZW;ZWE;256;Midlands;Midlands;province;MI;21281

--- a/ISO-3166.csv
+++ b/ISO-3166.csv
@@ -2946,7 +2946,6 @@ Morocco;MA;MAR;153;Skhirate-Témara;Skhirate-Temara;prefecture;SKH;48484
 Morocco;MA;MAR;153;Souss-Massa-Draa;Souss-Massa-Draa;region;13;15570
 Morocco;MA;MAR;153;Tadla-Azilal;Tadla-Azilal;region;12;15533
 Morocco;MA;MAR;153;Tan-Tan;Tan-Tan;province;TNT;15542
-Morocco;MA;MAR;153;Tanger;Tanger;;TNG;15584
 Morocco;MA;MAR;153;Tanger-Assilah;Tanger-Assilah;prefecture;TNG;48485
 Morocco;MA;MAR;153;Tanger-Tetouan;Tanger-Tetouan;region;01;15571
 Morocco;MA;MAR;153;Taounate;Taounate;province;TAO;15562

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ISO_3166_2['GB']['LND'] = "City of London";
 CSV files included:
 ------
 
-* **ISO-3166.csv**: All information about ISO Country codes and Region codes splitted with semicolon. Columns in file: COUNTRY NAME, COUNTRY SHORT CODE, COUNTRY LONG CODE, COUNTRY NUMBER CODE, REGION NAME, REGION TYPE, REGIONAL CODE, REGIONAL NUMBER CODE.
+* **ISO-3166.csv**: All information about ISO Country codes and Region codes splitted with semicolon. Columns in file: COUNTRY NAME, COUNTRY SHORT CODE, COUNTRY LONG CODE, COUNTRY NUMBER CODE, REGION NAME, REGION TYPE, REGION TYPE (ASCII), REGIONAL CODE, REGIONAL NUMBER CODE.  The REGION TYPE (ASCII) column is included to make searching/filtering by region type more flexible.
 * **ISO-3166-1.csv**: Only information about Country codes, columns in file: COUNTRY NAME, COUNTRY SHORT CODE, COUNTRY LONG CODE, COUNTRY NUMBER CODE.
 * **ISO-3166-2.csv**: Only information aboun Region codes, columns in file: COUNTRY SHORT CODE, REGION NAME, REGION TYPE, REGIONAL CODE, REGIONAL NUMBER CODE.
 * **ISO folder**: Individual csv files per region, same format as ISO-3166.csv.


### PR DESCRIPTION
Changes to ISO-3166.csv:
Improved overall formatting of CSV filetype (e.g. removed extraneous
spaces in field names)

For case consistency, lowercased REGION NAME
For syntax consistency, replaced brackets in REGION NAME with
parentheses
Removed unnecessary asterisks in REGION NAME
Added new REGION NAME (ASCII) field.

In the REGION TYPE field:
"administrative regions" -> "administrative region" (Unnecessary
plurality)
"council area (scotland)" -> "council area" (The "Scotland" affiliation
can be derived from other data)
"district council area (northern ireland)" -> "district council area"
(The "Northern Ireland" affiliation can be derived from other data)
"development regions" -> "development region" (Unnecessary plurality)
"geographic regions" -> "geographic region" (Unnecessary plurality)
"geographic units" -> "geographic unit" (Unnecessary plurality)
"geographical entities" -> "geographical entity" (Unnecessary plurality)
"governorates" -> "governorate" (Unnecessary plurality)
"metropolitan regions" -> "metropolitan region" (Unnecessary plurality)
"overseas regions" -> "overseas region" (Unnecessary plurality)
"perfecture" -> "prefecture" (Misspelling)
"rerion" -> "region" (Misspelling)
"special zone." -> "special zone" (Extraneous period)
"states" -> "state" (Unnecessary plurality)
"unitary authority (wales)" -> "unitary authority" (The "Wales"
affiliation can be derived from other data)
"urban perfecture" -> "urban prefecture" (Misspelling)
"voivodship" -> "voivodeship" (Misspelling)